### PR TITLE
ci: switch Dependabot nuget prefix to "build" so PR Title check passes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,10 @@ updates:
       - "dependencies"
       - "nuget"
     commit-message:
-      prefix: "nuget"
+      # Use "build" to match the Conventional Commits convention for
+      # dependency / build-system changes. Required for our pr-title
+      # workflow's type allowlist (build is in, nuget is not).
+      prefix: "build"
       include: "scope"
     groups:
       microsoft-extensions:


### PR DESCRIPTION
## Summary

- Switch Dependabot's NuGet ecosystem `commit-message.prefix` from `nuget` to `build`.
- `nuget` isn't in the pr-title workflow's allowlist, so every NuGet Dependabot PR (e.g. #10) was failing its own PR Title check.
- `build` is the Conventional Commits convention for dependency / build-system changes and is already accepted by the pr-title workflow.

## Breaking changes

None - only affects how future Dependabot PRs are titled.

## Test plan

- [x] Diff inspection.
- [ ] After merge, retitle PR #10 manually (existing PR) or comment `@dependabot recreate` to get a new PR with the correct prefix.
- [ ] Next NuGet update sweep produces `build(deps): ...` titles which pass PR Title.

## Documentation

No doc references to the Dependabot prefix.

## Linked issues

Unblocks PR #10 (test-framework group bump).