### PR TITLE
test: migrate xunit v2 to xunit.v3 3.2.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -52,3 +52,12 @@ csharp_preferred_modifier_order = public,private,protected,internal,file,static,
 
 # Namespace style (file-scoped is the .NET 6+ default we use)
 csharp_style_namespace_declarations = file_scoped:warning
+
+# Test project — xunit.v3 analyzer tuning.
+[VitallyMcp.Tests/**.cs]
+# xUnit1051: prefer TestContext.Current.CancellationToken on cancellable calls.
+# Disabled here deliberately: the suite is fully in-memory/mocked and runs in ~1s,
+# so there is no long-running operation where cancellation responsiveness matters.
+# Threading the token through every HttpClient/ReadAsStringAsync call would add noise
+# with no practical benefit. Re-enable if slow or genuinely cancellable tests appear.
+dotnet_diagnostic.xUnit1051.severity = none

--- a/VitallyMcp.Tests/VitallyMcp.Tests.csproj
+++ b/VitallyMcp.Tests/VitallyMcp.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Last item in the "fully up to date before next release" sweep — clears the only deprecated package in the tree.

- `xunit` 2.9.3 → `xunit.v3` 3.2.2. xunit v2 is now flagged deprecated ("Legacy — xunit.v3").
- **Zero source changes** — `[Fact]`, `[Theory]`, `[InlineData]`, `IClassFixture<>`, `Assert`, and the FluentAssertions / Moq / `WebApplicationFactory` usage all carry over unchanged.
- Runs in **VSTest-compatibility mode** (`Microsoft.NET.Test.Sdk` + `xunit.runner.visualstudio` 3.1.5), so `dotnet test` and the CI workflow need no changes.
- xunit.v3 ships new analyzers. `xUnit1051` (prefer `TestContext.Current.CancellationToken`) is disabled for the test project in `.editorconfig`, with a justification: the suite is fully in-memory/mocked and runs in ~1s, so cancellation responsiveness has no practical benefit and threading the token through every call would only add noise.

## Verification

- `dotnet list package --deprecated` — now **clean** across the solution (was flagging xunit).
- `dotnet test -c Release` — **241/241 pass, 0 warnings**.

## Test plan

- [x] Release build clean, 0 warnings
- [x] All 241 tests pass under xunit.v3
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)