### PR TITLE
build: group Azure SDK + track Dockerfile in Dependabot, bump Test.Sdk

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,13 @@ updates:
       microsoft-extensions:
         patterns:
           - "Microsoft.Extensions.*"
+      # Azure SDK packages share a transitive Azure.Core dependency. Bumping them in
+      # separate PRs caused a CS0433 'DefaultAzureCredential' collision (KeyVault.Secrets
+      # pulled a newer Azure.Core than the pinned Azure.Identity). Grouping them means the
+      # set builds or fails as a unit.
+      azure:
+        patterns:
+          - "Azure.*"
       test-framework:
         patterns:
           - "xunit*"
@@ -48,4 +55,22 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "ci"
+      include: "scope"
+
+  # Track the Dockerfile base images (dotnet/sdk + dotnet/aspnet). The floating "10.0"
+  # tags already pick up patch/minor on rebuild; this surfaces major bumps (e.g. .NET 11
+  # base images) as a PR so the runtime doesn't silently drift behind a new release.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "build"
       include: "scope"

--- a/VitallyMcp.Tests/VitallyMcp.Tests.csproj
+++ b/VitallyMcp.Tests/VitallyMcp.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

Follow-up to the Dependabot batch merge (#26–#30). Closes the gaps a full freshness sweep surfaced.

- **`azure` Dependabot group** (`Azure.*`) — the Azure SDK packages share a transitive `Azure.Core` dependency. Bumping them in separate PRs is what caused the `CS0433` `DefaultAzureCredential` collision on #28 (newer `KeyVault.Secrets` pulled a newer `Azure.Core` than the still-pinned `Azure.Identity`). Grouping means the set builds or fails as a unit and lands in one PR.
- **`docker` Dependabot ecosystem** — the Dockerfile base images (`dotnet/sdk`, `dotnet/aspnet`) weren't tracked. The floating `10.0` tags already pick up patch/minor on rebuild; this surfaces major bumps (e.g. .NET 11 base images) as a PR.
- **`Microsoft.NET.Test.Sdk` 18.5.1 → 18.6.0** — the only outstanding package update from `dotnet list package --outdated` across the solution.

## Freshness sweep findings (for the record)

- Main project (`VitallyMcp`) is fully current: Azure.Identity 1.21.0, KeyVault.Secrets 4.11.0, JwtBearer 10.0.8, ModelContextProtocol 1.3.0 (latest).
- **No vulnerable packages** anywhere (`dotnet list package --vulnerable --include-transitive`).
- All GitHub Actions current (checkout@v6, setup-dotnet@v5, upload-artifact@v7, cache@v5, codeql-action@v4, test-reporter@v3, action-semantic-pull-request@v6).
- **`xunit` 2.9.3 is flagged deprecated** ("Legacy — xunit.v3"). That's a *migration* (v2 → v3), not a version bump — deliberately **not** included here; worth a dedicated effort later.

## Test plan

- [x] `dotnet test -c Release` — 241/241 pass with Test.Sdk 18.6.0
- [ ] CI green
- [ ] (post-merge) confirm Dependabot parses the new config — check the Dependabot logs / next scheduled run groups Azure.* and lists the docker ecosystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)