### PR TITLE
docs: friendlier and uniform wording for MCPB user_config fields

### DIFF
--- a/Output/mcpb/manifest.json
+++ b/Output/mcpb/manifest.json
@@ -399,24 +399,24 @@
     "VITALLY_API_KEY": {
       "type": "string",
       "title": "API Key",
-      "description": "API key used to authenticate with the Vitally",
+      "description": "Your Vitally API key. You can generate one in Vitally under Settings → Integrations → API Keys.",
       "required": true,
       "sensitive": true
-    },
-    "VITALLY_SUBDOMAIN": {
-      "type": "string",
-      "title": "Subdomain",
-      "description": "Subdomain of your Vitally instance. Only required when VITALLY_REGION is 'US' (the EU region uses a single shared host with no subdomain).",
-      "required": false,
-      "sensitive": false
     },
     "VITALLY_REGION": {
       "type": "string",
       "title": "Region",
-      "description": "Vitally data centre region: 'EU' (default, uses rest.vitally-eu.io with no subdomain) or 'US' (uses {subdomain}.rest.vitally.io and requires VITALLY_SUBDOMAIN)",
+      "description": "The Vitally data centre your tenant uses. Leave as EU unless you're on a US tenant.",
       "required": false,
       "sensitive": false,
       "default": "EU"
+    },
+    "VITALLY_SUBDOMAIN": {
+      "type": "string",
+      "title": "Subdomain",
+      "description": "Your Vitally subdomain (for example, 'fiscaltec' from 'fiscaltec.vitally.io'). Only needed when Region is set to US.",
+      "required": false,
+      "sensitive": false
     }
   }
 }


### PR DESCRIPTION
## Summary

Pilot install feedback: the env-var descriptions Claude Desktop shows during MCPB install were inconsistent (one had a full stop, others didn't) and a bit jargon-heavy for end users.

Rewrites all three:

| Field | Before | After |
|---|---|---|
| `VITALLY_API_KEY` | "API key used to authenticate with the Vitally" *(grammar slip + no full stop)* | "Your Vitally API key. You can generate one in Vitally under Settings → Integrations → API Keys." |
| `VITALLY_REGION` | "Vitally data centre region: 'EU' (default, uses rest.vitally-eu.io with no subdomain) or 'US' (uses {subdomain}.rest.vitally.io and requires VITALLY_SUBDOMAIN)" *(no full stop, leaks hostnames)* | "The Vitally data centre your tenant uses. Leave as EU unless you're on a US tenant." |
| `VITALLY_SUBDOMAIN` | "Subdomain of your Vitally instance. Only required when VITALLY_REGION is 'US' (the EU region uses a single shared host with no subdomain)." | "Your Vitally subdomain (for example, 'fiscaltec' from 'fiscaltec.vitally.io'). Only needed when Region is set to US." |

Also reorders so Region appears before Subdomain in the form, since the Subdomain hint now references Region.

## Breaking changes

None - description text only. Same env-var names, same defaults, same behaviour.

## Test plan

- [x] Diff inspection.
- [ ] After merge, tag a v3.0.1 and run the release workflow to ship a fresh `.mcpb`. Pilot user re-installs and confirms the install form reads better.