### PR TITLE
fix: address Copilot review comments from PR #23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,19 @@ All notable changes to this project are documented here. Format based on
 - **Remote HTTP MCP server** using the streamable HTTP transport (MCP
   2025-06-18, stateless mode) on the `ModelContextProtocol.AspNetCore`
   package. Replaces the previous stdio transport.
-- **Auth0 OAuth 2.1 protection** on the `/mcp` endpoint via JwtBearer.
-  Publishes a `/.well-known/oauth-protected-resource` metadata document
-  (RFC 9728) so MCP clients discover the authorisation server automatically.
-- **Per-request Vitally API key resolution** via the new
-  `VitallyApiKeyProvider`: reads the `Vitally:SecretRefClaim` from the
-  authenticated user's access token, fetches the named secret from Azure
-  Key Vault (with a 5-minute in-memory cache), and falls back to the
-  configured `DefaultSecretRef` when the claim is absent.
-- **Configurable Auth0 + Key Vault settings** under the `Vitally:` and
-  `Auth0:` configuration sections. See `appsettings.Example.json`.
-- **`Auth0:NoAuth` development flag** that skips JWT validation for local
+- **OAuth 2.0 protection** on the `/mcp` endpoint via JwtBearer, with
+  Auth0 as the authorisation server federating to Microsoft Entra for
+  FISCAL identity. Publishes a `/.well-known/oauth-protected-resource`
+  metadata document (RFC 9728) so MCP clients discover the authorisation
+  server automatically.
+- **On-demand Vitally API key fetch** via the new `VitallyApiKeyProvider`:
+  fetches the secret named by `Vitally:DefaultSecretRef` from Azure Key
+  Vault using the Container App's managed identity, caches it for
+  `Vitally:SecretCacheDuration`. (A future per-user variant can be added
+  by re-introducing claim-based secret resolution; not in this release.)
+- **Configurable OAuth + Key Vault settings** under the `Vitally:` and
+  `OAuth:` configuration sections. See `appsettings.Example.json`.
+- **`OAuth:NoAuth` development flag** that skips JWT validation for local
   smoke tests; logs a loud warning at startup.
 
 ### Changed
@@ -32,8 +34,8 @@ All notable changes to this project are documented here. Format based on
   work against Vitally but receive no further updates.
 - **BREAKING — Configuration shape.** `VITALLY_API_KEY`, `VITALLY_REGION`,
   and `VITALLY_SUBDOMAIN` environment variables are replaced by the
-  `Vitally:` and `Auth0:` configuration sections (or the
-  `Vitally__*` / `Auth0__*` env-var equivalents in ASP.NET Core style).
+  `Vitally:` and `OAuth:` configuration sections (or the
+  `Vitally__*` / `OAuth__*` env-var equivalents in ASP.NET Core style).
   Local self-hosters set `Vitally:DevelopmentApiKey` instead of
   `VITALLY_API_KEY`.
 - `VitallyMcp.csproj` switched from `Microsoft.NET.Sdk` to

--- a/VitallyMcp.Tests/TestHelpers.cs
+++ b/VitallyMcp.Tests/TestHelpers.cs
@@ -14,7 +14,13 @@ public static class TestHelpers
 {
     /// <summary>
     /// Creates a mock HttpClient that returns the specified JSON response.
+    /// The HttpResponseMessage and HttpClient created here are owned by the test method
+    /// that calls this helper; lifetime is bounded by the test method's duration.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
+        Justification = "Test mock — HttpResponseMessage is returned via Moq to the consuming HttpClient; lifetime is bounded by the test run.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "cs/local-not-disposed",
+        Justification = "Test mock — HttpResponseMessage is owned by the Moq setup and bounded by the test method's lifetime.")]
     public static HttpClient CreateMockHttpClient(string jsonResponse, HttpStatusCode statusCode = HttpStatusCode.OK)
     {
         var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
@@ -59,7 +65,12 @@ public static class TestHelpers
 
     /// <summary>
     /// Creates a mock HttpClient that allows verification of the request URL.
+    /// The HttpResponseMessage and HttpClient are owned by the test method.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
+        Justification = "Test mock — see CreateMockHttpClient.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "cs/local-not-disposed",
+        Justification = "Test mock — see CreateMockHttpClient.")]
     public static (HttpClient client, Mock<HttpMessageHandler> handler) CreateMockHttpClientWithHandler(
         string jsonResponse,
         HttpStatusCode statusCode = HttpStatusCode.OK)

--- a/VitallyMcp.Tests/VitallyRateLimitHandlerTests.cs
+++ b/VitallyMcp.Tests/VitallyRateLimitHandlerTests.cs
@@ -11,7 +11,7 @@ namespace VitallyMcp.Tests;
 /// HttpMessageHandler so each test can stage a sequence of responses (e.g. 429 then 200).
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
-    Justification = "Test class — HttpClient and HttpResponseMessage instances created here are owned by the test method invocation and live only for its duration. Adding explicit disposal would obscure the test setup without changing real-world behaviour (xUnit isolates tests in their own process).")]
+    Justification = "Test class — HttpClient and HttpResponseMessage instances created here are scoped to a single test method invocation and become eligible for garbage collection as soon as the test returns. The leaked sockets/timers don't accumulate across the test suite because the process exits after the run. Adding explicit disposal would obscure the test setup without changing real behaviour.")]
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "cs/local-not-disposed",
     Justification = "Test class — see CA2000 suppression above.")]
 public class VitallyRateLimitHandlerTests

--- a/VitallyMcp.Tests/VitallyRateLimitHandlerTests.cs
+++ b/VitallyMcp.Tests/VitallyRateLimitHandlerTests.cs
@@ -10,6 +10,10 @@ namespace VitallyMcp.Tests;
 /// Tests for the VitallyRateLimitHandler delegating handler. Drives an inner queueable
 /// HttpMessageHandler so each test can stage a sequence of responses (e.g. 429 then 200).
 /// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
+    Justification = "Test class — HttpClient and HttpResponseMessage instances created here are owned by the test method invocation and live only for its duration. Adding explicit disposal would obscure the test setup without changing real-world behaviour (xUnit isolates tests in their own process).")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "cs/local-not-disposed",
+    Justification = "Test class — see CA2000 suppression above.")]
 public class VitallyRateLimitHandlerTests
 {
     /// <summary>

--- a/VitallyMcp.Tests/VitallyRateLimitHandlerTests.cs
+++ b/VitallyMcp.Tests/VitallyRateLimitHandlerTests.cs
@@ -9,15 +9,17 @@ namespace VitallyMcp.Tests;
 /// <summary>
 /// Tests for the VitallyRateLimitHandler delegating handler. Drives an inner queueable
 /// HttpMessageHandler so each test can stage a sequence of responses (e.g. 429 then 200).
+/// Implements IDisposable so xUnit cleans up the HttpClient + handler chain (and any
+/// undequeued HttpResponseMessages still sitting in the QueueingHandler) at the end of
+/// every test, rather than relying on the GC.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
-    Justification = "Test class — HttpClient and HttpResponseMessage instances created here are scoped to a single test method invocation and become eligible for garbage collection as soon as the test returns. The leaked sockets/timers don't accumulate across the test suite because the process exits after the run. Adding explicit disposal would obscure the test setup without changing real behaviour.")]
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "cs/local-not-disposed",
-    Justification = "Test class — see CA2000 suppression above.")]
-public class VitallyRateLimitHandlerTests
+public class VitallyRateLimitHandlerTests : IDisposable
 {
+    private readonly List<HttpClient> _clients = new();
+
     /// <summary>
     /// Test handler that returns responses from a queue and records all received requests.
+    /// Disposes any unconsumed responses + received requests on its own disposal.
     /// </summary>
     private sealed class QueueingHandler : HttpMessageHandler
     {
@@ -29,6 +31,22 @@ public class VitallyRateLimitHandlerTests
         {
             Requests.Add(request);
             return Task.FromResult(Responses.Dequeue());
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                while (Responses.Count > 0)
+                {
+                    Responses.Dequeue().Dispose();
+                }
+                foreach (var req in Requests)
+                {
+                    req.Dispose();
+                }
+            }
+            base.Dispose(disposing);
         }
     }
 
@@ -55,7 +73,7 @@ public class VitallyRateLimitHandlerTests
         return response;
     }
 
-    private static (HttpClient client, QueueingHandler inner, Mock<ILogger<VitallyRateLimitHandler>> logger) BuildClient(
+    private (HttpClient client, QueueingHandler inner, Mock<ILogger<VitallyRateLimitHandler>> logger) BuildClient(
         Action<VitallyRateLimitHandler>? configure = null)
     {
         var inner = new QueueingHandler();
@@ -68,7 +86,22 @@ public class VitallyRateLimitHandlerTests
             MaxRetryDelay = TimeSpan.FromMilliseconds(50)
         };
         configure?.Invoke(handler);
-        return (new HttpClient(handler), inner, logger);
+        var client = new HttpClient(handler);
+        _clients.Add(client);
+        return (client, inner, logger);
+    }
+
+    public void Dispose()
+    {
+        // Disposing the HttpClient disposes its handler chain (the VitallyRateLimitHandler
+        // and the inner QueueingHandler), which in turn disposes any undequeued responses
+        // and recorded requests.
+        foreach (var client in _clients)
+        {
+            client.Dispose();
+        }
+        _clients.Clear();
+        GC.SuppressFinalize(this);
     }
 
     [Fact]
@@ -77,7 +110,7 @@ public class VitallyRateLimitHandlerTests
         var (client, inner, _) = BuildClient();
         inner.Responses.Enqueue(Ok());
 
-        var response = await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         inner.Requests.Should().HaveCount(1);
@@ -90,7 +123,7 @@ public class VitallyRateLimitHandlerTests
         inner.Responses.Enqueue(TooManyRequests());
         inner.Responses.Enqueue(Ok());
 
-        var response = await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         inner.Requests.Should().HaveCount(2);
@@ -105,7 +138,7 @@ public class VitallyRateLimitHandlerTests
         inner.Responses.Enqueue(Ok());
 
         var start = DateTimeOffset.UtcNow;
-        var response = await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
         var elapsed = DateTimeOffset.UtcNow - start;
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -121,7 +154,7 @@ public class VitallyRateLimitHandlerTests
         inner.Responses.Enqueue(TooManyRequests());
         inner.Responses.Enqueue(TooManyRequests());
 
-        var response = await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
 
         response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
         inner.Requests.Should().HaveCount(3);
@@ -133,7 +166,7 @@ public class VitallyRateLimitHandlerTests
         var (client, inner, logger) = BuildClient(h => h.LowRemainingThreshold = 50);
         inner.Responses.Enqueue(Ok(rateLimitRemaining: 10));
 
-        await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
 
         VerifyWarningLoggedContaining(logger, "10 requests remaining");
     }
@@ -144,7 +177,7 @@ public class VitallyRateLimitHandlerTests
         var (client, inner, logger) = BuildClient(h => h.LowRemainingThreshold = 50);
         inner.Responses.Enqueue(Ok(rateLimitRemaining: 500));
 
-        await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
 
         logger.Verify(
             l => l.Log(
@@ -162,7 +195,7 @@ public class VitallyRateLimitHandlerTests
         var (client, inner, logger) = BuildClient();
         inner.Responses.Enqueue(Ok(rateLimitRemaining: null));
 
-        await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
 
         logger.Verify(
             l => l.Log(
@@ -181,7 +214,7 @@ public class VitallyRateLimitHandlerTests
         inner.Responses.Enqueue(TooManyRequests());
         inner.Responses.Enqueue(Ok());
 
-        await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
 
         VerifyWarningLoggedContaining(logger, "rate limited");
     }
@@ -193,7 +226,7 @@ public class VitallyRateLimitHandlerTests
         inner.Responses.Enqueue(TooManyRequests());
         inner.Responses.Enqueue(TooManyRequests());
 
-        await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
 
         VerifyWarningLoggedContaining(logger, "retries exhausted");
     }
@@ -209,7 +242,7 @@ public class VitallyRateLimitHandlerTests
         inner.Responses.Enqueue(response429);
         inner.Responses.Enqueue(Ok());
 
-        var response = await client.GetAsync("http://example.test/x");
+        using var response = await client.GetAsync("http://example.test/x");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         inner.Requests.Should().HaveCount(2);

--- a/VitallyMcp.Tests/VitallyServiceTests.cs
+++ b/VitallyMcp.Tests/VitallyServiceTests.cs
@@ -873,6 +873,41 @@ public class VitallyServiceTests
             ItExpr.IsAny<CancellationToken>());
     }
 
+    [Fact]
+    public async Task GetResourcesAsync_ShouldUrlEncodeQueryParameters()
+    {
+        // Arrange — values contain a space, an ampersand, an equals sign, and a slash,
+        // each of which would corrupt the URL if concatenated verbatim.
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler("""{"results":[]}""");
+        var service = CreateService(client);
+        var additionalParams = new Dictionary<string, string>
+        {
+            ["customFieldValue"] = "Acme Corp",        // space
+            ["filter"] = "name=John&Co",                // & and =
+            ["path"] = "a/b"                            // slash
+        };
+
+        // Act
+        await service.GetResourcesAsync(
+            "customObjects/inst/instances/search",
+            limit: 10,
+            from: "cursor with space",
+            sortBy: "createdAt desc",
+            additionalParams: additionalParams);
+
+        // Assert — every value in the resulting URL is percent-encoded.
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.Query.Contains("from=cursor%20with%20space")
+                && req.RequestUri.Query.Contains("sortBy=createdAt%20desc")
+                && req.RequestUri.Query.Contains("customFieldValue=Acme%20Corp")
+                && req.RequestUri.Query.Contains("filter=name%3DJohn%26Co")
+                && req.RequestUri.Query.Contains("path=a%2Fb")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
     #endregion
 
     #region Resource-Specific Defaults — newly-added resources

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -67,24 +67,35 @@ public class OAuthOptions
         SharedClientId = SharedClientId?.Trim() ?? string.Empty;
         SharedClientSecret = SharedClientSecret?.Trim() ?? string.Empty;
 
-        if (NoAuth)
+        // The OAuth proxy endpoints (/oauth/authorize, /oauth/token, /.well-known/*)
+        // use Authority to build upstream URLs even when JWT validation is skipped, so
+        // Authority is required whenever the proxy is enabled — including NoAuth dev mode.
+        var proxyEnabled = !string.IsNullOrWhiteSpace(SharedClientId);
+
+        if (NoAuth && !proxyEnabled)
         {
-            // Dev-mode bypass; remaining fields not required.
+            // Dev-mode bypass with no proxy: nothing else to validate.
             return;
         }
 
         if (string.IsNullOrWhiteSpace(Authority))
         {
-            throw new InvalidOperationException("OAuth:Authority is required when OAuth:NoAuth is false.");
+            throw new InvalidOperationException(
+                NoAuth
+                    ? "OAuth:Authority is required when OAuth:SharedClientId is set — the OAuth proxy uses it to build upstream URLs."
+                    : "OAuth:Authority is required when OAuth:NoAuth is false.");
         }
         if (!Uri.TryCreate(Authority, UriKind.Absolute, out var authorityUri) || authorityUri.Scheme != Uri.UriSchemeHttps)
         {
             throw new InvalidOperationException($"OAuth:Authority must be an absolute https URI (got '{Authority}').");
         }
-        if (string.IsNullOrWhiteSpace(Audience))
+
+        // Audience is only used by JwtBearer, which is skipped when NoAuth=true.
+        if (!NoAuth && string.IsNullOrWhiteSpace(Audience))
         {
             throw new InvalidOperationException("OAuth:Audience is required when OAuth:NoAuth is false.");
         }
+
         if (!string.IsNullOrWhiteSpace(SharedClientSecret) && string.IsNullOrWhiteSpace(SharedClientId))
         {
             throw new InvalidOperationException("OAuth:SharedClientSecret requires OAuth:SharedClientId to also be set.");

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -52,4 +52,40 @@ public class OAuthOptions
     /// secret to MCP clients. Optional: leave empty for public-client mode (consent screen will show).
     /// </summary>
     public string SharedClientSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Fail-fast configuration sanity check. Wired via <c>PostConfigure</c> in <c>Program.cs</c>
+    /// so misconfiguration surfaces at startup rather than at the first failed token validation.
+    /// </summary>
+    public void Validate()
+    {
+        Authority = Authority?.Trim() ?? string.Empty;
+        Audience = Audience?.Trim() ?? string.Empty;
+        Resource = Resource?.Trim() ?? string.Empty;
+        SharedClientId = SharedClientId?.Trim() ?? string.Empty;
+        SharedClientSecret = SharedClientSecret?.Trim() ?? string.Empty;
+
+        if (NoAuth)
+        {
+            // Dev-mode bypass; remaining fields not required.
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(Authority))
+        {
+            throw new InvalidOperationException("OAuth:Authority is required when OAuth:NoAuth is false.");
+        }
+        if (!Uri.TryCreate(Authority, UriKind.Absolute, out var authorityUri) || authorityUri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new InvalidOperationException($"OAuth:Authority must be an absolute https URI (got '{Authority}').");
+        }
+        if (string.IsNullOrWhiteSpace(Audience))
+        {
+            throw new InvalidOperationException("OAuth:Audience is required when OAuth:NoAuth is false.");
+        }
+        if (!string.IsNullOrWhiteSpace(SharedClientSecret) && string.IsNullOrWhiteSpace(SharedClientId))
+        {
+            throw new InvalidOperationException("OAuth:SharedClientSecret requires OAuth:SharedClientId to also be set.");
+        }
+    }
 }

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -54,8 +54,10 @@ public class OAuthOptions
     public string SharedClientSecret { get; set; } = string.Empty;
 
     /// <summary>
-    /// Fail-fast configuration sanity check. Wired via <c>PostConfigure</c> in <c>Program.cs</c>
-    /// so misconfiguration surfaces at startup rather than at the first failed token validation.
+    /// Fail-fast configuration sanity check. Wired via <c>PostConfigure</c> in <c>Program.cs</c>,
+    /// then triggered immediately after <c>builder.Build()</c> by resolving
+    /// <c>IOptions&lt;OAuthOptions&gt;</c>, so misconfiguration throws at startup rather than at
+    /// the first failed token validation.
     /// </summary>
     public void Validate()
     {

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -14,7 +14,8 @@ builder.Services.AddOptions<VitallyServerOptions>()
     .PostConfigure(o => o.Validate());
 
 builder.Services.AddOptions<OAuthOptions>()
-    .Bind(builder.Configuration.GetSection(OAuthOptions.SectionName));
+    .Bind(builder.Configuration.GetSection(OAuthOptions.SectionName))
+    .PostConfigure(o => o.Validate());
 
 builder.Services.AddMemoryCache();
 
@@ -51,10 +52,14 @@ builder.Services.AddMcpServer()
 
 // Honour X-Forwarded-Proto / X-Forwarded-Host from Container Apps ingress so absolute URLs
 // (issuer, registration_endpoint, etc.) emit the public https scheme rather than the
-// internal http scheme the container sees.
+// internal http scheme the container sees. KnownNetworks/KnownProxies are cleared because
+// the ACA ingress hop isn't on the default loopback-only trust list — and we don't know
+// the ingress IP range in advance. ForwardLimit=1 bounds the trust to exactly one hop
+// (the ingress), so a client can't smuggle a second X-Forwarded-* through.
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedFor;
+    options.ForwardLimit = 1;
     options.KnownNetworks.Clear();
     options.KnownProxies.Clear();
 });

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -48,11 +48,18 @@ var noAuth = oauthSection.GetValue<bool>("NoAuth");
 if (!noAuth)
 {
     builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(options =>
+        .AddJwtBearer();
+
+    // Configure JwtBearer from the *validated* OAuthOptions (trimmed/URI-checked by
+    // OAuthOptions.Validate) rather than the raw IConfiguration values. This guarantees
+    // that what JwtBearer sees matches what passed validation.
+    builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+        .Configure<IOptions<OAuthOptions>>((jwt, oauth) =>
         {
-            options.Authority = oauthSection["Authority"];
-            options.Audience = oauthSection["Audience"];
+            jwt.Authority = oauth.Value.Authority;
+            jwt.Audience = oauth.Value.Audience;
         });
+
     builder.Services.AddAuthorization();
 }
 

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -9,6 +9,10 @@ using VitallyMcp;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// PostConfigure + a forced IOptions resolution after build() gives us fail-fast startup
+// validation without the boilerplate of a separate IValidateOptions implementation. If
+// Validate() throws, the app crashes immediately after Build() rather than serving
+// requests with bad config.
 builder.Services.AddOptions<VitallyServerOptions>()
     .Bind(builder.Configuration.GetSection(VitallyServerOptions.SectionName))
     .PostConfigure(o => o.Validate());
@@ -19,11 +23,17 @@ builder.Services.AddOptions<OAuthOptions>()
 
 builder.Services.AddMemoryCache();
 
+// SecretClient registration uses the *validated* options (via IOptions) rather than raw
+// config, so trimmed/URI-checked KeyVaultUri is what's constructed. Conditional on the
+// raw config being present so the registration only fires when KV is actually configured.
 var vitallySection = builder.Configuration.GetSection(VitallyServerOptions.SectionName);
-var keyVaultUri = vitallySection["KeyVaultUri"];
-if (!string.IsNullOrWhiteSpace(keyVaultUri))
+if (!string.IsNullOrWhiteSpace(vitallySection["KeyVaultUri"]))
 {
-    builder.Services.AddSingleton(new SecretClient(new Uri(keyVaultUri), new DefaultAzureCredential()));
+    builder.Services.AddSingleton(sp =>
+    {
+        var opts = sp.GetRequiredService<IOptions<VitallyServerOptions>>().Value;
+        return new SecretClient(new Uri(opts.KeyVaultUri!), new DefaultAzureCredential());
+    });
 }
 
 builder.Services.AddScoped<VitallyApiKeyProvider>();
@@ -52,10 +62,19 @@ builder.Services.AddMcpServer()
 
 // Honour X-Forwarded-Proto / X-Forwarded-Host from Container Apps ingress so absolute URLs
 // (issuer, registration_endpoint, etc.) emit the public https scheme rather than the
-// internal http scheme the container sees. KnownNetworks/KnownProxies are cleared because
-// the ACA ingress hop isn't on the default loopback-only trust list — and we don't know
-// the ingress IP range in advance. ForwardLimit=1 bounds the trust to exactly one hop
-// (the ingress), so a client can't smuggle a second X-Forwarded-* through.
+// internal http scheme the container sees.
+//
+// Trust model: the container is not directly reachable from the public internet — the
+// Container Apps ingress is the only path in, and it overwrites/normalises the
+// X-Forwarded-* headers from clients before forwarding. So we trust those headers
+// implicitly via network isolation, not via authentication of the headers themselves.
+// KnownNetworks/KnownProxies are cleared because we don't know the ACA ingress IP range
+// statically. ForwardLimit=1 is defence-in-depth: it limits how many entries the
+// middleware will process, preventing client-supplied chained headers from being honoured
+// even if the ingress ever stops normalising them. If this app ever became reachable
+// outside of an ingress (e.g. via private endpoint exposure), this configuration would
+// need to tighten — either via KnownNetworks pinning or by removing ForwardedHeaders
+// support entirely.
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedFor;
@@ -65,6 +84,11 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 });
 
 var app = builder.Build();
+
+// Fail-fast: force resolution of bound + PostConfigured options now so misconfiguration
+// throws at startup rather than at first request.
+_ = app.Services.GetRequiredService<IOptions<VitallyServerOptions>>().Value;
+_ = app.Services.GetRequiredService<IOptions<OAuthOptions>>().Value;
 
 app.UseForwardedHeaders();
 

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -9,10 +9,10 @@ using VitallyMcp;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// PostConfigure + a forced IOptions resolution after build() gives us fail-fast startup
-// validation without the boilerplate of a separate IValidateOptions implementation. If
-// Validate() throws, the app crashes immediately after Build() rather than serving
-// requests with bad config.
+// PostConfigure + a forced IOptions resolution after WebApplicationBuilder.Build() gives
+// us fail-fast startup validation without the boilerplate of a separate IValidateOptions
+// implementation. If Validate() throws, the app crashes immediately after Build() rather
+// than serving requests with bad config.
 builder.Services.AddOptions<VitallyServerOptions>()
     .Bind(builder.Configuration.GetSection(VitallyServerOptions.SectionName))
     .PostConfigure(o => o.Validate());

--- a/VitallyMcp/Tools/CustomObjectsTools.cs
+++ b/VitallyMcp/Tools/CustomObjectsTools.cs
@@ -45,17 +45,13 @@ public static class CustomObjectsTools
         [Description("Search criteria as query parameters (e.g., id, externalId, customerId, organizationId, customFieldId, customFieldValue)")] string searchQuery,
         [Description("Comma-separated list of fields to include. Defaults to: id,createdAt,updatedAt. Client-side filtering.")] string? fields = null)
     {
-        var additionalParams = new Dictionary<string, string>();
-        // Parse search query into parameters
-        var queryParts = searchQuery.Split('&');
-        foreach (var part in queryParts)
-        {
-            var keyValue = part.Split('=');
-            if (keyValue.Length == 2)
-            {
-                additionalParams[keyValue[0].Trim()] = keyValue[1].Trim();
-            }
-        }
+        // Parse search query (key=value pairs separated by &) into a parameter dictionary.
+        // Malformed pairs (anything without exactly one '=') are silently dropped.
+        var additionalParams = searchQuery
+            .Split('&')
+            .Select(part => part.Split('=', 2))
+            .Where(kv => kv.Length == 2)
+            .ToDictionary(kv => kv[0].Trim(), kv => kv[1].Trim());
 
         return await vitallyService.GetResourcesAsync($"customObjects/{customObjectId}/instances/search", 100, null, fields, null, additionalParams, null);
     }

--- a/VitallyMcp/Tools/CustomObjectsTools.cs
+++ b/VitallyMcp/Tools/CustomObjectsTools.cs
@@ -46,12 +46,16 @@ public static class CustomObjectsTools
         [Description("Comma-separated list of fields to include. Defaults to: id,createdAt,updatedAt. Client-side filtering.")] string? fields = null)
     {
         // Parse search query (key=value pairs separated by &) into a parameter dictionary.
-        // Malformed pairs (anything without exactly one '=') are silently dropped.
-        var additionalParams = searchQuery
-            .Split('&')
-            .Select(part => part.Split('=', 2))
-            .Where(kv => kv.Length == 2)
-            .ToDictionary(kv => kv[0].Trim(), kv => kv[1].Trim());
+        // - Split on the first '=' so values can themselves contain '=' (e.g. a=b=c -> key "a", value "b=c").
+        // - Pairs without an '=' are silently dropped.
+        // - Duplicate keys: last value wins, matching typical lenient URL-form parsing.
+        var additionalParams = new Dictionary<string, string>();
+        foreach (var part in searchQuery.Split('&'))
+        {
+            var keyValue = part.Split('=', 2);
+            if (keyValue.Length != 2) continue;
+            additionalParams[keyValue[0].Trim()] = keyValue[1].Trim();
+        }
 
         return await vitallyService.GetResourcesAsync($"customObjects/{customObjectId}/instances/search", 100, null, fields, null, additionalParams, null);
     }

--- a/VitallyMcp/Tools/CustomObjectsTools.cs
+++ b/VitallyMcp/Tools/CustomObjectsTools.cs
@@ -52,12 +52,21 @@ public static class CustomObjectsTools
         // - Percent-decode keys/values so callers can pass either raw ("Acme Corp") or
         //   already-encoded ("Acme%20Corp") values; VitallyService.GetResourcesAsync then
         //   re-encodes consistently, avoiding double-encoding (%20 -> %2520).
+        // - Malformed percent-escapes (e.g. literal "50%off") fall back to the raw segment
+        //   rather than failing the whole tool call.
+        static string SafeDecode(string s)
+        {
+            try { return Uri.UnescapeDataString(s); }
+            catch (UriFormatException) { return s; }
+            catch (ArgumentException) { return s; }
+        }
+
         var additionalParams = new Dictionary<string, string>();
         foreach (var part in searchQuery.Split('&'))
         {
             var keyValue = part.Split('=', 2);
             if (keyValue.Length != 2) continue;
-            additionalParams[Uri.UnescapeDataString(keyValue[0].Trim())] = Uri.UnescapeDataString(keyValue[1].Trim());
+            additionalParams[SafeDecode(keyValue[0].Trim())] = SafeDecode(keyValue[1].Trim());
         }
 
         return await vitallyService.GetResourcesAsync($"customObjects/{customObjectId}/instances/search", 100, null, fields, null, additionalParams, null);

--- a/VitallyMcp/Tools/CustomObjectsTools.cs
+++ b/VitallyMcp/Tools/CustomObjectsTools.cs
@@ -49,12 +49,15 @@ public static class CustomObjectsTools
         // - Split on the first '=' so values can themselves contain '=' (e.g. a=b=c -> key "a", value "b=c").
         // - Pairs without an '=' are silently dropped.
         // - Duplicate keys: last value wins, matching typical lenient URL-form parsing.
+        // - Percent-decode keys/values so callers can pass either raw ("Acme Corp") or
+        //   already-encoded ("Acme%20Corp") values; VitallyService.GetResourcesAsync then
+        //   re-encodes consistently, avoiding double-encoding (%20 -> %2520).
         var additionalParams = new Dictionary<string, string>();
         foreach (var part in searchQuery.Split('&'))
         {
             var keyValue = part.Split('=', 2);
             if (keyValue.Length != 2) continue;
-            additionalParams[keyValue[0].Trim()] = keyValue[1].Trim();
+            additionalParams[Uri.UnescapeDataString(keyValue[0].Trim())] = Uri.UnescapeDataString(keyValue[1].Trim());
         }
 
         return await vitallyService.GetResourcesAsync($"customObjects/{customObjectId}/instances/search", 100, null, fields, null, additionalParams, null);

--- a/VitallyMcp/VitallyServerOptions.cs
+++ b/VitallyMcp/VitallyServerOptions.cs
@@ -43,12 +43,22 @@ public class VitallyServerOptions
 
         KeyVaultUri = KeyVaultUri?.Trim();
         DevelopmentApiKey = DevelopmentApiKey?.Trim();
+        DefaultSecretRef = DefaultSecretRef?.Trim() ?? string.Empty;
 
         if (!string.IsNullOrWhiteSpace(KeyVaultUri)
             && (!Uri.TryCreate(KeyVaultUri, UriKind.Absolute, out var vaultUri) || vaultUri.Scheme != Uri.UriSchemeHttps))
         {
             throw new InvalidOperationException(
                 $"Vitally:KeyVaultUri must be an absolute https URI (got '{KeyVaultUri}').");
+        }
+
+        // Without a non-empty secret name, VitallyApiKeyProvider would later call
+        // SecretClient.GetSecretAsync("") and fail at first use. Required only when
+        // Key Vault is actually in play (dev mode uses DevelopmentApiKey directly).
+        if (!string.IsNullOrWhiteSpace(KeyVaultUri) && string.IsNullOrWhiteSpace(DefaultSecretRef))
+        {
+            throw new InvalidOperationException(
+                "Vitally:DefaultSecretRef cannot be empty when Vitally:KeyVaultUri is set.");
         }
 
         if (string.IsNullOrWhiteSpace(KeyVaultUri) && string.IsNullOrWhiteSpace(DevelopmentApiKey))

--- a/VitallyMcp/VitallyServerOptions.cs
+++ b/VitallyMcp/VitallyServerOptions.cs
@@ -39,6 +39,18 @@ public class VitallyServerOptions
                 "Vitally:Subdomain is required when Vitally:Region is 'US'.");
         }
 
+        KeyVaultUri = KeyVaultUri?.Trim();
+        DevelopmentApiKey = DevelopmentApiKey?.Trim();
+
+        if (!string.IsNullOrWhiteSpace(KeyVaultUri))
+        {
+            if (!Uri.TryCreate(KeyVaultUri, UriKind.Absolute, out var vaultUri) || vaultUri.Scheme != Uri.UriSchemeHttps)
+            {
+                throw new InvalidOperationException(
+                    $"Vitally:KeyVaultUri must be an absolute https URI (got '{KeyVaultUri}').");
+            }
+        }
+
         if (string.IsNullOrWhiteSpace(KeyVaultUri) && string.IsNullOrWhiteSpace(DevelopmentApiKey))
         {
             throw new InvalidOperationException(

--- a/VitallyMcp/VitallyServerOptions.cs
+++ b/VitallyMcp/VitallyServerOptions.cs
@@ -42,13 +42,11 @@ public class VitallyServerOptions
         KeyVaultUri = KeyVaultUri?.Trim();
         DevelopmentApiKey = DevelopmentApiKey?.Trim();
 
-        if (!string.IsNullOrWhiteSpace(KeyVaultUri))
+        if (!string.IsNullOrWhiteSpace(KeyVaultUri)
+            && (!Uri.TryCreate(KeyVaultUri, UriKind.Absolute, out var vaultUri) || vaultUri.Scheme != Uri.UriSchemeHttps))
         {
-            if (!Uri.TryCreate(KeyVaultUri, UriKind.Absolute, out var vaultUri) || vaultUri.Scheme != Uri.UriSchemeHttps)
-            {
-                throw new InvalidOperationException(
-                    $"Vitally:KeyVaultUri must be an absolute https URI (got '{KeyVaultUri}').");
-            }
+            throw new InvalidOperationException(
+                $"Vitally:KeyVaultUri must be an absolute https URI (got '{KeyVaultUri}').");
         }
 
         if (string.IsNullOrWhiteSpace(KeyVaultUri) && string.IsNullOrWhiteSpace(DevelopmentApiKey))

--- a/VitallyMcp/VitallyServerOptions.cs
+++ b/VitallyMcp/VitallyServerOptions.cs
@@ -33,6 +33,8 @@ public class VitallyServerOptions
         }
         Region = region;
 
+        Subdomain = Subdomain?.Trim();
+
         if (region == RegionUs && string.IsNullOrWhiteSpace(Subdomain))
         {
             throw new InvalidOperationException(

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -230,6 +230,10 @@ public class VitallyService
         writer.WriteEndObject();
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1860",
+        Justification = "JsonElement.TryGetProperty uses an out parameter that LINQ Where cannot expose without a redundant second call. The explicit foreach is clearer and more efficient than the LINQ rewrite.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "cs/linq/missed-where",
+        Justification = "Same as above — TryGetProperty out parameter pattern.")]
     private static void WriteFilteredFields(Utf8JsonWriter writer, JsonElement element, string[] fields, string[]? requestedTraits)
     {
         foreach (var field in fields)
@@ -250,6 +254,8 @@ public class VitallyService
         }
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "cs/linq/missed-where",
+        Justification = "JsonElement.TryGetProperty out parameter doesn't translate to LINQ Where without a redundant second call.")]
     private static void WriteFilteredTraits(Utf8JsonWriter writer, JsonElement traitsElement, string[] requestedTraits)
     {
         writer.WriteStartObject();

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -66,19 +66,22 @@ public class VitallyService
 
     public async Task<string> GetResourcesAsync(string resourceType, int limit = 20, string? from = null, string? fields = null, string? sortBy = null, Dictionary<string, string>? additionalParams = null, string? traits = null)
     {
+        // URL-encode keys and values to handle spaces, ampersands, equals signs etc. in
+        // user-supplied filter values (e.g. customFieldValue="Acme Corp"). The Vitally REST
+        // API treats query strings as standard application/x-www-form-urlencoded.
         var queryParams = new List<string> { $"limit={limit}" };
 
         if (!string.IsNullOrEmpty(from))
-            queryParams.Add($"from={from}");
+            queryParams.Add($"from={Uri.EscapeDataString(from)}");
 
         if (!string.IsNullOrEmpty(sortBy))
-            queryParams.Add($"sortBy={sortBy}");
+            queryParams.Add($"sortBy={Uri.EscapeDataString(sortBy)}");
 
         if (additionalParams != null)
         {
             foreach (var param in additionalParams)
             {
-                queryParams.Add($"{param.Key}={param.Value}");
+                queryParams.Add($"{Uri.EscapeDataString(param.Key)}={Uri.EscapeDataString(param.Value)}");
             }
         }
 

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -66,9 +66,10 @@ public class VitallyService
 
     public async Task<string> GetResourcesAsync(string resourceType, int limit = 20, string? from = null, string? fields = null, string? sortBy = null, Dictionary<string, string>? additionalParams = null, string? traits = null)
     {
-        // URL-encode keys and values to handle spaces, ampersands, equals signs etc. in
-        // user-supplied filter values (e.g. customFieldValue="Acme Corp"). The Vitally REST
-        // API treats query strings as standard application/x-www-form-urlencoded.
+        // Percent-encode keys and values (RFC 3986 query-string encoding via
+        // Uri.EscapeDataString — spaces become %20, not +) so user-supplied filter values
+        // containing spaces, ampersands, equals signs etc. don't corrupt the URL
+        // (e.g. customFieldValue="Acme Corp" -> customFieldValue=Acme%20Corp).
         var queryParams = new List<string> { $"limit={limit}" };
 
         if (!string.IsNullOrEmpty(from))


### PR DESCRIPTION
Follow-up to #23 — Copilot left review comments that didn't get addressed before merge. Initial scope was those five; PR grew across several Copilot review passes to cover all subsequent findings.

## Initial fixes (the five comments from #23)

### Program.cs (Forwarded headers spoofing risk)
Copilot flagged that clearing `KnownNetworks` / `KnownProxies` on `ForwardedHeadersOptions` allows untrusted clients to spoof `X-Forwarded-Proto/Host/For`. The clear is unavoidable on Container Apps (the ingress isn't on the default loopback-only trust list and we don't know its CIDR ahead of time). Set `ForwardLimit = 1` to bound trust to exactly one upstream hop (the ACA ingress) and rewrote the comment to be honest about the trust model: trust comes from network isolation, not header authentication.

### OAuthOptions.cs (Missing fail-fast validation)
Added a `Validate()` method analogous to `VitallyServerOptions.Validate()`, wired via `PostConfigure` in `Program.cs` and triggered immediately after `WebApplicationBuilder.Build()` by forcing `IOptions.Value` resolution. Checks `Authority` (required + https + absolute URI whenever the OAuth proxy is enabled, including dev mode), `Audience` (required when `NoAuth=false`), and `SharedClientSecret` (requires `SharedClientId`).

### VitallyServerOptions.cs (KeyVaultUri validation)
`KeyVaultUri`, `Subdomain`, `DevelopmentApiKey`, and `DefaultSecretRef` are now trimmed in `Validate()`. `KeyVaultUri` is checked as an absolute https URI. `DefaultSecretRef` is required non-empty when `KeyVaultUri` is set (would otherwise cause an empty-name call to `SecretClient.GetSecretAsync` at first request).

### CHANGELOG.md (Two factual errors)
- Removed the claim that `VitallyApiKeyProvider` reads a `Vitally:SecretRefClaim` from the user's token. It doesn't; it uses `DefaultSecretRef` from config (the per-user variant was deferred).
- Replaced `Auth0:` config section references with `OAuth:` (the actual section name post-rename).

## Subsequent fixes (additional Copilot/CodeQL passes)

- **SecretClient factory uses validated options**: `SecretClient` is now constructed inside an `IServiceProvider` factory that resolves `IOptions<VitallyServerOptions>` (the trimmed/validated value), rather than reading raw config.
- **JwtBearer bound to validated OAuthOptions**: `JwtBearerOptions` is now configured via `.Configure<IOptions<OAuthOptions>>(...)` so it sees the trimmed values.
- **URL encoding in `VitallyService.GetResourcesAsync`**: `from`, `sortBy`, and `additionalParams` are now percent-encoded via `Uri.EscapeDataString` (this matches `GetRawAsync`'s existing behaviour). **Behavioural change worth flagging in operations**: outbound requests for inputs containing spaces, `&`, `=`, `/`, etc. now produce different URLs than before (correct URLs vs the previous malformed ones). Test added (`GetResourcesAsync_ShouldUrlEncodeQueryParameters`) to lock the contract.
- **Search-query parser hardening (CustomObjectsTools.cs)**: parses with `Split('=', 2)` so values can contain `=`; preserves lenient last-wins semantics for duplicate keys; percent-decodes keys/values via a `SafeDecode` helper that falls back to raw on malformed escapes (no more 500s from a literal `%` in user input). Round-trip is consistent with `GetResourcesAsync`'s re-encoding.
- **CodeQL clean-up**: combined a nested `if`, suppressed two `cs/linq/missed-where` findings where `JsonElement.TryGetProperty`'s out parameter doesn't translate to LINQ, refactored `VitallyRateLimitHandlerTests` to be `IDisposable` with real disposal of `HttpClient`s + `QueueingHandler` + responses (removed the broad file-level suppression), and added `using` to test response handling in 10 tests.

## Verification

- `dotnet test`: 182/182 pass (added `GetResourcesAsync_ShouldUrlEncodeQueryParameters`)
- The deployed server (`vitally.fiscaltec.com`) is on revision `--0000012` from PR #23's last image. **Once this PR merges and deploys**, the URL-encoding change above will affect outbound Vitally requests for any search containing reserved characters. If a tool was working around the old behaviour by pre-encoding values, that will now double-encode — fixed by the search-query parser's `SafeDecode` (it accepts either raw or pre-encoded).

## Process note (the underlying issue)

I queued the auto-merge on #23 without checking for outstanding review threads — sorry. To prevent this happening again, I'd suggest:

1. **Branch protection rule on `main`**: enable "Require conversation resolution before merging" (Settings → Branches → main → Branch protection). This makes `gh pr merge --auto` honour unresolved review comments.
2. **Optional**: Also enable "Require pull request reviews before merging" with at least 1 approval if you want a human (or Copilot) review gate.

Either fix is at the repo level, applies to all future PRs, and is the right place to enforce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)