### PR TITLE
chore(infra): privatise Azure Monitor (AMPLS) + add VNet flow logs

### DIFF
--- a/infra/terraform/ampls.tf
+++ b/infra/terraform/ampls.tf
@@ -1,0 +1,82 @@
+# Azure Monitor Private Link Scope (AMPLS) — privatises Log Analytics + Application Insights.
+# Applied to the live estate via CLI on 2026-06-10; adopt via the import blocks in imports.tf.
+# The matching public-access lockdown lives on the resources themselves in monitoring.tf.
+
+# Dedicated PE subnet — the azuremonitor private endpoint consumes ~13 IPs, so the existing
+# /28 snet-pe (KV + ACR endpoints) cannot host it; this /27 sits in the free VNet space.
+resource "azurerm_subnet" "pe_monitor" {
+  name                              = "snet-pe-monitor"
+  resource_group_name               = data.azurerm_resource_group.rg.name
+  virtual_network_name              = azurerm_virtual_network.vnet.name
+  address_prefixes                  = ["10.80.0.96/27"]
+  private_endpoint_network_policies = "Disabled"
+}
+
+# ---- Azure Monitor private DNS zones (the 5 required for the azuremonitor group) ----
+locals {
+  monitor_private_dns_zones = [
+    "privatelink.monitor.azure.com",
+    "privatelink.oms.opinsights.azure.com",
+    "privatelink.ods.opinsights.azure.com",
+    "privatelink.agentsvc.azure-automation.net",
+    "privatelink.blob.core.windows.net",
+  ]
+}
+
+resource "azurerm_private_dns_zone" "monitor" {
+  for_each            = toset(local.monitor_private_dns_zones)
+  name                = each.value
+  resource_group_name = data.azurerm_resource_group.rg.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "monitor" {
+  for_each              = toset(local.monitor_private_dns_zones)
+  name                  = "link-${replace(replace(each.value, "privatelink.", ""), ".", "-")}"
+  resource_group_name   = data.azurerm_resource_group.rg.name
+  private_dns_zone_name = azurerm_private_dns_zone.monitor[each.value].name
+  virtual_network_id    = azurerm_virtual_network.vnet.id
+  registration_enabled  = false
+}
+
+# ---- The scope + scoped resources ----
+resource "azurerm_monitor_private_link_scope" "ampls" {
+  name                = "${var.name_prefix}-ampls-uksouth"
+  resource_group_name = data.azurerm_resource_group.rg.name
+
+  ingestion_access_mode = "PrivateOnly"
+  query_access_mode     = "PrivateOnly"
+}
+
+resource "azurerm_monitor_private_link_scoped_service" "law" {
+  name                = "law-link"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  scope_name          = azurerm_monitor_private_link_scope.ampls.name
+  linked_resource_id  = azurerm_log_analytics_workspace.law.id
+}
+
+resource "azurerm_monitor_private_link_scoped_service" "appi" {
+  name                = "appi-link"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  scope_name          = azurerm_monitor_private_link_scope.ampls.name
+  linked_resource_id  = azurerm_application_insights.appi.id
+}
+
+# ---- Private endpoint (binds all 5 zones so endpoint A-records auto-populate) ----
+resource "azurerm_private_endpoint" "ampls" {
+  name                = "${var.name_prefix}-pe-ampls-uksouth"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = var.location
+  subnet_id           = azurerm_subnet.pe_monitor.id
+
+  private_service_connection {
+    name                           = "${var.name_prefix}-pe-ampls-uksouth-conn"
+    private_connection_resource_id = azurerm_monitor_private_link_scope.ampls.id
+    subresource_names              = ["azuremonitor"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "ampls-dns-group"
+    private_dns_zone_ids = [for z in azurerm_private_dns_zone.monitor : z.id]
+  }
+}

--- a/infra/terraform/flowlogs.tf
+++ b/infra/terraform/flowlogs.tf
@@ -1,0 +1,37 @@
+# VNet flow logs → dedicated, hardened storage account.
+# Applied to the live estate via CLI on 2026-06-10; adopt via the import blocks in imports.tf.
+# Traffic analytics is intentionally off (would ingest into the now-private LAW); raw flow logs only.
+
+resource "azurerm_storage_account" "flowlogs" {
+  name                            = "vitallyprodflowuksouth"
+  resource_group_name             = data.azurerm_resource_group.rg.name
+  location                        = var.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  account_kind                    = "StorageV2"
+  min_tls_version                 = "TLS1_2"
+  https_traffic_only_enabled      = true
+  allow_nested_items_to_be_public = false
+  public_network_access_enabled   = true
+
+  # Default-deny, with the trusted-services bypass so Network Watcher can write flow logs.
+  network_rules {
+    default_action = "Deny"
+    bypass         = ["AzureServices"]
+  }
+}
+
+resource "azurerm_network_watcher_flow_log" "vnet" {
+  name                 = "${var.name_prefix}-vnetflow-uksouth"
+  network_watcher_name = "NetworkWatcher_uksouth"
+  resource_group_name  = "NetworkWatcherRG"
+  location             = var.location
+  target_resource_id   = azurerm_virtual_network.vnet.id
+  storage_account_id   = azurerm_storage_account.flowlogs.id
+  enabled              = true
+
+  retention_policy {
+    enabled = true
+    days    = 30
+  }
+}

--- a/infra/terraform/imports.tf
+++ b/infra/terraform/imports.tf
@@ -84,6 +84,77 @@ import {
   id = "${local.rg_id}/providers/Microsoft.Network/privateEndpoints/vitally-prod-pe-acr-uksouth"
 }
 
+# ---- 2026-06-10: AMPLS (App Insights/LAW privatisation) + VNet flow logs ----
+# Applied to the live estate via CLI; bring under management with these imports.
+import {
+  to = azurerm_subnet.pe_monitor
+  id = "${local.rg_id}/providers/Microsoft.Network/virtualNetworks/vitally-prod-vnet-uksouth/subnets/snet-pe-monitor"
+}
+import {
+  to = azurerm_private_dns_zone.monitor["privatelink.monitor.azure.com"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.monitor.azure.com"
+}
+import {
+  to = azurerm_private_dns_zone.monitor["privatelink.oms.opinsights.azure.com"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.oms.opinsights.azure.com"
+}
+import {
+  to = azurerm_private_dns_zone.monitor["privatelink.ods.opinsights.azure.com"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.ods.opinsights.azure.com"
+}
+import {
+  to = azurerm_private_dns_zone.monitor["privatelink.agentsvc.azure-automation.net"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.agentsvc.azure-automation.net"
+}
+import {
+  to = azurerm_private_dns_zone.monitor["privatelink.blob.core.windows.net"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
+}
+import {
+  to = azurerm_private_dns_zone_virtual_network_link.monitor["privatelink.monitor.azure.com"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.monitor.azure.com/virtualNetworkLinks/link-monitor-azure-com"
+}
+import {
+  to = azurerm_private_dns_zone_virtual_network_link.monitor["privatelink.oms.opinsights.azure.com"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.oms.opinsights.azure.com/virtualNetworkLinks/link-oms-opinsights-azure-com"
+}
+import {
+  to = azurerm_private_dns_zone_virtual_network_link.monitor["privatelink.ods.opinsights.azure.com"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.ods.opinsights.azure.com/virtualNetworkLinks/link-ods-opinsights-azure-com"
+}
+import {
+  to = azurerm_private_dns_zone_virtual_network_link.monitor["privatelink.agentsvc.azure-automation.net"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.agentsvc.azure-automation.net/virtualNetworkLinks/link-agentsvc-azure-automation-net"
+}
+import {
+  to = azurerm_private_dns_zone_virtual_network_link.monitor["privatelink.blob.core.windows.net"]
+  id = "${local.rg_id}/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net/virtualNetworkLinks/link-blob-core-windows-net"
+}
+import {
+  to = azurerm_monitor_private_link_scope.ampls
+  id = "${local.rg_id}/providers/Microsoft.Insights/privateLinkScopes/vitally-prod-ampls-uksouth"
+}
+import {
+  to = azurerm_monitor_private_link_scoped_service.law
+  id = "${local.rg_id}/providers/Microsoft.Insights/privateLinkScopes/vitally-prod-ampls-uksouth/scopedResources/law-link"
+}
+import {
+  to = azurerm_monitor_private_link_scoped_service.appi
+  id = "${local.rg_id}/providers/Microsoft.Insights/privateLinkScopes/vitally-prod-ampls-uksouth/scopedResources/appi-link"
+}
+import {
+  to = azurerm_private_endpoint.ampls
+  id = "${local.rg_id}/providers/Microsoft.Network/privateEndpoints/vitally-prod-pe-ampls-uksouth"
+}
+import {
+  to = azurerm_storage_account.flowlogs
+  id = "${local.rg_id}/providers/Microsoft.Storage/storageAccounts/vitallyprodflowuksouth"
+}
+import {
+  to = azurerm_network_watcher_flow_log.vnet
+  id = "/subscriptions/${var.subscription_id}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_uksouth/flowLogs/vitally-prod-vnetflow-uksouth"
+}
+
 # ---- Need a looked-up ID first (uncomment + fill in, then plan) ----
 # Diagnostic settings:  import id = "<target-resource-id>|to-law"
 # Role assignments:     az role assignment list --scope <scope> --query "[].id"  → import "<assignment-id>"

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -4,6 +4,11 @@ resource "azurerm_log_analytics_workspace" "law" {
   location            = var.location
   sku                 = "PerGB2018"
   retention_in_days   = 30
+
+  # Privatised via AMPLS (ampls.tf): ingestion/query reachable only over the private endpoint.
+  internet_ingestion_enabled   = false
+  internet_query_enabled       = false
+  local_authentication_enabled = false
 }
 
 resource "azurerm_application_insights" "appi" {
@@ -12,4 +17,9 @@ resource "azurerm_application_insights" "appi" {
   location            = var.location
   application_type    = "web"
   workspace_id        = azurerm_log_analytics_workspace.law.id
+
+  # Privatised via AMPLS (ampls.tf). Local auth (connection-string ingestion) is left ENABLED:
+  # the Container App emits telemetry via the instrumentation key, so disabling it would break it.
+  internet_ingestion_enabled = false
+  internet_query_enabled     = false
 }


### PR DESCRIPTION
## Summary

Back-fills the Terraform IaC to match security hardening applied to the live Vitally MCP estate (`vitally-prod-rg-uksouth`) via `az` CLI, following a Microsoft Defender for Cloud review. **The changes are already live**; this PR brings them into IaC so the repo stays the source of truth.

## What changed

**`monitoring.tf`** — Log Analytics + Application Insights
- `internet_ingestion_enabled = false`, `internet_query_enabled = false` on both
- `local_authentication_enabled = false` on the workspace (Entra-only ingestion)

**`ampls.tf`** (new) — Azure Monitor private link
- `azurerm_monitor_private_link_scope` (ingestion + query `PrivateOnly`)
- LAW + App Insights scoped services
- dedicated `/27` PE subnet `snet-pe-monitor` (10.80.0.96/27) — the existing /28 couldn't fit the 13-IP `azuremonitor` endpoint
- the 5 required Azure Monitor private DNS zones + VNet links
- the AMPLS private endpoint (binds all 5 zones)

**`flowlogs.tf`** (new) — VNet flow logs
- hardened dedicated storage account (TLS1.2, no anonymous blob, default-deny + AzureServices bypass)
- VNet flow log, 30-day retention

**`imports.tf`** — import blocks to adopt the 17 CLI-applied resources

## Defender findings this clears
App Insights / LAW public ingestion + query, LAW non-AAD ingestion, and "audit flow-logs configuration for every VNet".

## Validation
- `terraform fmt -check` ✓ · `terraform validate` ✓ (no warnings)
- Verified live: logs continued to land over the private endpoint after public ingestion was disabled; app healthy (HTTP 200) throughout the cutover.

## ⚠️ Reviewer notes
- These are **`import` blocks** — they adopt existing live resources, they do not recreate them. The wider estate adoption (`terraform import` + state backend) is still pending; this just extends the import set.
- **Query is now private-only**: log queries from outside the VNet (portal / `az monitor log-analytics query`) will fail. Revert path: AMPLS `queryAccessMode=Open` + resource `publicNetworkAccessForQuery=Enabled`.
- The flow-logs storage account may surface 1–2 *Low* Defender findings (shared-key access, required for delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)