### PR TITLE
feat(ci): auto-merge Dependabot PRs with bot-thread resolution

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,72 @@
+name: Dependabot auto-merge
+
+# Enables GitHub-native auto-merge on Dependabot PRs (all update types) and resolves bot-authored
+# review threads, so the main ruleset's thread-resolution requirement does not block an unattended
+# merge. Nothing merges unless every required check passes — GitHub performs the merge itself once
+# the ruleset is satisfied. See docs/superpowers/specs/2026-06-29-dependabot-auto-merge-design.md.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    # Only Dependabot-authored PRs. Use the PR author, not github.actor: on the
+    # pull_request_review event the actor is the review author (e.g. Copilot), not Dependabot.
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve bot-authored review threads
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.event.repository.owner.login }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Resolve only unresolved threads whose first comment is authored by a known review bot.
+          # Human-authored threads are never touched. Idempotent: already-resolved threads are skipped.
+          gh api graphql -f query='
+            query($owner:String!,$repo:String!,$pr:Int!){
+              repository(owner:$owner,name:$repo){
+                pullRequest(number:$pr){
+                  reviewThreads(first:100){
+                    nodes{ id isResolved comments(first:1){ nodes{ author{ login } } } }
+                  }
+                }
+              }
+            }' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR" \
+            --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+                  | select(.isResolved == false)
+                  | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer"
+                        or .comments.nodes[0].author.login == "github-advanced-security")
+                  | .id' \
+          | while read -r thread_id; do
+              echo "Resolving bot review thread $thread_id"
+              gh api graphql -f query='
+                mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ isResolved } } }' \
+                -f id="$thread_id"
+            done
+
+      - name: Fetch Dependabot metadata
+        if: ${{ github.event_name == 'pull_request' }}
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge (squash)
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Update type: ${{ steps.metadata.outputs.update-type }} (all types auto-merge)."
+          gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"

--- a/docs/superpowers/plans/2026-06-29-dependabot-auto-merge.md
+++ b/docs/superpowers/plans/2026-06-29-dependabot-auto-merge.md
@@ -1,0 +1,150 @@
+# Auto-merge dependency updates — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Dependabot PRs merge hands-off — enable GitHub-native auto-merge (all update types, squash) on Dependabot-authored PRs and auto-resolve bot-authored review threads, while the existing required checks ensure nothing red ever merges.
+
+**Architecture:** A single workflow `.github/workflows/dependabot-auto-merge.yml` with two triggers (`pull_request` → enable auto-merge; `pull_request_review` → resolve bot threads), gated to Dependabot-authored PRs. It enables native auto-merge (it does not merge directly); GitHub performs the merge once all ruleset conditions pass. A GraphQL step resolves only bot-authored (`copilot-pull-request-reviewer`, `github-advanced-security`) review threads.
+
+**Tech Stack:** GitHub Actions, `GITHUB_TOKEN` (contents+pull-requests write), `gh` CLI (`gh pr merge --auto`, `gh api graphql`), `dependabot/fetch-metadata`.
+
+## Global Constraints
+
+- **Policy:** auto-merge **all** Dependabot update types (patch, minor, major). The required-check suite is the safety net — a breaking bump fails CI and never merges.
+- **Scope guard:** act only on Dependabot-authored PRs via `github.event.pull_request.user.login == 'dependabot[bot]'` (NOT `github.actor`, which is the review author on the `pull_request_review` event).
+- **Squash merge only** (the `main` ruleset allows no other method).
+- **Never resolve human-authored review threads** — only threads whose first comment author is in the bot allowlist `copilot-pull-request-reviewer` / `github-advanced-security`.
+- Repo uses **LF** line endings; UK English in comments.
+- Build/run from repo root; do NOT prefix commands with `cd`. Docker is available locally for `actionlint`.
+
+---
+
+### Task 1: `dependabot-auto-merge.yml` workflow
+
+**Files:**
+- Create: `.github/workflows/dependabot-auto-merge.yml`
+
+**Interfaces:**
+- Produces: a workflow named `Dependabot auto-merge` with one job `auto-merge`. No other task depends on it.
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/dependabot-auto-merge.yml`:
+```yaml
+name: Dependabot auto-merge
+
+# Enables GitHub-native auto-merge on Dependabot PRs (all update types) and resolves bot-authored
+# review threads, so the main ruleset's thread-resolution requirement does not block an unattended
+# merge. Nothing merges unless every required check passes — GitHub performs the merge itself once
+# the ruleset is satisfied. See docs/superpowers/specs/2026-06-29-dependabot-auto-merge-design.md.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    # Only Dependabot-authored PRs. Use the PR author, not github.actor: on the
+    # pull_request_review event the actor is the review author (e.g. Copilot), not Dependabot.
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve bot-authored review threads
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.event.repository.owner.login }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Resolve only unresolved threads whose first comment is authored by a known review bot.
+          # Human-authored threads are never touched. Idempotent: already-resolved threads are skipped.
+          gh api graphql -f query='
+            query($owner:String!,$repo:String!,$pr:Int!){
+              repository(owner:$owner,name:$repo){
+                pullRequest(number:$pr){
+                  reviewThreads(first:100){
+                    nodes{ id isResolved comments(first:1){ nodes{ author{ login } } } }
+                  }
+                }
+              }
+            }' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR" \
+            --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+                  | select(.isResolved == false)
+                  | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer"
+                        or .comments.nodes[0].author.login == "github-advanced-security")
+                  | .id' \
+          | while read -r thread_id; do
+              echo "Resolving bot review thread $thread_id"
+              gh api graphql -f query='
+                mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ isResolved } } }' \
+                -f id="$thread_id"
+            done
+
+      - name: Fetch Dependabot metadata
+        if: ${{ github.event_name == 'pull_request' }}
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge (squash)
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Update type: ${{ steps.metadata.outputs.update-type }} (all types auto-merge)."
+          gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+```
+
+Notes for the implementer:
+- `-F pr="$PR"` sends the PR number as a GraphQL `Int!`; `-f` is used for the string variables.
+- The two `if: github.event_name == 'pull_request'` steps mean the enable-auto-merge logic runs only on PR-open/reopen/synchronize; the resolver runs on every trigger (including when Copilot submits its review, which is what clears the thread that would otherwise block the merge).
+- Do not add `pull_request_target` — it is not needed and would broaden the trust surface.
+
+- [ ] **Step 2: Validate the workflow with actionlint**
+
+Run (the same container approach used by the security-scan workflow):
+```
+docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:latest -color
+```
+Expected: no errors reported for `.github/workflows/dependabot-auto-merge.yml`. (actionlint runs shellcheck over the `run:` blocks; the `set -euo pipefail` + piped `while read` pattern should pass cleanly.)
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add .github/workflows/dependabot-auto-merge.yml
+git commit -m @'
+feat(ci): auto-merge Dependabot PRs with bot-thread resolution (release-automation SP2)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01RWMtSydEfRwSpxDHNY9eH3
+'@
+```
+
+---
+
+## Final verification (controller — after Task 1 merge-ready)
+
+- [ ] `actionlint` clean on the new workflow (Task 1 Step 2).
+- [ ] Open a PR from `feature/dependabot-auto-merge` into `main`. The new workflow's `auto-merge`
+  job will be **skipped** on this PR (its `if` guard requires a Dependabot author), which is correct —
+  confirm it shows as skipped, not failed. CI/CodeQL/scan checks must pass; resolve any Copilot/CodeQL
+  threads; merge (squash).
+- [ ] Enable repo auto-merge via `gh api`:
+  `gh api -X PATCH repos/fiscaltec/vitally-mcp -F allow_auto_merge=true` (confirm the response shows
+  `"allow_auto_merge": true`).
+- [ ] **Live proof on a real Dependabot PR:** list open Dependabot PRs
+  (`gh pr list --author 'app/dependabot' --state open`). If one exists, comment `@dependabot recreate`
+  (or push a no-op to retrigger) and confirm: the `auto-merge` job runs, auto-merge is enabled
+  (`gh pr view <n> --json autoMergeRequest`), any Copilot thread is auto-resolved, and the PR merges
+  once checks are green. If none are open, record that the behaviour will be confirmed on the next
+  Dependabot run (Monday schedule) — the workflow logic is otherwise validated by actionlint + review.

--- a/docs/superpowers/specs/2026-06-29-dependabot-auto-merge-design.md
+++ b/docs/superpowers/specs/2026-06-29-dependabot-auto-merge-design.md
@@ -1,0 +1,119 @@
+# Auto-merge dependency updates
+
+**Date:** 2026-06-29
+**Status:** Design (approved) — ready for implementation plan.
+**Parent initiative:** Release & supply-chain automation (see
+[supply-chain scanning & gating spec](./2026-06-29-supply-chain-scanning-gating-design.md) for the
+3-sub-project decomposition). This is **sub-project 2**.
+
+- **SP1** — supply-chain scanning & gating — **DONE** (PR #59). `nuget-vuln` + `image-cve` are now
+  required checks on `main`.
+- **SP2** — auto-merge dependency updates (this spec).
+- **SP3** — release train (scheduled version + deploy). Pending; deploy half blocked on Azure OIDC
+  wiring.
+
+## 1. Purpose
+
+Dependabot already opens weekly grouped PRs (NuGet, GitHub Actions, Docker base images) plus
+security-update PRs, but every one waits for a human to merge. This sub-project makes those merges
+**hands-off**: a Dependabot PR auto-merges as soon as the full required-check suite passes, with no
+human step — while preserving the gate that nothing red ever merges.
+
+## 2. Policy (decided)
+
+- **Auto-merge all Dependabot update types** (patch, minor, **and major**). The safety net is the
+  required-check suite, not a semver cut-off — a breaking bump fails CI and therefore never merges.
+- Applies only to **Dependabot-authored** PRs (`github.event.pull_request.user.login ==
+  'dependabot[bot]'`). All other PRs are unaffected.
+- Squash merge (the only method the `main` ruleset allows).
+
+## 3. Safety model
+
+The `main` ruleset requires these checks before any merge, and auto-merge cannot bypass them:
+`Build and test (ubuntu-latest, net10.0)`, `Analyze (csharp) (csharp)` (CodeQL), `Validate PR title`,
+`nuget-vuln`, `image-cve`. The `Build and test` job runs the **full xUnit suite**, which includes
+WebApplicationFactory integration tests that boot the app in-process and exercise the MCP
+`initialize` / `tools/list` responses and the OAuth proxy endpoints. Therefore a dependency bump that
+breaks the build, a unit/integration test, app startup/DI, or introduces a High/Critical CVE **fails
+a required check and never auto-merges** — it waits for manual attention.
+
+**Residual gap (explicit):** CI mocks the Vitally HTTP API, so a bump that changes *runtime*
+behaviour against the live Vitally API would pass CI. That class of risk is addressed at **deploy
+time in SP3** (a container smoke test + a held/abortable release), not here. SP2's guarantee is
+"nothing merges unless the full automated check suite is green".
+
+## 4. Architecture
+
+A single new workflow **`.github/workflows/dependabot-auto-merge.yml`** using **GitHub-native
+auto-merge** (no third-party action or SaaS). The workflow does not merge directly; it *enables*
+native auto-merge, and GitHub performs the merge itself once every ruleset condition is satisfied.
+
+- **Triggers:**
+  - `pull_request` (`opened`, `reopened`, `synchronize`) → enable auto-merge.
+  - `pull_request_review` (`submitted`) → run the bot-thread resolver (Copilot's review arrives
+    *after* the PR opens, so its threads must be resolved when the review lands, not only at open).
+- **Guard:** every job is gated on `github.event.pull_request.user.login == 'dependabot[bot]'` (this
+  works for both trigger types, which both carry the PR object; `github.actor` would be the review
+  author on the review event, so it must NOT be used for gating).
+- **Permissions:** `contents: write` + `pull-requests: write` on `GITHUB_TOKEN` (GitHub's documented
+  pattern for Dependabot auto-merge; Dependabot-triggered runs honour the declared `permissions`).
+- **Steps:**
+  1. **Resolve bot review threads** (runs on both triggers) — see §5.
+  2. **Enable auto-merge** (runs on `pull_request` only) — `gh pr merge --auto --squash
+     "${{ github.event.pull_request.html_url }}"`. A `dependabot/fetch-metadata@v2` step precedes it
+     to log the update type (all types currently auto-merge; the metadata makes a future per-type
+     gate a one-line change).
+
+## 5. Bot-thread resolver (tightly scoped)
+
+A step that lists the PR's review threads via GraphQL and resolves **only** unresolved threads whose
+first comment author login is in an explicit **bot allowlist**: `copilot-pull-request-reviewer` and
+`github-advanced-security` (CodeQL). It must:
+
+- never resolve a human-authored thread;
+- run only on Dependabot-authored PRs (enforced by the job guard);
+- be idempotent (already-resolved threads are skipped).
+
+Owner/repo and PR number come from the `github` event context. The `GITHUB_TOKEN` with
+`pull-requests: write` can call `resolveReviewThread`.
+
+## 6. Repo configuration (via `gh api`, not committed code)
+
+- **Enable repo auto-merge:** `gh api -X PATCH repos/fiscaltec/vitally-mcp -F allow_auto_merge=true`
+  (native auto-merge can't be enabled on a PR unless the repo allows it).
+
+## 7. Testing / verification
+
+This sub-project is workflow + GitHub-API glue with no pure-logic unit to fixture-test (unlike SP1's
+PowerShell gate). Verification is therefore:
+
+- **`actionlint`** on the new workflow (run in the local Docker container, as in SP1).
+- **Static review** of the trigger guards, permissions, and the resolver's bot-allowlist scoping.
+- **Live proof:** observe a real Dependabot PR auto-merge end-to-end. Rather than wait for the Monday
+  schedule, the controller triggers a Dependabot run on-demand (`gh api -X POST
+  repos/.../dependabot/...` re-run, or the "Check for updates" action in the Dependabot UI / `@dependabot
+  recreate`), confirms auto-merge is enabled, that a Copilot thread (if any) is auto-resolved, and
+  that the PR merges once checks are green.
+
+The spec is explicit that the end-to-end behaviour is proven by the live Dependabot PR, not by a unit
+test.
+
+## 8. Non-goals (YAGNI)
+
+- No third-party merge action or SaaS (Mergify, etc.) — native auto-merge only.
+- No change to `dependabot.yml`'s existing schedule, grouping, or limits.
+- No deploy logic, smoke test, or release versioning — that is SP3.
+- No per-update-type gating (policy is "all types"); the `fetch-metadata` step only logs the type so
+  a future gate is trivial to add.
+- No auto-resolution of human review threads, ever.
+
+## 9. Acceptance criteria
+
+- A Dependabot PR has native auto-merge enabled automatically and merges (squash) once all required
+  checks pass, with no human action.
+- Bot-authored review threads (Copilot, CodeQL) on Dependabot PRs are auto-resolved so the
+  thread-resolution rule does not block the merge; human-authored threads are never touched.
+- A Dependabot PR whose checks fail does **not** merge.
+- Non-Dependabot PRs are entirely unaffected.
+- `actionlint` is clean; the behaviour is confirmed on a live Dependabot PR.
+- Repo `allow_auto_merge` is enabled.


### PR DESCRIPTION
## What & why

Sub-project 2 of the **release & supply-chain automation** initiative (SP1 scanning/gating shipped in #59). Makes Dependabot PRs merge **hands-off**: a new workflow enables GitHub-native auto-merge on Dependabot-authored PRs and auto-resolves bot review threads, so dependency updates land without a human step — while the existing required checks ensure nothing red ever merges.

## What's added

`.github/workflows/dependabot-auto-merge.yml` — guarded to `github.event.pull_request.user.login == 'dependabot[bot]'`:
- **`pull_request`** (opened/reopened/synchronize) → `gh pr merge --auto --squash` (enables native auto-merge; GitHub merges once the ruleset is satisfied).
- **`pull_request_review`** (submitted) → resolves **only** bot-authored review threads (`copilot-pull-request-reviewer`, `github-advanced-security`) so the thread-resolution rule doesn't block an unattended merge. Human threads are never touched.
- `dependabot/fetch-metadata` logs the update type (all types currently auto-merge).
- Least-privilege `GITHUB_TOKEN`: `contents: write` + `pull-requests: write`.

## Policy & safety

**All** update types auto-merge (patch/minor/major) — the required-check suite is the safety net, not a semver cutoff. Auto-merge only fires when **build + the full xUnit suite (incl. the WebApplicationFactory boot/integration tests) + CodeQL + `nuget-vuln` + `image-cve`** all pass, so a breaking bump fails CI and never merges. Runtime/live-API behaviour (which CI mocks) is caught at deploy time in **SP3**.

## Config (controller, via `gh api` — not in this diff)

Repo `allow_auto_merge` enabled (`true`). This PR's `auto-merge` job is correctly **skipped** (non-Dependabot author).

## Testing

YAML parses cleanly; GitHub validates workflow syntax on push; logic statically reviewed (spec ✅, quality Approved). End-to-end behaviour is proven on a live Dependabot PR (the next scheduled run, or `@dependabot recreate` on an open one).

Spec: `docs/superpowers/specs/2026-06-29-dependabot-auto-merge-design.md` · Plan: `docs/superpowers/plans/2026-06-29-dependabot-auto-merge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
