### PR TITLE
fix: live group check skipped due to sub→NameIdentifier claim mapping

### DIFF
--- a/VitallyMcp.Tests/ToolAuthorizerTests.cs
+++ b/VitallyMcp.Tests/ToolAuthorizerTests.cs
@@ -158,6 +158,20 @@ public class ToolAuthorizerTests
     }
 
     [Fact]
+    public async Task LiveCheck_Engages_WhenSubIsMappedToNameIdentifier()
+    {
+        // Regression: JwtBearer maps "sub" -> ClaimTypes.NameIdentifier in production, so the live
+        // path must still find the object id from the mapped claim (no raw "sub" present here).
+        var resolver = new StubResolver(new HashSet<string> { "vitally:read", "vitally:write", "vitally:delete" });
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.NameIdentifier, SubWithOid) }, "Test"));
+        var authorizer = Build(user: user, options: LiveOptions(), resolver: resolver);
+
+        await authorizer.Invoking(a => a.EnsureAuthorizedAsync(HttpMethod.Delete)).Should().NotThrowAsync();
+        resolver.LastObjectId.Should().Be("675ebdda-7590-4d79-8ec3-a2d17ab029ba");
+    }
+
+    [Fact]
     public async Task LiveCheck_Denies_WhenLiveGroupsLackPermission()
     {
         // Live membership says read-only — must override a stale token claim that still has delete.

--- a/VitallyMcp/ToolAuthorizer.cs
+++ b/VitallyMcp/ToolAuthorizer.cs
@@ -93,7 +93,11 @@ public class ToolAuthorizer
             return oid;
         }
 
-        var sub = user.FindFirst("sub")?.Value;
+        // JwtBearer's default inbound claim mapping renames "sub" to ClaimTypes.NameIdentifier, so
+        // check both — otherwise the object id is never found in production and the live lookup is
+        // silently skipped (falling back to the frozen token claim).
+        var sub = user.FindFirst("sub")?.Value
+            ?? user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         if (!string.IsNullOrWhiteSpace(sub))
         {
             var last = sub.Split('|', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();


### PR DESCRIPTION
## Bug

After enabling `LiveGroupCheck` in prod, users were denied even when their live Entra group membership granted access — with **no resolver warning** (so not a Graph failure).

## Root cause

JwtBearer's default **inbound claim mapping renames the JWT `sub` claim to `ClaimTypes.NameIdentifier`**. `ToolAuthorizer.ExtractObjectId` only looked for `"sub"` (and `"oid"`), so in production it found no object id → silently skipped the live lookup → fell back to the frozen token claim → denied. Verified live via Graph `checkMemberGroups` returning the correct group, while the server still denied. Unit tests passed because they set a raw `"sub"` claim, masking the mapping.

## Fix

`ExtractObjectId` now also reads `ClaimTypes.NameIdentifier` (mirroring `AuditLogger`, which is why audit lines logged the subject correctly). One-line fix + a regression test that uses the mapped claim with no raw `"sub"`. 275 tests pass.

## Deploy

Rebuild and roll the container app (env vars already set on the app from the previous deploy carry forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)