### PR TITLE
feat(instances): scope custom-object-instance listing + get-by-id, remove broken search (SP1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,7 @@ When no fields are specified, each resource type returns an optimised field set:
 | **Task Categories** | id, name, createdAt, updatedAt |
 | **Meetings** | id, title, externalId, startDateTime, endDateTime, location, source, accountIds, organizationIds, participants, createdAt, updatedAt |
 | **Meeting Transcripts** | id, meetingId, createdAt, updatedAt |
+| **Custom Object Instances** | id, name, externalId, createdAt, updatedAt, organizationId, customerId, archivedAt |
 | **Admins / Admins Search** | id, name, email |
 
 These defaults balance usefulness (business context, relationships, key metrics) with response size (excluding large fields like traits objects, rich text content, transcript bodies, and meeting summaries).
@@ -258,6 +259,13 @@ public static class AccountsTools
 **Note:** The `status` parameter is specific to `AccountsTools`, and `archived` is specific to `MeetingsTools`. The `traits` parameter is available for resources that support traits (Accounts, Organizations, Users, Tasks, Notes, Projects, Meetings, Project Templates). Other resource types have the standard parameters (limit, from, fields, sortBy).
 
 **Raw pass-through tools:** `CustomTraitsTools`, `SurveysTools`, and the participant/transcript methods on `MeetingsTools` call `GetRawAsync` / `PostRawAsync` / `DeleteRawAsync` directly. They do not accept a `fields` parameter because Vitally returns these endpoints with a non-standard JSON envelope (`{data}` for surveys, bare arrays for `customFields`).
+
+**Custom object instances:** `List_custom_object_instances` accepts an optional single scope
+criterion — `organizationId`, `customerId`, `externalId`, or `customFieldId`+`customFieldValue`
+— which routes to Vitally's `customObjects/:id/instances/search` endpoint (exactly one criterion;
+paging params are ignored when scoped). `Get_custom_object_instance` reads one instance by id via
+the same search endpoint (Vitally has no direct single-instance GET). The legacy free-text
+`Search_custom_object_instances` tool has been removed in favour of these typed paths.
 
 ## Adding New Resource Types
 

--- a/VitallyMcp.Tests/TestHelpers.cs
+++ b/VitallyMcp.Tests/TestHelpers.cs
@@ -493,6 +493,33 @@ public static class TestHelpers
     """;
 
     /// <summary>
+    /// Sample custom object instance JSON with the full field set (for default-field and
+    /// trait-subsetting tests). Includes a large field that should be excluded by default.
+    /// </summary>
+    public static string GetSampleRichCustomObjectInstanceJson() => """
+    {
+      "results": [
+        {
+          "id": "inst-123",
+          "name": "Annual Goal",
+          "externalId": "ext-inst-123",
+          "createdAt": "2024-01-01T00:00:00Z",
+          "updatedAt": "2024-01-15T00:00:00Z",
+          "organizationId": "org-456",
+          "customerId": "cust-789",
+          "archivedAt": null,
+          "descriptionBody": "A very long description body we do not want by default",
+          "traits": {
+            "target": "100",
+            "owner": "CSM"
+          }
+        }
+      ],
+      "next": "cursor-inst-next"
+    }
+    """;
+
+    /// <summary>
     /// Sample meeting JSON for testing.
     /// </summary>
     public static string GetSampleMeetingJson() => """

--- a/VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
+++ b/VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
@@ -405,4 +405,41 @@ public class CustomObjectsToolsTests
         result.Should().Contain("target");
         result.Should().NotContain("owner");
     }
+
+    [Fact]
+    public async Task GetCustomObjectInstance_WithMatch_ReturnsSingleObject()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        var result = await CustomObjectsTools.GetCustomObjectInstance(service, "cobj-123", "inst-123");
+
+        // Assert
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("id=inst-123")),
+            ItExpr.IsAny<CancellationToken>());
+        result.Should().NotContain("\"results\"");
+        result.Should().Contain("inst-123");
+    }
+
+    [Fact]
+    public async Task GetCustomObjectInstance_NoMatch_ReturnsNotFoundMessage()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetEmptyResultsJson());
+        var service = CreateService(mockClient);
+
+        // Act
+        var result = await CustomObjectsTools.GetCustomObjectInstance(service, "cobj-123", "inst-999");
+
+        // Assert
+        result.Should().Contain("No custom object instance found with id inst-999");
+    }
 }

--- a/VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
+++ b/VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
@@ -1,4 +1,6 @@
 using FluentAssertions;
+using Moq;
+using Moq.Protected;
 using VitallyMcp.Tools;
 
 namespace VitallyMcp.Tests.Tools;
@@ -230,5 +232,177 @@ public class CustomObjectsToolsTests
         // Assert
         result.Should().NotBeNullOrEmpty();
         result.Should().Contain("success");
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithOrganizationId_RoutesToSearchWithoutLimit()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        var result = await CustomObjectsTools.ListCustomObjectInstances(service, "cobj-123", organizationId: "org-456");
+
+        // Assert
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Method == HttpMethod.Get
+                && req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("organizationId=org-456")
+                && !req.RequestUri.Query.Contains("limit")),
+            ItExpr.IsAny<CancellationToken>());
+        result.Should().Contain("\"results\"");
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithCustomFieldPair_RoutesToSearchWithBothParams()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        await CustomObjectsTools.ListCustomObjectInstances(
+            service, "cobj-123", customFieldId: "cf-1", customFieldValue: "Gold");
+
+        // Assert
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("customFieldId=cf-1")
+                && req.RequestUri.Query.Contains("customFieldValue=Gold")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithTwoScopeCriteria_ThrowsAndMakesNoCall()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler("""{"results":[]}""");
+        var service = CreateService(client);
+
+        // Act
+        Func<Task> act = () => CustomObjectsTools.ListCustomObjectInstances(
+            service, "cobj-123", organizationId: "org-1", customerId: "cust-1");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+        handler.Protected().Verify("SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithCustomFieldIdOnly_Throws()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler("""{"results":[]}""");
+        var service = CreateService(client);
+
+        // Act
+        Func<Task> act = () => CustomObjectsTools.ListCustomObjectInstances(
+            service, "cobj-123", customFieldId: "cf-1");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+        handler.Protected().Verify("SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithCustomerId_RoutesToSearch()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        await CustomObjectsTools.ListCustomObjectInstances(service, "cobj-123", customerId: "cust-1");
+
+        // Assert
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("customerId=cust-1")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithCustomFieldValueOnly_Throws()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler("""{"results":[]}""");
+        var service = CreateService(client);
+
+        // Act
+        Func<Task> act = () => CustomObjectsTools.ListCustomObjectInstances(
+            service, "cobj-123", customFieldValue: "Gold");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+        handler.Protected().Verify("SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_Unscoped_SendsLimitToPlainListPath()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        await CustomObjectsTools.ListCustomObjectInstances(service, "cobj-123");
+
+        // Assert
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances"
+                && req.RequestUri.Query.Contains("limit=20")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_Unscoped_AppliesInstanceDefaultFields()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(mockClient);
+
+        // Act
+        var result = await CustomObjectsTools.ListCustomObjectInstances(service, "cobj-123");
+
+        // Assert — new defaults applied, large field excluded
+        result.Should().Contain("\"organizationId\"");
+        result.Should().Contain("\"name\"");
+        result.Should().NotContain("descriptionBody");
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithTraits_SubsetsTraits()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(mockClient);
+
+        // Act — request only the 'target' trait
+        var result = await CustomObjectsTools.ListCustomObjectInstances(
+            service, "cobj-123", fields: "id,traits", traits: "target");
+
+        // Assert — only the requested trait survives
+        result.Should().Contain("target");
+        result.Should().NotContain("owner");
     }
 }

--- a/VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
+++ b/VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
@@ -90,21 +90,6 @@ public class CustomObjectsToolsTests
     }
 
     [Fact]
-    public async Task SearchCustomObjectInstances_WithQuery_ShouldReturnMatchingInstances()
-    {
-        // Arrange
-        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleCustomObjectInstanceJson());
-        var service = CreateService(mockClient);
-
-        // Act
-        var result = await CustomObjectsTools.SearchCustomObjectInstances(service, "cobj-123", "externalId=ext-inst-123");
-
-        // Assert
-        result.Should().NotBeNullOrEmpty();
-        result.Should().Contain("inst-123");
-    }
-
-    [Fact]
     public async Task CreateCustomObject_WithValidData_ShouldReturnCreatedObject()
     {
         // Arrange

--- a/VitallyMcp.Tests/VitallyServiceTests.cs
+++ b/VitallyMcp.Tests/VitallyServiceTests.cs
@@ -950,6 +950,64 @@ public class VitallyServiceTests
 
     #endregion
 
+    #region GetCustomObjectInstanceByIdAsync Tests
+
+    [Fact]
+    public async Task GetCustomObjectInstanceByIdAsync_WithMatch_ReturnsSingleUnwrappedObject()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        var result = await service.GetCustomObjectInstanceByIdAsync("cobj-123", "inst-123");
+
+        // Assert — searched by id, returned a single object (not a {results} envelope)
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("id=inst-123")),
+            ItExpr.IsAny<CancellationToken>());
+        result.Should().NotContain("\"results\"");
+        result.Should().Contain("inst-123");
+        result.Should().Contain("\"organizationId\"");
+    }
+
+    [Fact]
+    public async Task GetCustomObjectInstanceByIdAsync_NoMatch_ReturnsNotFoundMessage()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetEmptyResultsJson());
+        var service = CreateService(mockClient);
+
+        // Act
+        var result = await service.GetCustomObjectInstanceByIdAsync("cobj-123", "inst-999");
+
+        // Assert
+        result.Should().Contain("No custom object instance found with id inst-999");
+    }
+
+    [Fact]
+    public async Task GetCustomObjectInstanceByIdAsync_WithExplicitFields_HonoursFieldSelection()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(mockClient);
+
+        // Act — request only id,name
+        var result = await service.GetCustomObjectInstanceByIdAsync("cobj-123", "inst-123", fields: "id,name");
+
+        // Assert — requested fields present, non-requested default field excluded
+        result.Should().Contain("\"id\"");
+        result.Should().Contain("\"name\"");
+        result.Should().NotContain("\"organizationId\"");
+    }
+
+    #endregion
+
     #region SearchCustomObjectInstancesAsync Tests
 
     [Fact]

--- a/VitallyMcp.Tests/VitallyServiceTests.cs
+++ b/VitallyMcp.Tests/VitallyServiceTests.cs
@@ -93,6 +93,28 @@ public class VitallyServiceTests
         firstUser.TryGetProperty("traits", out _).Should().BeFalse();
     }
 
+    [Fact]
+    public async Task GetResourcesAsync_WithDefaultsKey_UsesThatKeysDefaultFields()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(mockClient);
+
+        // Act — instance URL path is not an exact-match defaults key, so we pass defaultsKey explicitly
+        var result = await service.GetResourcesAsync(
+            "customObjects/cobj-1/instances", defaultsKey: "customObjectInstances");
+        var jsonDoc = JsonDocument.Parse(result);
+        var firstInstance = jsonDoc.RootElement.GetProperty("results")[0];
+
+        // Assert — new instance default fields present
+        firstInstance.TryGetProperty("name", out _).Should().BeTrue();
+        firstInstance.TryGetProperty("organizationId", out _).Should().BeTrue();
+        firstInstance.TryGetProperty("customerId", out _).Should().BeTrue();
+
+        // Assert — large field excluded by default
+        firstInstance.TryGetProperty("descriptionBody", out _).Should().BeFalse();
+    }
+
     #endregion
 
     #region Field Filtering Tests

--- a/VitallyMcp.Tests/VitallyServiceTests.cs
+++ b/VitallyMcp.Tests/VitallyServiceTests.cs
@@ -950,6 +950,38 @@ public class VitallyServiceTests
 
     #endregion
 
+    #region SearchCustomObjectInstancesAsync Tests
+
+    [Fact]
+    public async Task SearchCustomObjectInstancesAsync_BuildsSearchUrlWithCriterionAndNoLimit()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+        var criteria = new Dictionary<string, string> { ["organizationId"] = "org-456" };
+
+        // Act
+        var result = await service.SearchCustomObjectInstancesAsync("cobj-123", criteria);
+
+        // Assert — routes to /search with the criterion and NO limit param
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Method == HttpMethod.Get
+                && req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("organizationId=org-456")
+                && !req.RequestUri.Query.Contains("limit")),
+            ItExpr.IsAny<CancellationToken>());
+
+        // Assert — list envelope is filtered and preserved
+        result.Should().Contain("\"results\"");
+        result.Should().Contain("\"organizationId\"");
+    }
+
+    #endregion
+
     #region Resource-Specific Defaults — newly-added resources
 
     [Fact]

--- a/VitallyMcp.Tests/VitallyServiceTests.cs
+++ b/VitallyMcp.Tests/VitallyServiceTests.cs
@@ -1038,6 +1038,22 @@ public class VitallyServiceTests
         result.Should().Contain("\"organizationId\"");
     }
 
+    [Fact]
+    public async Task SearchCustomObjectInstancesAsync_WithNoCriteria_ThrowsAndMakesNoCall()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler("""{"results":[]}""");
+        var service = CreateService(client);
+
+        // Act
+        Func<Task> act = () => service.SearchCustomObjectInstancesAsync("cobj-123", new Dictionary<string, string>());
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+        handler.Protected().Verify("SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
     #endregion
 
     #region Resource-Specific Defaults — newly-added resources

--- a/VitallyMcp/Tools/CustomObjectsTools.cs
+++ b/VitallyMcp/Tools/CustomObjectsTools.cs
@@ -91,6 +91,17 @@ public static class CustomObjectsTools
         return criteria;
     }
 
+    [McpServerTool(Name = "Get_custom_object_instance", Title = "Get custom object instance", ReadOnly = true, Destructive = false), Description("Get a single custom object instance by its ID. Implemented via Vitally's instance search (Vitally has no direct single-instance GET). Returns a not-found message if the ID does not match.")]
+    public static async Task<string> GetCustomObjectInstance(
+        VitallyService vitallyService,
+        [Description("The custom object ID")] string customObjectId,
+        [Description("The instance ID")] string instanceId,
+        [Description("Comma-separated list of fields to include. Defaults to: id,name,externalId,createdAt,updatedAt,organizationId,customerId,archivedAt. Client-side filtering.")] string? fields = null,
+        [Description("Comma-separated trait names to include (requires 'traits' in fields). Client-side filtering.")] string? traits = null)
+    {
+        return await vitallyService.GetCustomObjectInstanceByIdAsync(customObjectId, instanceId, fields, traits);
+    }
+
     [McpServerTool(Name = "Search_custom_object_instances", Title = "Search custom object instances", ReadOnly = true, Destructive = false), Description("Search for custom object instances by various criteria")]
     public static async Task<string> SearchCustomObjectInstances(
         VitallyService vitallyService,

--- a/VitallyMcp/Tools/CustomObjectsTools.cs
+++ b/VitallyMcp/Tools/CustomObjectsTools.cs
@@ -102,40 +102,6 @@ public static class CustomObjectsTools
         return await vitallyService.GetCustomObjectInstanceByIdAsync(customObjectId, instanceId, fields, traits);
     }
 
-    [McpServerTool(Name = "Search_custom_object_instances", Title = "Search custom object instances", ReadOnly = true, Destructive = false), Description("Search for custom object instances by various criteria")]
-    public static async Task<string> SearchCustomObjectInstances(
-        VitallyService vitallyService,
-        [Description("The custom object ID")] string customObjectId,
-        [Description("Search criteria as query parameters (e.g., id, externalId, customerId, organizationId, customFieldId, customFieldValue)")] string searchQuery,
-        [Description("Comma-separated list of fields to include. Defaults to: id,createdAt,updatedAt. Client-side filtering.")] string? fields = null)
-    {
-        // Parse search query (key=value pairs separated by &) into a parameter dictionary.
-        // - Split on the first '=' so values can themselves contain '=' (e.g. a=b=c -> key "a", value "b=c").
-        // - Pairs without an '=' are silently dropped.
-        // - Duplicate keys: last value wins, matching typical lenient URL-form parsing.
-        // - Percent-decode keys/values so callers can pass either raw ("Acme Corp") or
-        //   already-encoded ("Acme%20Corp") values; VitallyService.GetResourcesAsync then
-        //   re-encodes consistently, avoiding double-encoding (%20 -> %2520).
-        // - Malformed percent-escapes (e.g. literal "50%off") fall back to the raw segment
-        //   rather than failing the whole tool call.
-        static string SafeDecode(string s)
-        {
-            try { return Uri.UnescapeDataString(s); }
-            catch (UriFormatException) { return s; }
-            catch (ArgumentException) { return s; }
-        }
-
-        var additionalParams = new Dictionary<string, string>();
-        foreach (var part in searchQuery.Split('&'))
-        {
-            var keyValue = part.Split('=', 2);
-            if (keyValue.Length != 2) continue;
-            additionalParams[SafeDecode(keyValue[0].Trim())] = SafeDecode(keyValue[1].Trim());
-        }
-
-        return await vitallyService.GetResourcesAsync($"customObjects/{customObjectId}/instances/search", 100, null, fields, null, additionalParams, null);
-    }
-
     [McpServerTool(Name = "Create_custom_object", Title = "Create custom object", ReadOnly = false, Destructive = false), Description("Create a new Vitally custom object")]
     public static async Task<string> CreateCustomObject(
         VitallyService vitallyService,

--- a/VitallyMcp/Tools/CustomObjectsTools.cs
+++ b/VitallyMcp/Tools/CustomObjectsTools.cs
@@ -26,16 +26,69 @@ public static class CustomObjectsTools
         return await vitallyService.GetResourceByIdAsync("customObjects", id, fields);
     }
 
-    [McpServerTool(Name = "List_custom_object_instances", Title = "List custom object instances", ReadOnly = true, Destructive = false), Description("List instances of a Vitally custom object with optional pagination")]
+    [McpServerTool(Name = "List_custom_object_instances", Title = "List custom object instances", ReadOnly = true, Destructive = false), Description("List instances of a Vitally custom object. Optionally scope to a single organisation, customer, external id, or custom-field value — Vitally allows exactly ONE scope criterion. When a scope is supplied the limit/from/sortBy paging params are ignored (the matching set is returned as Vitally provides it).")]
     public static async Task<string> ListCustomObjectInstances(
         VitallyService vitallyService,
         [Description("The custom object ID")] string customObjectId,
-        [Description("Maximum number of instances to return (default: 20, max: 100)")] int limit = 20,
-        [Description("Pagination cursor from previous response (use the 'next' value)")] string? from = null,
-        [Description("Comma-separated list of fields to include. Defaults to: id,createdAt,updatedAt. Client-side filtering.")] string? fields = null,
-        [Description("Sort by field: 'createdAt' or 'updatedAt' (default: updatedAt)")] string? sortBy = null)
+        [Description("Maximum number of instances for an UNSCOPED list (default: 20, max: 100). Ignored when a scope criterion is supplied.")] int limit = 20,
+        [Description("Pagination cursor for an UNSCOPED list (use the 'next' value). Ignored when a scope criterion is supplied.")] string? from = null,
+        [Description("Comma-separated list of fields to include. Defaults to: id,name,externalId,createdAt,updatedAt,organizationId,customerId,archivedAt. Client-side filtering.")] string? fields = null,
+        [Description("Sort an UNSCOPED list by 'createdAt' or 'updatedAt' (default: updatedAt). Ignored when a scope criterion is supplied.")] string? sortBy = null,
+        [Description("Comma-separated trait names to include (requires 'traits' in fields). Client-side filtering.")] string? traits = null,
+        [Description("Scope to a single organisation ID. Mutually exclusive with the other scope criteria.")] string? organizationId = null,
+        [Description("Scope to a single customer/account ID. Mutually exclusive with the other scope criteria.")] string? customerId = null,
+        [Description("Scope to a single external ID. Mutually exclusive with the other scope criteria.")] string? externalId = null,
+        [Description("Find instances where this custom field ID equals customFieldValue. Must be supplied together with customFieldValue.")] string? customFieldId = null,
+        [Description("The value to match for customFieldId. Must be supplied together with customFieldId.")] string? customFieldValue = null)
     {
-        return await vitallyService.GetResourcesAsync($"customObjects/{customObjectId}/instances", limit, from, fields, sortBy, null, null);
+        var criteria = BuildInstanceSearchCriteria(organizationId, customerId, externalId, customFieldId, customFieldValue);
+
+        if (criteria.Count == 0)
+        {
+            return await vitallyService.GetResourcesAsync(
+                $"customObjects/{customObjectId}/instances", limit, from, fields, sortBy,
+                additionalParams: null, traits: traits, defaultsKey: "customObjectInstances");
+        }
+
+        return await vitallyService.SearchCustomObjectInstancesAsync(customObjectId, criteria, fields, traits);
+    }
+
+    /// <summary>
+    /// Builds the single-criterion search dictionary for instance scoping and validates Vitally's
+    /// "exactly one criterion" rule (customFieldId+customFieldValue count as one paired criterion).
+    /// Throws <see cref="ArgumentException"/> with an actionable message if the rule is violated.
+    /// Returns an empty dictionary when no scope is supplied (caller uses the plain-list path).
+    /// </summary>
+    internal static Dictionary<string, string> BuildInstanceSearchCriteria(
+        string? organizationId, string? customerId, string? externalId,
+        string? customFieldId, string? customFieldValue)
+    {
+        var criteria = new Dictionary<string, string>();
+        if (!string.IsNullOrWhiteSpace(organizationId)) criteria["organizationId"] = organizationId;
+        if (!string.IsNullOrWhiteSpace(customerId)) criteria["customerId"] = customerId;
+        if (!string.IsNullOrWhiteSpace(externalId)) criteria["externalId"] = externalId;
+
+        var hasFieldId = !string.IsNullOrWhiteSpace(customFieldId);
+        var hasFieldValue = !string.IsNullOrWhiteSpace(customFieldValue);
+        if (hasFieldId != hasFieldValue)
+        {
+            throw new ArgumentException("customFieldId and customFieldValue must be supplied together.");
+        }
+
+        var criterionGroups = criteria.Count + (hasFieldId ? 1 : 0);
+        if (criterionGroups > 1)
+        {
+            throw new ArgumentException(
+                "Vitally instance search accepts exactly one of organizationId, customerId, externalId, or customFieldId+customFieldValue.");
+        }
+
+        if (hasFieldId)
+        {
+            criteria["customFieldId"] = customFieldId!;
+            criteria["customFieldValue"] = customFieldValue!;
+        }
+
+        return criteria;
     }
 
     [McpServerTool(Name = "Search_custom_object_instances", Title = "Search custom object instances", ReadOnly = true, Destructive = false), Description("Search for custom object instances by various criteria")]

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -36,7 +36,8 @@ public class VitallyService
         ["noteCategories"] = ["id", "name", "createdAt", "updatedAt"],
         ["taskCategories"] = ["id", "name", "createdAt", "updatedAt"],
         ["meetings"] = ["id", "title", "externalId", "startDateTime", "endDateTime", "location", "source", "accountIds", "organizationIds", "participants", "createdAt", "updatedAt"],
-        ["meetingTranscripts"] = ["id", "meetingId", "createdAt", "updatedAt"]
+        ["meetingTranscripts"] = ["id", "meetingId", "createdAt", "updatedAt"],
+        ["customObjectInstances"] = ["id", "name", "externalId", "createdAt", "updatedAt", "organizationId", "customerId", "archivedAt"]
     };
 
     private static readonly string[] FallbackDefaultFields = ["id", "createdAt", "updatedAt"];
@@ -102,7 +103,7 @@ public class VitallyService
     private static string Truncate(string value, int max) =>
         value.Length <= max ? value : value[..max] + "…(truncated)";
 
-    public async Task<string> GetResourcesAsync(string resourceType, int limit = 20, string? from = null, string? fields = null, string? sortBy = null, Dictionary<string, string>? additionalParams = null, string? traits = null)
+    public async Task<string> GetResourcesAsync(string resourceType, int limit = 20, string? from = null, string? fields = null, string? sortBy = null, Dictionary<string, string>? additionalParams = null, string? traits = null, string? defaultsKey = null)
     {
         // Percent-encode keys and values (RFC 3986 query-string encoding via
         // Uri.EscapeDataString — spaces become %20, not +) so user-supplied filter values
@@ -128,7 +129,7 @@ public class VitallyService
         var url = $"{_baseUrl}/resources/{resourceType}?{queryString}";
 
         var jsonResponse = await SendAsync(HttpMethod.Get, url);
-        return FilterJsonFields(jsonResponse, fields, resourceType, isListResponse: true, traits);
+        return FilterJsonFields(jsonResponse, fields, defaultsKey ?? resourceType, isListResponse: true, traits);
     }
 
     public async Task<string> GetResourceByIdAsync(string resourceType, string id, string? fields = null, string? traits = null)

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -140,6 +140,22 @@ public class VitallyService
         return FilterJsonFields(jsonResponse, fields, resourceType, isListResponse: false, traits);
     }
 
+    /// <summary>
+    /// Searches custom object instances via Vitally's <c>/instances/search</c> endpoint, which
+    /// accepts exactly one criterion (where <c>customFieldId</c>+<c>customFieldValue</c> are a
+    /// single paired criterion). Only the criterion is sent — no <c>limit</c>/<c>from</c>/<c>sortBy</c>,
+    /// since the search endpoint's pagination support is not documented. The standard
+    /// <c>{results, next}</c> field/trait filtering is applied; <c>next</c> is passed through if present.
+    /// </summary>
+    public async Task<string> SearchCustomObjectInstancesAsync(string customObjectId, IReadOnlyDictionary<string, string> criteria, string? fields = null, string? traits = null)
+    {
+        var query = string.Join("&", criteria.Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
+        var url = $"{_baseUrl}/resources/customObjects/{customObjectId}/instances/search?{query}";
+
+        var jsonResponse = await SendAsync(HttpMethod.Get, url);
+        return FilterJsonFields(jsonResponse, fields, "customObjectInstances", isListResponse: true, traits);
+    }
+
     public async Task<string> CreateResourceAsync(string resourceType, string jsonBody)
     {
         var url = $"{_baseUrl}/resources/{resourceType}";

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -149,6 +149,11 @@ public class VitallyService
     /// </summary>
     public async Task<string> SearchCustomObjectInstancesAsync(string customObjectId, IReadOnlyDictionary<string, string> criteria, string? fields = null, string? traits = null)
     {
+        if (criteria.Count == 0)
+        {
+            throw new ArgumentException("At least one search criterion is required.", nameof(criteria));
+        }
+
         var query = string.Join("&", criteria.Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
         var url = $"{_baseUrl}/resources/customObjects/{customObjectId}/instances/search?{query}";
 

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -141,12 +141,22 @@ public class VitallyService
     }
 
     /// <summary>
-    /// Searches custom object instances via Vitally's <c>/instances/search</c> endpoint, which
-    /// accepts exactly one criterion (where <c>customFieldId</c>+<c>customFieldValue</c> are a
-    /// single paired criterion). Only the criterion is sent — no <c>limit</c>/<c>from</c>/<c>sortBy</c>,
-    /// since the search endpoint's pagination support is not documented. The standard
-    /// <c>{results, next}</c> field/trait filtering is applied; <c>next</c> is passed through if present.
+    /// Issues a custom object instance search against Vitally's <c>/instances/search</c> endpoint
+    /// with the supplied <paramref name="criteria"/>. Only the criteria are sent — no
+    /// <c>limit</c>/<c>from</c>/<c>sortBy</c>, since the endpoint's pagination support is undocumented.
+    /// The standard <c>{results, next}</c> field/trait filtering is applied; <c>next</c> is passed
+    /// through if present.
     /// </summary>
+    /// <remarks>
+    /// Vitally accepts exactly ONE criterion (with <c>customFieldId</c>+<c>customFieldValue</c> as a
+    /// single paired criterion). Enforcing that rule is the caller's responsibility:
+    /// <c>CustomObjectsTools.BuildInstanceSearchCriteria</c> validates it from the typed tool
+    /// parameters, where the pairing is unambiguous — a raw key/value dictionary cannot tell a valid
+    /// <c>customFieldId</c>+<c>customFieldValue</c> pair apart from two separate criteria, so this
+    /// transport-level method does not re-attempt that check. It only rejects an empty dictionary
+    /// (which cannot form a valid query) and forwards any other shape as-is, letting Vitally return
+    /// its own validation error.
+    /// </remarks>
     public async Task<string> SearchCustomObjectInstancesAsync(string customObjectId, IReadOnlyDictionary<string, string> criteria, string? fields = null, string? traits = null)
     {
         if (criteria.Count == 0)

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -156,6 +156,19 @@ public class VitallyService
         return FilterJsonFields(jsonResponse, fields, "customObjectInstances", isListResponse: true, traits);
     }
 
+    /// <summary>
+    /// Reads a single custom object instance by id. Vitally has no direct single-instance GET, so
+    /// this uses <c>/instances/search?id=…</c> and unwraps the single result. Returns a clear
+    /// not-found message (not an exception) when the search yields no match (HTTP 200, empty results).
+    /// </summary>
+    public async Task<string> GetCustomObjectInstanceByIdAsync(string customObjectId, string instanceId, string? fields = null, string? traits = null)
+    {
+        var url = $"{_baseUrl}/resources/customObjects/{customObjectId}/instances/search?id={Uri.EscapeDataString(instanceId)}";
+        var jsonResponse = await SendAsync(HttpMethod.Get, url);
+        return FilterSingleFromResults(jsonResponse, fields, "customObjectInstances", traits,
+            notFoundMessage: $"No custom object instance found with id {instanceId}");
+    }
+
     public async Task<string> CreateResourceAsync(string resourceType, string jsonBody)
     {
         var url = $"{_baseUrl}/resources/{resourceType}";
@@ -218,6 +231,16 @@ public class VitallyService
         return await SendAsync(HttpMethod.Delete, url);
     }
 
+    private static string[] ResolveFields(string? fields, string defaultsKey) =>
+        string.IsNullOrWhiteSpace(fields)
+            ? (ResourceDefaultFields.TryGetValue(defaultsKey, out var defaults) ? defaults : FallbackDefaultFields)
+            : fields.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static string[]? ResolveTraits(string? traits) =>
+        string.IsNullOrWhiteSpace(traits)
+            ? null
+            : traits.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
     /// <summary>
     /// Filters JSON response to include only requested fields and traits.
     /// If no fields specified, returns resource-specific default field set.
@@ -226,13 +249,8 @@ public class VitallyService
     /// </summary>
     private static string FilterJsonFields(string jsonResponse, string? fields, string resourceType, bool isListResponse, string? traits = null)
     {
-        var requestedFields = string.IsNullOrWhiteSpace(fields)
-            ? (ResourceDefaultFields.TryGetValue(resourceType, out var defaults) ? defaults : FallbackDefaultFields)
-            : fields.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        var requestedTraits = string.IsNullOrWhiteSpace(traits)
-            ? null
-            : traits.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var requestedFields = ResolveFields(fields, resourceType);
+        var requestedTraits = ResolveTraits(traits);
 
         using var document = JsonDocument.Parse(jsonResponse);
         using var stream = new MemoryStream();
@@ -267,6 +285,31 @@ public class VitallyService
         }
 
         writer.WriteEndObject();
+        writer.Flush();
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    /// <summary>
+    /// Extracts the first element of a <c>{results: [...]}</c> response and returns it as a single
+    /// filtered object. Returns <c>{"message": notFoundMessage}</c> when results are absent or empty.
+    /// </summary>
+    private static string FilterSingleFromResults(string jsonResponse, string? fields, string defaultsKey, string? traits, string notFoundMessage)
+    {
+        using var document = JsonDocument.Parse(jsonResponse);
+        if (!document.RootElement.TryGetProperty("results", out var results)
+            || results.ValueKind != JsonValueKind.Array
+            || results.GetArrayLength() == 0)
+        {
+            return JsonSerializer.Serialize(new { message = notFoundMessage });
+        }
+
+        var requestedFields = ResolveFields(fields, defaultsKey);
+        var requestedTraits = ResolveTraits(traits);
+
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+        WriteFilteredObject(writer, results[0], requestedFields, requestedTraits);
         writer.Flush();
 
         return Encoding.UTF8.GetString(stream.ToArray());


### PR DESCRIPTION
## Summary

SP1 of the Vitally MCP user-feedback backlog — custom-object-instance scoping & ergonomics.

- **P1.1 (headline win):** `List_custom_object_instances` gains optional single-criterion scoping (`organizationId`, `customerId`, `externalId`, `customFieldId`+`customFieldValue`), routing to Vitally's `customObjects/:id/instances/search`. Collapses "page every customer's instances (~1.7 MB/page) and sift" into one cheap call. Vitally allows exactly one criterion; more than one (or half a customField pair) fails fast with an actionable `ArgumentException` before any HTTP call.
- **P2.7:** new `Get_custom_object_instance` (single instance by id) via `/search?id=…` (Vitally has no direct single-instance GET); returns a clear not-found message on a miss rather than throwing.
- **P2.9:** instances get a real default field set (`id,name,externalId,createdAt,updatedAt,organizationId,customerId,archivedAt`) via a path-decoupled defaults key, plus `traits` subsetting.
- **P1.6:** removed the consistently-broken free-text `Search_custom_object_instances` tool — its capability is now covered by the typed scope params + get-by-id. The scoped `/search` path deliberately sends only the criterion (no `limit`/`from`/`sortBy`), the suspected cause of the old breakage.

Every new HTTP path still funnels through `VitallyService.SendAsync`, so the server-side RBAC backstop and audit logging are preserved (GET -> `vitally:read`).

Design/spec and the full TDD plan live on the `docs/vitally-feedback-decomposition` branch (`docs/superpowers/specs/2026-06-10-sp1-custom-object-instances-design.md` and `docs/superpowers/plans/2026-06-10-sp1-custom-object-instances.md`). SP2-SP5 of the backlog remain.

## Test Plan

- [x] `dotnet test VitallyMcp.sln` — 291 passed, 0 failed.
- [ ] **Manual, pre-merge (needs a Vitally dev key):** live `/search` smoke test — confirm `List_custom_object_instances(customObjectId, organizationId=<org>)` returns only that org's instances in the `{results, next}` shape, and note whether `/search` honours `next`/`from` (pagination). If it does, open a follow-up to wire `from` into the scoped path; if not, the scoped set is returned whole (acceptable — scoped sets are small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)