### PR TITLE
fix(instances): handle Vitally /search bare-array response (SP1 live-validation fix)

### DIFF
--- a/VitallyMcp.Tests/TestHelpers.cs
+++ b/VitallyMcp.Tests/TestHelpers.cs
@@ -520,6 +520,31 @@ public static class TestHelpers
     """;
 
     /// <summary>
+    /// Sample custom object instance search response. Vitally's /instances/search endpoint returns
+    /// a BARE JSON array (no {results, next} envelope) — this mirrors that real shape so the
+    /// search / get-by-id paths are tested against what the API actually returns.
+    /// </summary>
+    public static string GetSampleInstanceSearchArrayJson() => """
+    [
+      {
+        "id": "inst-123",
+        "name": "Annual Goal",
+        "externalId": "ext-inst-123",
+        "createdAt": "2024-01-01T00:00:00Z",
+        "updatedAt": "2024-01-15T00:00:00Z",
+        "organizationId": "org-456",
+        "customerId": "cust-789",
+        "archivedAt": null,
+        "descriptionBody": "A very long description body we do not want by default",
+        "traits": {
+          "target": "100",
+          "owner": "CSM"
+        }
+      }
+    ]
+    """;
+
+    /// <summary>
     /// Sample meeting JSON for testing.
     /// </summary>
     public static string GetSampleMeetingJson() => """

--- a/VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
+++ b/VitallyMcp.Tests/Tools/CustomObjectsToolsTests.cs
@@ -224,7 +224,7 @@ public class CustomObjectsToolsTests
     {
         // Arrange
         var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
-            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+            TestHelpers.GetSampleInstanceSearchArrayJson());
         var service = CreateService(client);
 
         // Act
@@ -248,7 +248,7 @@ public class CustomObjectsToolsTests
     {
         // Arrange
         var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
-            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+            TestHelpers.GetSampleInstanceSearchArrayJson());
         var service = CreateService(client);
 
         // Act
@@ -305,7 +305,7 @@ public class CustomObjectsToolsTests
     {
         // Arrange
         var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
-            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+            TestHelpers.GetSampleInstanceSearchArrayJson());
         var service = CreateService(client);
 
         // Act
@@ -396,7 +396,7 @@ public class CustomObjectsToolsTests
     {
         // Arrange
         var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
-            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+            TestHelpers.GetSampleInstanceSearchArrayJson());
         var service = CreateService(client);
 
         // Act
@@ -418,7 +418,7 @@ public class CustomObjectsToolsTests
     public async Task GetCustomObjectInstance_NoMatch_ReturnsNotFoundMessage()
     {
         // Arrange
-        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetEmptyResultsJson());
+        var mockClient = TestHelpers.CreateMockHttpClient("[]");
         var service = CreateService(mockClient);
 
         // Act

--- a/VitallyMcp.Tests/VitallyServiceTests.cs
+++ b/VitallyMcp.Tests/VitallyServiceTests.cs
@@ -957,7 +957,7 @@ public class VitallyServiceTests
     {
         // Arrange
         var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
-            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+            TestHelpers.GetSampleInstanceSearchArrayJson());
         var service = CreateService(client);
 
         // Act
@@ -980,7 +980,7 @@ public class VitallyServiceTests
     public async Task GetCustomObjectInstanceByIdAsync_NoMatch_ReturnsNotFoundMessage()
     {
         // Arrange
-        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetEmptyResultsJson());
+        var mockClient = TestHelpers.CreateMockHttpClient("[]");
         var service = CreateService(mockClient);
 
         // Act
@@ -994,7 +994,7 @@ public class VitallyServiceTests
     public async Task GetCustomObjectInstanceByIdAsync_WithExplicitFields_HonoursFieldSelection()
     {
         // Arrange
-        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleRichCustomObjectInstanceJson());
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleInstanceSearchArrayJson());
         var service = CreateService(mockClient);
 
         // Act — request only id,name
@@ -1015,7 +1015,7 @@ public class VitallyServiceTests
     {
         // Arrange
         var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler(
-            TestHelpers.GetSampleRichCustomObjectInstanceJson());
+            TestHelpers.GetSampleInstanceSearchArrayJson());
         var service = CreateService(client);
         var criteria = new Dictionary<string, string> { ["organizationId"] = "org-456" };
 

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -143,9 +143,9 @@ public class VitallyService
     /// <summary>
     /// Issues a custom object instance search against Vitally's <c>/instances/search</c> endpoint
     /// with the supplied <paramref name="criteria"/>. Only the criteria are sent — no
-    /// <c>limit</c>/<c>from</c>/<c>sortBy</c>, since the endpoint's pagination support is undocumented.
-    /// The standard <c>{results, next}</c> field/trait filtering is applied; <c>next</c> is passed
-    /// through if present.
+    /// <c>limit</c>/<c>from</c>/<c>sortBy</c>. Unlike the list endpoints, <c>/search</c> returns a
+    /// bare <c>[...]</c> array with no pagination cursor; the results are field/trait-filtered and
+    /// wrapped in the standard <c>{results}</c> envelope so the tool output stays uniform.
     /// </summary>
     /// <remarks>
     /// Vitally accepts exactly ONE criterion (with <c>customFieldId</c>+<c>customFieldValue</c> as a
@@ -275,7 +275,23 @@ public class VitallyService
 
         if (isListResponse)
         {
-            if (document.RootElement.TryGetProperty("results", out var resultsElement))
+            // List endpoints return a {results, next} envelope, but the customObjects
+            // /instances/search endpoint returns a bare [...] array. Accept both, and always emit
+            // a {results, ...} envelope so callers get a uniform shape regardless of the source.
+            var root = document.RootElement;
+            JsonElement resultsElement;
+            bool hasResults;
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                resultsElement = root;
+                hasResults = true;
+            }
+            else
+            {
+                hasResults = root.TryGetProperty("results", out resultsElement);
+            }
+
+            if (hasResults && resultsElement.ValueKind == JsonValueKind.Array)
             {
                 writer.WritePropertyName("results");
                 writer.WriteStartArray();
@@ -288,7 +304,10 @@ public class VitallyService
                 writer.WriteEndArray();
             }
 
-            if (document.RootElement.TryGetProperty("next", out var nextElement))
+            // A bare-array (search) response carries no pagination cursor; only the
+            // {results, next} envelope does.
+            if (root.ValueKind == JsonValueKind.Object
+                && root.TryGetProperty("next", out var nextElement))
             {
                 writer.WritePropertyName("next");
                 nextElement.WriteTo(writer);
@@ -306,15 +325,26 @@ public class VitallyService
     }
 
     /// <summary>
-    /// Extracts the first element of a <c>{results: [...]}</c> response and returns it as a single
-    /// filtered object. Returns <c>{"message": notFoundMessage}</c> when results are absent or empty.
+    /// Extracts the first instance from a search response and returns it as a single filtered
+    /// object. Vitally's <c>/instances/search</c> returns a bare <c>[...]</c> array; the list
+    /// endpoints return <c>{results: [...]}</c>. Both are accepted. Returns
+    /// <c>{"message": notFoundMessage}</c> when the response holds no instances.
     /// </summary>
     private static string FilterSingleFromResults(string jsonResponse, string? fields, string defaultsKey, string? traits, string notFoundMessage)
     {
         using var document = JsonDocument.Parse(jsonResponse);
-        if (!document.RootElement.TryGetProperty("results", out var results)
-            || results.ValueKind != JsonValueKind.Array
-            || results.GetArrayLength() == 0)
+        var root = document.RootElement;
+        JsonElement results;
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            results = root;
+        }
+        else
+        {
+            root.TryGetProperty("results", out results);
+        }
+
+        if (results.ValueKind != JsonValueKind.Array || results.GetArrayLength() == 0)
         {
             return JsonSerializer.Serialize(new { message = notFoundMessage });
         }


### PR DESCRIPTION
## Summary

Fixes a bug in SP1 (#45) found during **live validation against real Vitally** (Task 8): the two new scope-driven capabilities threw `InvalidOperationException` for every call.

**Root cause:** Vitally's `customObjects/:id/instances/search` endpoint returns a **bare JSON array** (`[ … ]`), not the `{results, next}` envelope the list endpoints use. SP1's `SearchCustomObjectInstancesAsync` / `FilterSingleFromResults` assumed the envelope and called `TryGetProperty("results")` on an array root → threw. The unit tests passed only because their mocks used the wrong shape (`{results:[…]}`).

**Impact (pre-fix):** scoped `List_custom_object_instances` (P1.1) and `Get_custom_object_instance` (P2.7) were non-functional against real Vitally. Not yet deployed (deploy is manual), so it never reached production.

**Fix:**
- `FilterJsonFields` (list path) and `FilterSingleFromResults` now accept **both** a bare array and the `{results}` envelope. Search results are wrapped in a uniform `{results}` envelope (no `next` — `/search` does not paginate).
- Updated the search / get-by-id test mocks to the **real bare-array shape** (new `GetSampleInstanceSearchArrayJson` helper) so they reflect what Vitally actually returns and guard the regression. Verified red→green: the updated tests fail against the pre-fix code.

## Live re-validation (real Vitally, EU)

- ✅ P1.1 scoped list by `organizationId` → returns only that org's instances, wrapped `{results}`, no error.
- ✅ P2.7 get-by-id (match) → single unwrapped object.
- ✅ P2.7 get-by-id (genuine miss, valid UUID) → friendly `{"message":"No custom object instance found…"}` (Vitally returns `[]` for a miss).
- ✅ P2.9 default fields + traits subsetting.
- Confirmed: `/search` returns a bare array with **no pagination cursor** (answers the open Task 8 question — no `from` wiring needed).

## Test Plan

- [x] `dotnet test VitallyMcp.sln` — 291 passed, 0 failed.
- [x] Red-check: updated tests fail against pre-fix code (9 failures, all in the search/get-by-id paths).
- [x] Live validation against real Vitally (above).

## Follow-up (out of scope, noted)

A malformed (non-UUID) instance id makes Vitally return `400 "Given ID expected to be a UUID"`, which the MCP SDK surfaces to clients as a generic "An error occurred" — the helpful Vitally message is masked. This masking is systemic across all tools and pre-existing; worth a separate change to surface upstream error detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)