### PR TITLE
feat(conversations): surface source & status in default fields (SP2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ When no fields are specified, each resource type returns an optimised field set:
 | **Accounts** | id, name, createdAt, updatedAt, externalId, organizationId, healthScore, mrr, accountOwnerId, lastSeenTimestamp |
 | **Organizations** | id, name, createdAt, updatedAt, externalId, healthScore, mrr, lastSeenTimestamp |
 | **Users** | id, name, createdAt, updatedAt, externalId, email, accountId, organizationId, lastSeenTimestamp |
-| **Conversations** | id, externalId, subject, authorId, accountId, organizationId |
+| **Conversations** | id, externalId, subject, status, source, authorId, accountId, organizationId |
 | **Notes** | id, createdAt, updatedAt, externalId, subject, noteDate, authorId, accountId, organizationId, categoryId, archivedAt |
 | **Tasks** | id, name, createdAt, updatedAt, externalId, dueDate, completedAt, assignedToId, accountId, organizationId, archivedAt |
 | **Projects** | id, name, createdAt, updatedAt, accountId, organizationId, archivedAt |

--- a/VitallyMcp.Tests/TestHelpers.cs
+++ b/VitallyMcp.Tests/TestHelpers.cs
@@ -327,6 +327,8 @@ public static class TestHelpers
           "id": "conv-123",
           "externalId": "ext-conv-123",
           "subject": "Test Conversation",
+          "status": "open",
+          "source": "intercom",
           "authorId": "user-456",
           "accountId": "account-789",
           "organizationId": "org-101",

--- a/VitallyMcp.Tests/Tools/ConversationsToolsTests.cs
+++ b/VitallyMcp.Tests/Tools/ConversationsToolsTests.cs
@@ -50,6 +50,22 @@ public class ConversationsToolsTests
     }
 
     [Fact]
+    public async Task ListConversations_WithDefaultParameters_ShouldIncludeSourceAndStatus()
+    {
+        // Arrange
+        var mockClient = TestHelpers.CreateMockHttpClient(TestHelpers.GetSampleConversationJson());
+        var service = CreateService(mockClient);
+
+        // Act
+        var result = await ConversationsTools.ListConversations(service);
+
+        // Assert — source/status are in the default set so support tickets are
+        // distinguishable from calendar/email (e.g. source=outlook) without a per-record fetch.
+        result.Should().Contain("\"source\"");
+        result.Should().Contain("\"status\"");
+    }
+
+    [Fact]
     public async Task ListConversationsByAccount_WithValidAccountId_ShouldReturnConversations()
     {
         // Arrange

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -22,7 +22,7 @@ public class VitallyService
         ["accounts"] = ["id", "name", "createdAt", "updatedAt", "externalId", "organizationId", "healthScore", "mrr", "accountOwnerId", "lastSeenTimestamp"],
         ["organizations"] = ["id", "name", "createdAt", "updatedAt", "externalId", "healthScore", "mrr", "lastSeenTimestamp"],
         ["users"] = ["id", "name", "createdAt", "updatedAt", "externalId", "email", "accountId", "organizationId", "lastSeenTimestamp"],
-        ["conversations"] = ["id", "externalId", "subject", "authorId", "accountId", "organizationId"],
+        ["conversations"] = ["id", "externalId", "subject", "status", "source", "authorId", "accountId", "organizationId"],
         ["notes"] = ["id", "createdAt", "updatedAt", "externalId", "subject", "noteDate", "authorId", "accountId", "organizationId", "categoryId", "archivedAt"],
         ["tasks"] = ["id", "name", "createdAt", "updatedAt", "externalId", "dueDate", "completedAt", "assignedToId", "accountId", "organizationId", "archivedAt"],
         ["projects"] = ["id", "name", "createdAt", "updatedAt", "accountId", "organizationId", "archivedAt"],

--- a/docs/superpowers/specs/2026-06-22-sp2-conversation-source-status-design.md
+++ b/docs/superpowers/specs/2026-06-22-sp2-conversation-source-status-design.md
@@ -1,0 +1,64 @@
+# SP2 — Conversations: surface `source` & `status` by default
+
+**Date:** 2026-06-22
+**Status:** Design (approved) — ready for implementation plan.
+**Parent:** [Vitally MCP feedback backlog decomposition](./2026-06-10-vitally-mcp-feedback-decomposition-design.md)
+**Feedback item:** P1.2 — conversations list can't distinguish genuine support tickets from calendar invites/emails.
+
+## 1. Purpose
+
+Let a caller tell real support tickets apart from calendar/email conversations **from the list
+response alone**, without an expensive per-record fetch — by including the conversation `source`
+(e.g. `outlook`, `intercom`) and `status` in the default field set.
+
+## 2. Verified finding (live, against real Vitally EU)
+
+A direct `GET /resources/conversations` returns each conversation with:
+
+```
+id, createdAt, updatedAt, externalId, subject, status, rating, source, traits
+```
+
+(envelope: `{results, next, atEnd}`). So `source`, `status` and `subject` **are** present on the
+list payload — no per-record fetch needed. Sample rows were all `source=outlook, status=(empty)`,
+i.e. exactly the calendar/email items the feedback wants to filter out. This was verified live
+because the docs list example omitted these fields and the `/search` bug taught us not to trust
+the docs on response shapes.
+
+## 3. The change
+
+Add `source` and `status` to the `conversations` entry in `VitallyService.ResourceDefaultFields`:
+
+- **From:** `id, externalId, subject, authorId, accountId, organizationId`
+- **To:** `id, externalId, subject, status, source, authorId, accountId, organizationId`
+
+Because all conversation read tools resolve defaults from the same `conversations` key, this
+surfaces `source`/`status` on `List_conversations`, `List_conversations_by_account`,
+`List_conversations_by_organization` **and** `Get_conversation` with no new parameters. Fields are
+included only when present (existing `TryGetProperty` behaviour), so the change is safe.
+
+## 4. Non-goals
+
+- **`rating`** — also in the payload, but not requested by the feedback (YAGNI). Callers can still
+  request it explicitly via `fields`.
+- **No new parameters**, and **no server-side filtering by `source`** — Vitally's list endpoint
+  offers no `source` filter, and SP3 owns any client-side page-and-filter work.
+
+## 5. Testing
+
+- Update `TestHelpers.GetSampleConversationJson()` to include `source` and `status` (mirroring the
+  **real** list shape — applying the `/search` lesson; the current sample omits them).
+- Add a test asserting `List_conversations` with no `fields` returns `source` and `status`.
+- Existing conversation tests must still pass.
+
+## 6. Docs
+
+- `CLAUDE.md`: update the **Conversations** row in the default-fields table to
+  `id, externalId, subject, status, source, authorId, accountId, organizationId`.
+
+## 7. Acceptance criteria
+
+- `List_conversations` (no `fields`) returns `source` and `status` for conversations that have
+  them.
+- `Get_conversation` likewise surfaces `source`/`status` by default.
+- Test suite green; the conversation sample reflects the real list shape.


### PR DESCRIPTION
## Summary

SP2 of the Vitally MCP feedback backlog (P1.2). Adds `source` and `status` to the **conversations default field set** so callers can distinguish genuine support tickets from calendar/email conversations directly from the list — no per-record fetch.

- Default: `id, externalId, subject, authorId, accountId, organizationId` → **`id, externalId, subject, status, source, authorId, accountId, organizationId`**.
- All conversation read tools share the `conversations` defaults key, so this surfaces `source`/`status` on `List_conversations`, `List_conversations_by_account`, `List_conversations_by_organization` and `Get_conversation` — zero new params.

## Verified live (real Vitally EU)

- `GET /resources/conversations` returns `id, createdAt, updatedAt, externalId, subject, status, rating, source, traits` — confirming `source`/`status` are in the list payload (the docs example omitted them; verified directly per the `/search` lesson).
- After the change, `List_conversations` (no `fields`) returns `…, status, source` and the sample page shows `source=outlook` — exactly the calendar/email items to filter out.

## Non-goals

- `rating` (also present) — not requested (YAGNI); callers can request it via `fields`.
- No server-side filtering by `source` (Vitally offers none; SP3 owns client-side page-and-filter).

## Test Plan

- [x] `dotnet test` — 292 passed, 0 failed (new test: `ListConversations_WithDefaultParameters_ShouldIncludeSourceAndStatus`, red→green verified).
- [x] Test sample updated to the real list shape (`source`/`status`).
- [x] Live: `List_conversations` surfaces `source`/`status` through the running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)