### PR TITLE
docs: Vitally MCP feedback backlog decomposition + SP1 spec/plan

### DIFF
--- a/docs/superpowers/plans/2026-06-10-sp1-custom-object-instances.md
+++ b/docs/superpowers/plans/2026-06-10-sp1-custom-object-instances.md
@@ -1,0 +1,838 @@
+# SP1 — Custom-object-instance scoping & ergonomics — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let callers scope custom-object-instance listing to a single organisation/customer/externalId/custom-field, read one instance by id, subset traits, and get a useful default field set — and remove the broken free-text search tool.
+
+**Architecture:** Add typed scope params to `List_custom_object_instances` that route to Vitally's `/search` endpoint (which accepts exactly one criterion) when a scope is given, else keep the plain-list path. Add `Get_custom_object_instance` implemented as `/search?id=…` with single-object unwrapping. Give instances their own default-fields key, decoupled from the URL path. All calls still funnel through `VitallyService.SendAsync` (RBAC + audit preserved).
+
+**Tech Stack:** .NET 10, C#, xUnit + FluentAssertions + Moq (`Moq.Protected` for request-URL verification).
+
+**Branch:** Implement on a new branch off `main`, e.g. `feature/sp1-custom-object-instances` (the planning docs live on `docs/vitally-feedback-decomposition`; do **not** build on that branch). Create it before Task 1.
+
+**Spec:** [SP1 design](../specs/2026-06-10-sp1-custom-object-instances-design.md)
+
+---
+
+## File Structure
+
+- **Modify** `VitallyMcp/VitallyService.cs` — add `customObjectInstances` to `ResourceDefaultFields`; add optional `defaultsKey` to `GetResourcesAsync`; add `SearchCustomObjectInstancesAsync`, `GetCustomObjectInstanceByIdAsync`, and private `FilterSingleFromResults` + `ResolveFields`/`ResolveTraits` helpers.
+- **Modify** `VitallyMcp/Tools/CustomObjectsTools.cs` — add scope params + `BuildInstanceSearchCriteria` to `ListCustomObjectInstances`; add `GetCustomObjectInstance`; remove `SearchCustomObjectInstances`.
+- **Modify** `VitallyMcp.Tests/TestHelpers.cs` — add `GetSampleRichCustomObjectInstanceJson()`.
+- **Modify** `VitallyMcp.Tests/VitallyServiceTests.cs` — add `defaultsKey` and search/get-by-id service tests.
+- **Modify** `VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs` — add scope/throw/get-by-id tests; remove the old search test.
+- **Modify** `CLAUDE.md` — default-fields table row + tool-surface note.
+
+---
+
+### Task 0: Create the implementation branch
+
+- [ ] **Step 1: Branch off `main`**
+
+```powershell
+git checkout main
+git checkout -b feature/sp1-custom-object-instances
+```
+
+---
+
+### Task 1: Instance default fields + `defaultsKey` plumbing
+
+**Files:**
+- Modify: `VitallyMcp/VitallyService.cs`
+- Modify: `VitallyMcp.Tests/TestHelpers.cs`
+- Test: `VitallyMcp.Tests/VitallyServiceTests.cs`
+
+- [ ] **Step 1: Add a rich instance sample to TestHelpers**
+
+Add this method to `VitallyMcp.Tests/TestHelpers.cs` (next to `GetSampleCustomObjectInstanceJson`):
+
+```csharp
+    /// <summary>
+    /// Sample custom object instance JSON with the full field set (for default-field and
+    /// trait-subsetting tests). Includes a large field that should be excluded by default.
+    /// </summary>
+    public static string GetSampleRichCustomObjectInstanceJson() => """
+    {
+      "results": [
+        {
+          "id": "inst-123",
+          "name": "Annual Goal",
+          "externalId": "ext-inst-123",
+          "createdAt": "2024-01-01T00:00:00Z",
+          "updatedAt": "2024-01-15T00:00:00Z",
+          "organizationId": "org-456",
+          "customerId": "cust-789",
+          "archivedAt": null,
+          "descriptionBody": "A very long description body we do not want by default",
+          "traits": {
+            "target": "100",
+            "owner": "CSM"
+          }
+        }
+      ],
+      "next": "cursor-inst-next"
+    }
+    """;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `VitallyMcp.Tests/VitallyServiceTests.cs` (inside the `Default Field Tests` region):
+
+```csharp
+    [Fact]
+    public async Task GetResourcesAsync_WithDefaultsKey_UsesThatKeysDefaultFields()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(mockClient);
+
+        // Act — instance URL path is not an exact-match defaults key, so we pass defaultsKey explicitly
+        var result = await service.GetResourcesAsync(
+            "customObjects/cobj-1/instances", defaultsKey: "customObjectInstances");
+
+        // Assert — new instance default fields present, large field excluded
+        result.Should().Contain("\"organizationId\"");
+        result.Should().Contain("\"customerId\"");
+        result.Should().Contain("\"name\"");
+        result.Should().NotContain("descriptionBody");
+    }
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetResourcesAsync_WithDefaultsKey_UsesThatKeysDefaultFields"`
+Expected: FAIL — `GetResourcesAsync` has no `defaultsKey` parameter (compile error).
+
+- [ ] **Step 4: Add the instance defaults entry**
+
+In `VitallyMcp/VitallyService.cs`, add to the `ResourceDefaultFields` dictionary (after the `meetingTranscripts` line):
+
+```csharp
+        ["customObjectInstances"] = ["id", "name", "externalId", "createdAt", "updatedAt", "organizationId", "customerId", "archivedAt"],
+```
+
+- [ ] **Step 5: Add the `defaultsKey` parameter to `GetResourcesAsync`**
+
+Change the signature and the final filter call:
+
+```csharp
+    public async Task<string> GetResourcesAsync(string resourceType, int limit = 20, string? from = null, string? fields = null, string? sortBy = null, Dictionary<string, string>? additionalParams = null, string? traits = null, string? defaultsKey = null)
+    {
+```
+
+and the return line at the end of the method:
+
+```csharp
+        var jsonResponse = await SendAsync(HttpMethod.Get, url);
+        return FilterJsonFields(jsonResponse, fields, defaultsKey ?? resourceType, isListResponse: true, traits);
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetResourcesAsync_WithDefaultsKey_UsesThatKeysDefaultFields"`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add VitallyMcp/VitallyService.cs VitallyMcp.Tests/TestHelpers.cs VitallyMcp.Tests/VitallyServiceTests.cs
+git commit -m @'
+feat(instances): add customObjectInstances default fields + defaultsKey plumbing
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 2: `SearchCustomObjectInstancesAsync` service method
+
+**Files:**
+- Modify: `VitallyMcp/VitallyService.cs`
+- Test: `VitallyMcp.Tests/VitallyServiceTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `VitallyMcp.Tests/VitallyServiceTests.cs`:
+
+```csharp
+    [Fact]
+    public async Task SearchCustomObjectInstancesAsync_BuildsSearchUrlWithCriterionAndNoLimit()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+        var criteria = new Dictionary<string, string> { ["organizationId"] = "org-456" };
+
+        // Act
+        var result = await service.SearchCustomObjectInstancesAsync("cobj-123", criteria);
+
+        // Assert — routes to /search with the criterion and NO limit param
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Method == HttpMethod.Get
+                && req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("organizationId=org-456")
+                && !req.RequestUri.Query.Contains("limit")),
+            ItExpr.IsAny<CancellationToken>());
+
+        // Assert — list envelope is filtered and preserved
+        result.Should().Contain("\"results\"");
+        result.Should().Contain("\"organizationId\"");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~SearchCustomObjectInstancesAsync_BuildsSearchUrlWithCriterionAndNoLimit"`
+Expected: FAIL — `SearchCustomObjectInstancesAsync` is not defined (compile error).
+
+- [ ] **Step 3: Implement the method**
+
+In `VitallyMcp/VitallyService.cs`, add after `GetResourceByIdAsync`:
+
+```csharp
+    /// <summary>
+    /// Searches custom object instances via Vitally's <c>/instances/search</c> endpoint, which
+    /// accepts exactly one criterion (where <c>customFieldId</c>+<c>customFieldValue</c> are a
+    /// single paired criterion). Only the criterion is sent — no <c>limit</c>/<c>from</c>/<c>sortBy</c>,
+    /// since the search endpoint's pagination support is not documented. The standard
+    /// <c>{results, next}</c> field/trait filtering is applied; <c>next</c> is passed through if present.
+    /// </summary>
+    public async Task<string> SearchCustomObjectInstancesAsync(string customObjectId, IReadOnlyDictionary<string, string> criteria, string? fields = null, string? traits = null)
+    {
+        var query = string.Join("&", criteria.Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
+        var url = $"{_baseUrl}/resources/customObjects/{customObjectId}/instances/search?{query}";
+
+        var jsonResponse = await SendAsync(HttpMethod.Get, url);
+        return FilterJsonFields(jsonResponse, fields, "customObjectInstances", isListResponse: true, traits);
+    }
+```
+
+(`System.Linq` is available via implicit global usings — `Select` will resolve.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test --filter "FullyQualifiedName~SearchCustomObjectInstancesAsync_BuildsSearchUrlWithCriterionAndNoLimit"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add VitallyMcp/VitallyService.cs VitallyMcp.Tests/VitallyServiceTests.cs
+git commit -m @'
+feat(instances): add SearchCustomObjectInstancesAsync (single-criterion /search)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 3: `GetCustomObjectInstanceByIdAsync` + single-result filtering
+
+**Files:**
+- Modify: `VitallyMcp/VitallyService.cs`
+- Test: `VitallyMcp.Tests/VitallyServiceTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `VitallyMcp.Tests/VitallyServiceTests.cs`:
+
+```csharp
+    [Fact]
+    public async Task GetCustomObjectInstanceByIdAsync_WithMatch_ReturnsSingleUnwrappedObject()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        var result = await service.GetCustomObjectInstanceByIdAsync("cobj-123", "inst-123");
+
+        // Assert — searched by id, returned a single object (not a {results} envelope)
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("id=inst-123")),
+            ItExpr.IsAny<CancellationToken>());
+        result.Should().NotContain("\"results\"");
+        result.Should().Contain("inst-123");
+        result.Should().Contain("\"organizationId\"");
+    }
+
+    [Fact]
+    public async Task GetCustomObjectInstanceByIdAsync_NoMatch_ReturnsNotFoundMessage()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetEmptyResultsJson());
+        var service = CreateService(mockClient);
+
+        // Act
+        var result = await service.GetCustomObjectInstanceByIdAsync("cobj-123", "inst-999");
+
+        // Assert
+        result.Should().Contain("No custom object instance found with id inst-999");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetCustomObjectInstanceByIdAsync"`
+Expected: FAIL — method not defined (compile error).
+
+- [ ] **Step 3: Extract field/trait resolution helpers**
+
+In `VitallyMcp/VitallyService.cs`, add these two helpers (place them just above `FilterJsonFields`):
+
+```csharp
+    private static string[] ResolveFields(string? fields, string defaultsKey) =>
+        string.IsNullOrWhiteSpace(fields)
+            ? (ResourceDefaultFields.TryGetValue(defaultsKey, out var defaults) ? defaults : FallbackDefaultFields)
+            : fields.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    private static string[]? ResolveTraits(string? traits) =>
+        string.IsNullOrWhiteSpace(traits)
+            ? null
+            : traits.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+```
+
+Then replace the first two statements inside `FilterJsonFields` (the `requestedFields` / `requestedTraits` assignments) with:
+
+```csharp
+        var requestedFields = ResolveFields(fields, resourceType);
+        var requestedTraits = ResolveTraits(traits);
+```
+
+- [ ] **Step 4: Add `FilterSingleFromResults` and `GetCustomObjectInstanceByIdAsync`**
+
+In `VitallyMcp/VitallyService.cs`, add the service method after `SearchCustomObjectInstancesAsync`:
+
+```csharp
+    /// <summary>
+    /// Reads a single custom object instance by id. Vitally has no direct single-instance GET, so
+    /// this uses <c>/instances/search?id=…</c> and unwraps the single result. Returns a clear
+    /// not-found message (not an exception) when the search yields no match (HTTP 200, empty results).
+    /// </summary>
+    public async Task<string> GetCustomObjectInstanceByIdAsync(string customObjectId, string instanceId, string? fields = null, string? traits = null)
+    {
+        var url = $"{_baseUrl}/resources/customObjects/{customObjectId}/instances/search?id={Uri.EscapeDataString(instanceId)}";
+        var jsonResponse = await SendAsync(HttpMethod.Get, url);
+        return FilterSingleFromResults(jsonResponse, fields, "customObjectInstances", traits,
+            notFoundMessage: $"No custom object instance found with id {instanceId}");
+    }
+```
+
+and the private helper after `FilterJsonFields`:
+
+```csharp
+    /// <summary>
+    /// Extracts the first element of a <c>{results: [...]}</c> response and returns it as a single
+    /// filtered object. Returns <c>{"message": notFoundMessage}</c> when results are absent or empty.
+    /// </summary>
+    private static string FilterSingleFromResults(string jsonResponse, string? fields, string defaultsKey, string? traits, string notFoundMessage)
+    {
+        using var document = JsonDocument.Parse(jsonResponse);
+        if (!document.RootElement.TryGetProperty("results", out var results)
+            || results.ValueKind != JsonValueKind.Array
+            || results.GetArrayLength() == 0)
+        {
+            return JsonSerializer.Serialize(new { message = notFoundMessage });
+        }
+
+        var requestedFields = ResolveFields(fields, defaultsKey);
+        var requestedTraits = ResolveTraits(traits);
+
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+        WriteFilteredObject(writer, results[0], requestedFields, requestedTraits);
+        writer.Flush();
+
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetCustomObjectInstanceByIdAsync"`
+Expected: PASS (both tests)
+
+- [ ] **Step 6: Run the full service test class to confirm the helper extraction broke nothing**
+
+Run: `dotnet test --filter "FullyQualifiedName~VitallyServiceTests"`
+Expected: PASS (all)
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add VitallyMcp/VitallyService.cs VitallyMcp.Tests/VitallyServiceTests.cs
+git commit -m @'
+feat(instances): add GetCustomObjectInstanceByIdAsync via search-by-id
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 4: Scope params + validation on `List_custom_object_instances`
+
+**Files:**
+- Modify: `VitallyMcp/Tools/CustomObjectsTools.cs`
+- Test: `VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs`
+
+- [ ] **Step 1: Add Moq imports to the tool test file**
+
+At the top of `VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs`, add to the using block:
+
+```csharp
+using Moq;
+using Moq.Protected;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs`:
+
+```csharp
+    [Fact]
+    public async Task ListCustomObjectInstances_WithOrganizationId_RoutesToSearchWithoutLimit()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        var result = await CustomObjectsTools.ListCustomObjectInstances(service, "cobj-123", organizationId: "org-456");
+
+        // Assert
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Method == HttpMethod.Get
+                && req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("organizationId=org-456")
+                && !req.RequestUri.Query.Contains("limit")),
+            ItExpr.IsAny<CancellationToken>());
+        result.Should().Contain("\"results\"");
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithCustomFieldPair_RoutesToSearchWithBothParams()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        await CustomObjectsTools.ListCustomObjectInstances(
+            service, "cobj-123", customFieldId: "cf-1", customFieldValue: "Gold");
+
+        // Assert
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("customFieldId=cf-1")
+                && req.RequestUri.Query.Contains("customFieldValue=Gold")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithTwoScopeCriteria_ThrowsAndMakesNoCall()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler("""{"results":[]}""");
+        var service = CreateService(client);
+
+        // Act
+        Func<Task> act = () => CustomObjectsTools.ListCustomObjectInstances(
+            service, "cobj-123", organizationId: "org-1", customerId: "cust-1");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+        handler.Protected().Verify("SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithCustomFieldIdOnly_Throws()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient("""{"results":[]}""");
+        var service = CreateService(mockClient);
+
+        // Act
+        Func<Task> act = () => CustomObjectsTools.ListCustomObjectInstances(
+            service, "cobj-123", customFieldId: "cf-1");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_Unscoped_SendsLimitToPlainListPath()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        await CustomObjectsTools.ListCustomObjectInstances(service, "cobj-123");
+
+        // Assert
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances"
+                && req.RequestUri.Query.Contains("limit=20")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_Unscoped_AppliesInstanceDefaultFields()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(mockClient);
+
+        // Act
+        var result = await CustomObjectsTools.ListCustomObjectInstances(service, "cobj-123");
+
+        // Assert — new defaults applied, large field excluded
+        result.Should().Contain("\"organizationId\"");
+        result.Should().Contain("\"name\"");
+        result.Should().NotContain("descriptionBody");
+    }
+
+    [Fact]
+    public async Task ListCustomObjectInstances_WithTraits_SubsetsTraits()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(mockClient);
+
+        // Act — request only the 'target' trait
+        var result = await CustomObjectsTools.ListCustomObjectInstances(
+            service, "cobj-123", fields: "id,traits", traits: "target");
+
+        // Assert — only the requested trait survives
+        result.Should().Contain("target");
+        result.Should().NotContain("owner");
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~CustomObjectsToolsTests.ListCustomObjectInstances_With|FullyQualifiedName~CustomObjectsToolsTests.ListCustomObjectInstances_Unscoped"`
+Expected: FAIL — `ListCustomObjectInstances` has no `organizationId`/`customFieldId`/etc. parameters (compile error).
+
+- [ ] **Step 4: Replace `ListCustomObjectInstances` and add the criteria builder**
+
+In `VitallyMcp/Tools/CustomObjectsTools.cs`, replace the existing `ListCustomObjectInstances` method with:
+
+```csharp
+    [McpServerTool(Name = "List_custom_object_instances", Title = "List custom object instances", ReadOnly = true, Destructive = false), Description("List instances of a Vitally custom object. Optionally scope to a single organisation, customer, external id, or custom-field value — Vitally allows exactly ONE scope criterion. When a scope is supplied the limit/from/sortBy paging params are ignored (the matching set is returned as Vitally provides it).")]
+    public static async Task<string> ListCustomObjectInstances(
+        VitallyService vitallyService,
+        [Description("The custom object ID")] string customObjectId,
+        [Description("Maximum number of instances for an UNSCOPED list (default: 20, max: 100). Ignored when a scope criterion is supplied.")] int limit = 20,
+        [Description("Pagination cursor for an UNSCOPED list (use the 'next' value). Ignored when a scope criterion is supplied.")] string? from = null,
+        [Description("Comma-separated list of fields to include. Defaults to: id,name,externalId,createdAt,updatedAt,organizationId,customerId,archivedAt. Client-side filtering.")] string? fields = null,
+        [Description("Sort an UNSCOPED list by 'createdAt' or 'updatedAt' (default: updatedAt). Ignored when a scope criterion is supplied.")] string? sortBy = null,
+        [Description("Comma-separated trait names to include (requires 'traits' in fields). Client-side filtering.")] string? traits = null,
+        [Description("Scope to a single organisation ID. Mutually exclusive with the other scope criteria.")] string? organizationId = null,
+        [Description("Scope to a single customer/account ID. Mutually exclusive with the other scope criteria.")] string? customerId = null,
+        [Description("Scope to a single external ID. Mutually exclusive with the other scope criteria.")] string? externalId = null,
+        [Description("Find instances where this custom field ID equals customFieldValue. Must be supplied together with customFieldValue.")] string? customFieldId = null,
+        [Description("The value to match for customFieldId. Must be supplied together with customFieldId.")] string? customFieldValue = null)
+    {
+        var criteria = BuildInstanceSearchCriteria(organizationId, customerId, externalId, customFieldId, customFieldValue);
+
+        if (criteria.Count == 0)
+        {
+            return await vitallyService.GetResourcesAsync(
+                $"customObjects/{customObjectId}/instances", limit, from, fields, sortBy,
+                additionalParams: null, traits: traits, defaultsKey: "customObjectInstances");
+        }
+
+        return await vitallyService.SearchCustomObjectInstancesAsync(customObjectId, criteria, fields, traits);
+    }
+
+    /// <summary>
+    /// Builds the single-criterion search dictionary for instance scoping and validates Vitally's
+    /// "exactly one criterion" rule (customFieldId+customFieldValue count as one paired criterion).
+    /// Throws <see cref="ArgumentException"/> with an actionable message if the rule is violated.
+    /// Returns an empty dictionary when no scope is supplied (caller uses the plain-list path).
+    /// </summary>
+    internal static Dictionary<string, string> BuildInstanceSearchCriteria(
+        string? organizationId, string? customerId, string? externalId,
+        string? customFieldId, string? customFieldValue)
+    {
+        var criteria = new Dictionary<string, string>();
+        if (!string.IsNullOrWhiteSpace(organizationId)) criteria["organizationId"] = organizationId;
+        if (!string.IsNullOrWhiteSpace(customerId)) criteria["customerId"] = customerId;
+        if (!string.IsNullOrWhiteSpace(externalId)) criteria["externalId"] = externalId;
+
+        var hasFieldId = !string.IsNullOrWhiteSpace(customFieldId);
+        var hasFieldValue = !string.IsNullOrWhiteSpace(customFieldValue);
+        if (hasFieldId != hasFieldValue)
+        {
+            throw new ArgumentException("customFieldId and customFieldValue must be supplied together.");
+        }
+
+        var criterionGroups = criteria.Count + (hasFieldId ? 1 : 0);
+        if (criterionGroups > 1)
+        {
+            throw new ArgumentException(
+                "Vitally instance search accepts exactly one of organizationId, customerId, externalId, or customFieldId+customFieldValue.");
+        }
+
+        if (hasFieldId)
+        {
+            criteria["customFieldId"] = customFieldId!;
+            criteria["customFieldValue"] = customFieldValue!;
+        }
+
+        return criteria;
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~CustomObjectsToolsTests.ListCustomObjectInstances_With|FullyQualifiedName~CustomObjectsToolsTests.ListCustomObjectInstances_Unscoped"`
+Expected: PASS (all six)
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add VitallyMcp/Tools/CustomObjectsTools.cs VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
+git commit -m @'
+feat(instances): scope List_custom_object_instances by single /search criterion
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 5: `Get_custom_object_instance` tool
+
+**Files:**
+- Modify: `VitallyMcp/Tools/CustomObjectsTools.cs`
+- Test: `VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs`:
+
+```csharp
+    [Fact]
+    public async Task GetCustomObjectInstance_WithMatch_ReturnsSingleObject()
+    {
+        // Arrange
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
+            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var service = CreateService(client);
+
+        // Act
+        var result = await CustomObjectsTools.GetCustomObjectInstance(service, "cobj-123", "inst-123");
+
+        // Assert
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri!.AbsolutePath == "/resources/customObjects/cobj-123/instances/search"
+                && req.RequestUri.Query.Contains("id=inst-123")),
+            ItExpr.IsAny<CancellationToken>());
+        result.Should().NotContain("\"results\"");
+        result.Should().Contain("inst-123");
+    }
+
+    [Fact]
+    public async Task GetCustomObjectInstance_NoMatch_ReturnsNotFoundMessage()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetEmptyResultsJson());
+        var service = CreateService(mockClient);
+
+        // Act
+        var result = await CustomObjectsTools.GetCustomObjectInstance(service, "cobj-123", "inst-999");
+
+        // Assert
+        result.Should().Contain("No custom object instance found with id inst-999");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~CustomObjectsToolsTests.GetCustomObjectInstance"`
+Expected: FAIL — `GetCustomObjectInstance` not defined (compile error).
+
+- [ ] **Step 3: Add the tool method**
+
+In `VitallyMcp/Tools/CustomObjectsTools.cs`, add after `ListCustomObjectInstances` (before the `Create_custom_object` method):
+
+```csharp
+    [McpServerTool(Name = "Get_custom_object_instance", Title = "Get custom object instance", ReadOnly = true, Destructive = false), Description("Get a single custom object instance by its ID. Implemented via Vitally's instance search (Vitally has no direct single-instance GET). Returns a not-found message if the ID does not match.")]
+    public static async Task<string> GetCustomObjectInstance(
+        VitallyService vitallyService,
+        [Description("The custom object ID")] string customObjectId,
+        [Description("The instance ID")] string instanceId,
+        [Description("Comma-separated list of fields to include. Defaults to: id,name,externalId,createdAt,updatedAt,organizationId,customerId,archivedAt. Client-side filtering.")] string? fields = null,
+        [Description("Comma-separated trait names to include (requires 'traits' in fields). Client-side filtering.")] string? traits = null)
+    {
+        return await vitallyService.GetCustomObjectInstanceByIdAsync(customObjectId, instanceId, fields, traits);
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~CustomObjectsToolsTests.GetCustomObjectInstance"`
+Expected: PASS (both)
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add VitallyMcp/Tools/CustomObjectsTools.cs VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
+git commit -m @'
+feat(instances): add Get_custom_object_instance (search-by-id)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 6: Remove the broken `Search_custom_object_instances` tool
+
+**Files:**
+- Modify: `VitallyMcp/Tools/CustomObjectsTools.cs`
+- Modify: `VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs`
+
+- [ ] **Step 1: Delete the obsolete test**
+
+In `VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs`, delete the entire
+`SearchCustomObjectInstances_WithQuery_ShouldReturnMatchingInstances` test method (lines ~90–103).
+
+- [ ] **Step 2: Delete the tool method**
+
+In `VitallyMcp/Tools/CustomObjectsTools.cs`, delete the entire `SearchCustomObjectInstances`
+method (the `[McpServerTool(Name = "Search_custom_object_instances", …)]` method and its inner
+`SafeDecode` local function — the whole method block).
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `dotnet test VitallyMcp.sln -c Debug --nologo --verbosity minimal`
+Expected: PASS — no reference to the removed method remains; all tests green.
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add VitallyMcp/Tools/CustomObjectsTools.cs VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
+git commit -m @'
+refactor(instances): remove broken Search_custom_object_instances tool
+
+Capabilities are now covered by scoped List_custom_object_instances and
+Get_custom_object_instance.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 7: Documentation (`CLAUDE.md`)
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add the default-fields table row**
+
+In `CLAUDE.md`, in the "Resource-Specific Default Fields" table, add a row after the
+**Meeting Transcripts** row:
+
+```markdown
+| **Custom Object Instances** | id, name, externalId, createdAt, updatedAt, organizationId, customerId, archivedAt |
+```
+
+- [ ] **Step 2: Add a tool-surface note**
+
+In `CLAUDE.md`, under the custom-objects discussion (near the Tool Structure section), add:
+
+```markdown
+**Custom object instances:** `List_custom_object_instances` accepts an optional single scope
+criterion — `organizationId`, `customerId`, `externalId`, or `customFieldId`+`customFieldValue`
+— which routes to Vitally's `customObjects/:id/instances/search` endpoint (exactly one criterion;
+paging params are ignored when scoped). `Get_custom_object_instance` reads one instance by id via
+the same search endpoint (Vitally has no direct single-instance GET). The legacy free-text
+`Search_custom_object_instances` tool has been removed in favour of these typed paths.
+```
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add CLAUDE.md
+git commit -m @'
+docs: document custom-object-instance scoping & get-by-id in CLAUDE.md
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+'@
+```
+
+---
+
+### Task 8: Live `/search` smoke test (manual — before merge)
+
+> This is a manual verification, not an automated test. It resolves the one open item in the spec
+> (§6): whether `/instances/search` returns the `{results, next}` envelope and whether it honours
+> `from`/`limit`. Requires a Vitally dev API key.
+
+- [ ] **Step 1: Start the server in dev mode**
+
+```powershell
+$env:OAuth__NoAuth = "true"
+$env:Vitally__Region = "EU"
+$env:Vitally__DevelopmentApiKey = "sk_live_your_key"
+$env:ASPNETCORE_URLS = "http://localhost:5099"
+dotnet run --project VitallyMcp/VitallyMcp.csproj
+```
+
+- [ ] **Step 2: Call the scoped list against a known custom object + organisation**
+
+Use a real `customObjectId` and `organizationId` (e.g. the `customerGoals` object and an org with
+a handful of goals). Through your MCP client or a direct `tools/call`, invoke
+`List_custom_object_instances` with `organizationId` set, and confirm:
+- only that organisation's instances come back,
+- the response is the `{results, next}` shape (or note if `next` is absent),
+- the payload is small (one cheap call — the headline win).
+
+- [ ] **Step 3: Record the finding**
+
+If `/search` **does** honour `from` (i.e. `next` is populated and a follow-up call with it pages),
+open a follow-up task to wire `from` (and a client-side `limit` cap) into
+`SearchCustomObjectInstancesAsync`. If it does not, no action — the scoped set is returned whole.
+Note the outcome in the PR description.
+
+---
+
+## Final verification
+
+- [ ] Run the full suite: `dotnet test VitallyMcp.sln -c Debug --nologo --verbosity minimal` — all green.
+- [ ] Confirm `Search_custom_object_instances` no longer appears in `tools/list` (smoke-test `tools/list` per the CLAUDE.md instructions).
+- [ ] Open a PR from `feature/sp1-custom-object-instances` into `main`.

--- a/docs/superpowers/specs/2026-06-10-sp1-custom-object-instances-design.md
+++ b/docs/superpowers/specs/2026-06-10-sp1-custom-object-instances-design.md
@@ -1,0 +1,144 @@
+# SP1 — Custom-object-instance scoping & ergonomics
+
+**Date:** 2026-06-10
+**Status:** Design (approved) — ready for implementation plan.
+**Parent:** [Vitally MCP feedback backlog decomposition](./2026-06-10-vitally-mcp-feedback-decomposition-design.md)
+**Feedback items covered:** P1.1 (org scoping), P1.6 (broken search), P2.7 (get single instance), P2.9 (traits + default fields on instance lists).
+
+## 1. Purpose
+
+Make "give me *this organisation's* goal instances" a single cheap MCP call instead of paging
+every customer's instances (~1.7 MB/page) and sifting client-side; let callers read one instance
+by id; let callers subset traits and get a useful default field set on instance lists; and remove
+the consistently-broken free-text search tool that erodes trust in the surface.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Scope instance listing by a single Vitally `/search` criterion via typed parameters.
+- Add a single-instance read (`Get_custom_object_instance`) using search-by-id.
+- Give instance lists a real default field set and expose trait subsetting.
+- Remove `Search_custom_object_instances`.
+
+**Non-goals**
+- Server-side date-range / name filtering (that is SP3's "page-and-filter" mechanism).
+- A composite organisation summary (SP5).
+- Any change to other resource types.
+
+## 3. Public tool surface (the contract)
+
+### 3.1 `List_custom_object_instances` (modified)
+
+Existing params unchanged: `customObjectId` (required), `limit` (default 20), `from`, `fields`,
+`sortBy`. New optional params:
+
+| Param | Purpose |
+|---|---|
+| `organizationId` | Scope to one organisation (the headline win) |
+| `customerId` | Scope to one customer/account |
+| `externalId` | Scope by external key |
+| `customFieldId` | Find instances where a custom field equals a value — **must** accompany `customFieldValue` |
+| `customFieldValue` | The value to match — **must** accompany `customFieldId` |
+| `traits` | Comma-separated trait names to include (requires `traits` in `fields`) |
+
+**Routing rule** — Vitally's `/search` accepts *exactly one* criterion, where
+`customFieldId`+`customFieldValue` count as one paired criterion:
+
+- **Zero** scope criteria → plain list as today:
+  `GET /resources/customObjects/{customObjectId}/instances?limit=…&from=…&sortBy=…`.
+- **Exactly one** criterion → search:
+  `GET /resources/customObjects/{customObjectId}/instances/search?{criterion}` — **only the
+  criterion is sent** (no `limit`/`from`/`sortBy`; see §6). Client-side field/trait filtering and
+  `next` pass-through are applied as for any list.
+- **More than one** scope criterion → throw `ArgumentException` before any HTTP call:
+  *"Vitally instance search accepts exactly one of organizationId, customerId, externalId, or
+  customFieldId+customFieldValue."*
+- `customFieldId` without `customFieldValue` (or vice versa) → throw `ArgumentException`:
+  *"customFieldId and customFieldValue must be supplied together."*
+
+The param descriptions must state that `limit`/`from`/`sortBy` apply to **unscoped** listing only.
+
+### 3.2 `Get_custom_object_instance` (new)
+
+```
+Get_custom_object_instance(customObjectId, instanceId, fields?, traits?)
+```
+Vitally has no `GET …/instances/:id`, so this issues `GET …/instances/search?id={instanceId}`,
+unwraps the first element of `results`, and returns it as a single filtered object.
+On an empty result set (HTTP 200, `results: []`) it returns
+`{"message":"No custom object instance found with id {instanceId}"}` rather than throwing.
+
+### 3.3 `Search_custom_object_instances` (removed)
+
+Tool method and its test removed. Its capabilities are fully covered by the scoped list (§3.1)
+and get-by-id (§3.2).
+
+## 4. Service changes (`VitallyService.cs`)
+
+1. **`limit`-optional query building.** Factor the list query-string assembly so a variant can
+   omit `limit`. The scoped-search path uses it to send only the criterion.
+2. **Scoped-list path.** A method that issues the `/search` GET with the single criterion,
+   applies `FilterJsonFields(isListResponse: true)`, and forwards `next` if present.
+3. **Get-by-id path.** A method that issues `/search?id=…`, extracts the first `results`
+   element, applies single-object filtering, and returns the not-found message when empty.
+4. **Instance default fields.** Add `ResourceDefaultFields["customObjectInstances"]
+   = [id, name, externalId, createdAt, updatedAt, organizationId, customerId, archivedAt]`.
+   Decouple the **defaults key** from the **URL path** so the instance paths (whose URL is
+   `customObjects/{id}/instances`, not an exact-match key) resolve to this set — e.g. the
+   instance service methods pass an explicit `defaultsKey: "customObjectInstances"` into the
+   filter, leaving `GetResourcesAsync`'s existing behaviour for other resources unchanged.
+
+All new paths still funnel through `SendAsync`, preserving the RBAC backstop and audit logging
+(GET → `vitally:read`).
+
+## 5. Validation & error handling
+
+- Scope-criteria validation (§3.1) happens **before** any HTTP call; messages are actionable so
+  the LLM can self-correct.
+- API errors continue to surface via `SendAsync`'s `HttpRequestException` with the Vitally body.
+- Get-by-id "not found" is a normal 200 with empty `results` → returns the explicit message in
+  §3.2 (not an exception).
+
+## 6. Open / verification items (for the implementation plan)
+
+- **`/search` envelope & pagination (must verify live).** The docs confirm `/search` is GET and
+  takes one criterion, but do not confirm whether it paginates or honours `limit`/`from`. The
+  plan must include a smoke-test against a live (or dev-key) Vitally instance to confirm the
+  response is the `{results, next}` envelope and whether `from` is honoured. If `from` *is*
+  honoured, wire `from` (and a client-cap `limit`) into the scoped path as a low-risk follow-up;
+  if not, the scoped query returns the full matching set as Vitally provides it (acceptable —
+  scoped sets are small, e.g. an org's handful of goals).
+
+## 7. Testing
+
+`VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs` and `VitallyServiceTests`:
+
+- Scoped list (`organizationId`) issues `GET …/instances/search?organizationId=…` with **no**
+  `limit` query param (Moq protected URI verification).
+- `customFieldId`+`customFieldValue` issues the paired criterion correctly.
+- Two scope criteria → `ArgumentException`, no HTTP call.
+- `customFieldId` without `customFieldValue` → `ArgumentException`, no HTTP call.
+- `Get_custom_object_instance` issues `…/instances/search?id=…`, unwraps the single object;
+  empty `results` → the not-found message.
+- Unscoped list unchanged (still sends `limit`).
+- Instance default fields applied when `fields` omitted; trait subsetting applied when
+  `traits` set with `traits` in `fields`.
+- Remove the `Search_custom_object_instances` test.
+
+Use `TestHelpers.BuildVitallyService(httpClient)` per existing convention.
+
+## 8. Docs
+
+- `CLAUDE.md`: update the custom-object-instance tool surface (removed `Search_…`, new
+  `Get_custom_object_instance`, scoping params), and add a **Custom Object Instances** row to the
+  default-fields table.
+
+## 9. Acceptance criteria
+
+- One call `List_custom_object_instances(customObjectId, organizationId=X)` returns only org X's
+  instances.
+- `Get_custom_object_instance` returns a single instance by id, or a clear not-found message.
+- Instance lists return the new default field set and support `traits` subsetting.
+- `Search_custom_object_instances` no longer appears in `tools/list`.
+- Passing more than one scope criterion fails fast with an actionable message.
+- All existing tests pass; new tests cover the above; `dotnet test` is green.

--- a/docs/superpowers/specs/2026-06-10-vitally-mcp-feedback-decomposition-design.md
+++ b/docs/superpowers/specs/2026-06-10-vitally-mcp-feedback-decomposition-design.md
@@ -1,0 +1,143 @@
+# Vitally MCP — user-feedback backlog: decomposition & sequencing
+
+**Date:** 2026-06-10
+**Status:** Portfolio spec (approved). Each sub-project gets its own detailed spec → plan → implementation cycle.
+**Source:** First-hand feedback from three value-report runs (Lesley in Claude Desktop on Specsavers ×2; a Claude Code run on Aberdeen City Council).
+
+## 1. Context
+
+We are productising a customer value report as a Claude skill running on the Vitally + Rosetta
+MCPs. Live runs surfaced ~13 improvement requests. The data layer is sound; the issues are
+**scoping, filtering and tool-surface** — they are what burned the MCP tool budget and produced
+the slow runs. In Claude Code the report author could brute-force the missing filters with a
+local file parse; in Claude Desktop there is no local filesystem, so the only way to filter is
+**more MCP calls** — which is the tool-limit burn we watched.
+
+This document does **not** design the fixes. It records what each request actually means once
+checked against the Vitally REST API, groups the work into independently shippable
+sub-projects, and fixes the order we will tackle them. The sequence is **value-first**
+(approved): SP1 → SP2 → SP4 → SP3 → SP5.
+
+## 2. Feasibility reality-check (Vitally REST API)
+
+Verified against the Vitally Help Center REST API reference (June 2026):
+
+| # | Request | What Vitally actually allows | Verdict |
+|---|---------|------------------------------|---------|
+| P1.1 | `organizationId` on instances list | Instances **`/search`** endpoint (GET) accepts `organizationId` or `customerId`, but **exactly one** criterion; it is a *different* endpoint from the plain list | Feasible via `/search` |
+| P1.6 | `Search_custom_object_instances` broken | `/search` exists (GET, one-criterion). Our tool sends `limit=100` **plus** the criteria, likely violating the one-criterion rule and/or assuming the wrong envelope | Diagnose + fix or remove |
+| P2.7 | Get single instance | **No** `GET …/instances/:id` endpoint exists; `PUT`/`DELETE` use that path but there is no read. `/search?id=…` returns the one record | Feasible *via search-by-id* |
+| P1.2 | Conversations subject + source | List payload **already includes `subject`** (and so do our defaults). `source` (e.g. `google`, `intercom`) and `status` are real conversation fields but are **not** in our default set | Small — add fields; reconcile the "timestamps only" report against the deployed build |
+| P2.9 | Trait subset on instance lists | Instances carry `traits`; our client-side filter already supports subsetting — it just isn't exposed on the instance tools. Instance lists also fall back to the bare `id,createdAt,updatedAt` default | Small |
+| P2.10 | Filter `List_custom_traits` | `customFields` returns a bare array; any filter is client-side only | Small (client-side) |
+| P1.3 | Date-range filters | Vitally list endpoints accept **only** `limit`, `from`, `sortBy` — **no** server-side date filter | Only via our-server paging+filtering |
+| P1.4 | Org name search | **No** name search on Vitally; get-by-id does accept `externalId` | Only via our-server paging+filtering (or externalId) |
+| P1.5 | Read-only / role-scoped | Server-side RBAC is **already built** (`ToolAuthorizer`, enforced in `VitallyService.SendAsync`). Gap is rollout/config + the fact destructive tools still appear in `tools/list` (the `Destructive` flag is only an advisory client hint) | Mostly config/ops + a tool-surface design choice |
+| P2.12 | Server instructions / hints | MCP supports a server `instructions` field; tool descriptions are editable | High-leverage, low-risk |
+| P2.13 | Composite `Get_organization_summary` | Orchestrate existing calls server-side | Larger feature; depends on SP1 |
+| P2.8 | `totalCount` in envelopes | Vitally returns **no** total/count field anywhere | Infeasible without paging everything |
+| P2.11 | Timeouts on ID query params | Vitally-side performance (likely the `/search` path) | Not ours — escalate; mitigate with timeout/retry |
+
+Two structural observations drove the grouping:
+
+- **P1.1, P1.6 and P2.7 all collapse onto the single `/search` endpoint** — so they are one
+  cohesive piece of work, not three.
+- **P1.3, P1.4 and P2.10 all need the same mechanism** — "our server pages Vitally and filters
+  the results, because Vitally won't" — with the same cost/cap/timeout trade-offs.
+
+## 3. Sub-projects
+
+### SP1 — Custom-object-instance scoping & ergonomics *(value-report unblocker)*
+**Items:** P1.1, P1.6, P2.7, P2.9.
+**Files:** `Tools/CustomObjectsTools.cs`, `VitallyService.cs`.
+**Shape:** scope instance listing by `organizationId`/`customerId` by routing to `/search`;
+diagnose and fix (or remove) `Search_custom_object_instances`; add
+`Get_custom_object_instance` implemented as search-by-id; expose `traits` and give instance
+lists a real default field set (e.g. `id,name,externalId,createdAt,updatedAt,organizationId,
+customerId,archivedAt`).
+**Open questions for its spec:**
+- The `/search` envelope and whether it accepts `limit`/`from`/`sortBy` (drives whether scoped
+  lists can paginate). Needs live verification.
+- Instance default fields use a dynamic resource path (`customObjects/{id}/instances`), so the
+  exact-match `ResourceDefaultFields` lookup misses them — need a path-suffix rule or explicit
+  defaults.
+- Fix vs remove for the broken search tool (removal may be cleaner once scoped-list +
+  get-by-id cover its use cases).
+
+### SP2 — Conversations for support-ticket reporting
+**Items:** P1.2.
+**Files:** `VitallyService.cs` (`ResourceDefaultFields["conversations"]`), possibly
+`Tools/ConversationsTools.cs` descriptions.
+**Shape:** add `source` and `status` to the conversation default fields so genuine support
+tickets are distinguishable from calendar invites/emails.
+**Open questions for its spec:**
+- Confirm the *list* endpoint actually returns `source`/`status` (the documented list example
+  showed only `id,externalId,externalUrl,subject,traits`); if absent on list, document the
+  limitation rather than implying a per-record fetch is avoidable.
+- Reconcile the "list returns timestamps only" report — current defaults contain `subject`, not
+  timestamps, so this is likely a stale deployed build; verify before assuming a code change is
+  even needed.
+
+### SP3 — Server-side "page-and-filter" helpers
+**Items:** P1.4, P1.3, P2.10.
+**Files:** `VitallyService.cs` (new bounded auto-paging helper), the relevant list tools,
+`Tools/CustomTraitsTools.cs`.
+**Shape:** a single bounded helper that pages an endpoint up to a cap, applies a client-side
+predicate (name-contains, created/updated within range, trait-label-contains), and returns the
+matches plus a truncation flag. Org name search, date-range filtering and the custom-traits
+catalogue filter all reuse it.
+**Open questions for its spec (the real decision):**
+- Is auto-paging acceptable at all given the 1000 req/min budget, or do we cap hard and surface
+  "truncated — narrow your query"? What page-count / item-count / wall-clock caps?
+- Which list tools get date-range filtering?
+- For org name search, prefer exact `externalId` lookup where the caller has it.
+
+### SP4 — Safety / least-privilege rollout
+**Items:** P1.5 (and the "remove" half of P1.6 if SP1 chooses removal).
+**Files:** mostly **outside this repo** — Auth0 Action, Entra group assignments, Terraform/IaC;
+within the repo, an optional deploy-time "read-only mode".
+**Shape:** verify the RBAC backstop is actually enforced in the deployed revision
+(`Authorization:Enabled`, `LiveGroupCheck`), assign the reader/editor/admin Entra groups so CS
+users genuinely lack `vitally:delete`, and decide whether to also **hide** destructive tools
+(stateless HTTP + a static `tools/list` makes per-caller filtering non-trivial; a deploy-time
+read-only build that simply doesn't register destructive tools may be the pragmatic answer).
+**Open questions for its spec:**
+- Why are deletions happening now — enforcement off, or groups unassigned so everyone has
+  write/delete? Establish the actual current state first.
+- Hide-tools vs deny-on-call vs client-side hints — pick the model.
+- Relationship to the pending data-classification gate before wider rollout.
+
+### SP5 — Guidance & composites
+**Items:** P2.12, P2.13.
+**Files:** `Program.cs` (server `instructions`), tool descriptions, a new composite tool.
+**Shape:** ship server-level `instructions` and a few targeted tool-description hints ("rich
+data lives at organisation level; account traits are usually empty; customer goals = the
+`customerGoals` custom object; traits ≠ custom objects"); add a composite
+`Get_organization_summary(orgId)` that returns organisation + traits + goals + product feedback
++ ticket rollups in one call.
+**Open questions for its spec:**
+- SDK support for setting `instructions` via `AddMcpServer`.
+- `Get_organization_summary` depends on SP1's org-scoped instance fetch; define the exact
+  sub-calls, partial-failure handling and response size budget.
+
+## 4. Won't-fix / escalate (not a sub-project)
+
+- **P2.8 `totalCount`** — Vitally exposes no count. Default: won't-fix. Optional later: an
+  explicit, clearly-expensive `Count_*` tool that pages to exhaustion only when asked.
+- **P2.11 timeouts** — Vitally-side performance; raise with Vitally. We can tune the
+  `HttpClient` timeout and the existing `VitallyRateLimitHandler` retry behaviour as mitigation.
+
+## 5. Sequence (approved: value-first)
+
+1. **SP1** — instances (unblocks the value report).
+2. **SP2** — conversations (tiny, high value, can trail or parallel SP1).
+3. **SP4** — safety (urgent per the feedback; flagged as a judgement call — revisit if the
+   rollout timeline tightens).
+4. **SP3** — page-and-filter (needs the auto-paging decision).
+5. **SP5** — guidance & composite (polish + leverage; P2.13 depends on SP1).
+
+## 6. Credit (from the feedback, retained for context)
+
+Cursors are reliable; the `fields` selector is excellent and is what made the light-scan
+workaround possible; the data is accurate (rollup counts matched the instances exactly). The
+foundations are right — the asks above are mostly scoping and filtering.


### PR DESCRIPTION
## Summary

Planning artefacts for the Vitally MCP user-feedback backlog — companion to the SP1 implementation in #45 (docs only, no code changes):

- `docs/superpowers/specs/2026-06-10-vitally-mcp-feedback-decomposition-design.md` — the ~13 value-report feedback items reality-checked against the Vitally REST API and decomposed into 5 value-first sub-projects (SP1 instances → SP2 conversations → SP4 safety → SP3 page-and-filter → SP5 guidance/composite), plus a won't-fix/escalate list.
- `docs/superpowers/specs/2026-06-10-sp1-custom-object-instances-design.md` — the SP1 design (approved).
- `docs/superpowers/plans/2026-06-10-sp1-custom-object-instances.md` — the SP1 TDD implementation plan, delivered in #45.

SP2–SP5 remain to be brainstormed/implemented in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)