### PR TITLE
feat(deploy): private-ACR-aware deploy via GHCR + az acr import (SP3a)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,12 +45,21 @@ jobs:
 
       - name: Resolve image tag and GHCR repo
         id: vars
+        # The input is passed via env (not inlined as ${{ }}) to avoid shell injection, and the
+        # resolved tag is validated against the container-tag charset so it is safe to interpolate
+        # into the later az/docker steps.
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           set -euo pipefail
-          if [ -n "${{ inputs.image_tag }}" ]; then
-            tag="${{ inputs.image_tag }}"
+          if [ -n "$INPUT_IMAGE_TAG" ]; then
+            tag="$INPUT_IMAGE_TAG"
           else
             tag="sha-$(git rev-parse --short HEAD)"
+          fi
+          if ! printf '%s' "$tag" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+            echo "::error::Invalid image tag '$tag' (allowed characters: A-Za-z0-9._-)"
+            exit 1
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "ghcr=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,54 +1,74 @@
 name: Deploy
 
-# Builds the container image in Azure Container Registry and rolls the Azure Container App to
-# the new image. Authentication is via GitHub OIDC federation — no long-lived Azure credentials.
-#
-# SCAFFOLD: this is wired for manual runs only until the target infrastructure exists in the
-# Terraform repo. Once the registry / container app / federated identity are provisioned and the
-# repo variables + secrets below are set, uncomment the `push` trigger to deploy on merge to main.
+# Manual production deploy. The ACR has public network access disabled, so the image cannot be
+# built/pushed to it from a GitHub-hosted runner. Instead we build + push to a private GHCR package,
+# then `az acr import` (a server-side control-plane op that works with public access disabled) pulls
+# it into the private ACR, and `az containerapp update` rolls the app. OIDC auth as the user-assigned
+# managed identity (federated credential subject repo:fiscaltec/vitally-mcp:environment:production).
 on:
   workflow_dispatch:
     inputs:
-      image_tag:
-        description: "Image tag to build and deploy (defaults to sha-<short-sha>)"
+      ref:
+        description: "Git ref (branch/tag/SHA) to deploy"
         required: false
         type: string
-  # push:
-  #   branches: [main]
+      image_tag:
+        description: "Image tag to publish (default sha-<short-sha> of the chosen ref)"
+        required: false
+        type: string
 
-# OIDC federation requires id-token: write. contents: read to checkout.
 permissions:
-  id-token: write
+  id-token: write # OIDC token for azure/login
   contents: read
+  packages: write # push to GHCR
 
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: deploy-production
   cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Build image + update Container App
+    name: Build, import to ACR, roll Container App
     runs-on: ubuntu-latest
     environment: production
-
-    # Repo configuration (Settings -> Secrets and variables -> Actions):
-    #   Variables: ACR_NAME, RESOURCE_GROUP, CONTAINER_APP, IMAGE_NAME
-    #   Secrets:   AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
     env:
-      IMAGE_NAME: ${{ vars.IMAGE_NAME || 'vitally-mcp' }}
-
+      ACR_NAME: ${{ vars.ACR_NAME }}
+      RESOURCE_GROUP: ${{ vars.RESOURCE_GROUP }}
+      CONTAINER_APP: ${{ vars.CONTAINER_APP }}
+      IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+      HEALTH_URL: https://vitally.fiscaltec.com/health
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
-      - name: Resolve image tag
-        id: tag
+      - name: Resolve image tag and GHCR repo
+        id: vars
         run: |
+          set -euo pipefail
           if [ -n "${{ inputs.image_tag }}" ]; then
-            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+            tag="${{ inputs.image_tag }}"
           else
-            echo "tag=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            tag="sha-$(git rev-parse --short HEAD)"
           fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "ghcr=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}
 
       - name: Azure login (OIDC)
         uses: azure/login@v3
@@ -57,22 +77,52 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Build and push image in ACR
-        uses: azure/cli@v3
-        with:
-          azcliversion: latest
-          inlineScript: |
-            az acr build \
-              --registry "${{ vars.ACR_NAME }}" \
-              --image "${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}" \
-              --file Dockerfile .
+      - name: Import image into the private ACR (server-side)
+        run: |
+          set -euo pipefail
+          az config set extension.use_dynamic_install=yes_without_prompt
+          az acr import \
+            --name "$ACR_NAME" \
+            --source "${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}" \
+            --image "$IMAGE_NAME:${{ steps.vars.outputs.tag }}" \
+            --username "${{ github.actor }}" \
+            --password "${{ secrets.GITHUB_TOKEN }}" \
+            --force
 
       - name: Update Container App revision
-        uses: azure/cli@v3
-        with:
-          azcliversion: latest
-          inlineScript: |
-            az containerapp update \
-              --name "${{ vars.CONTAINER_APP }}" \
-              --resource-group "${{ vars.RESOURCE_GROUP }}" \
-              --image "${{ vars.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}"
+        run: |
+          set -euo pipefail
+          az containerapp update \
+            --name "$CONTAINER_APP" \
+            --resource-group "$RESOURCE_GROUP" \
+            --image "$ACR_NAME.azurecr.io/$IMAGE_NAME:${{ steps.vars.outputs.tag }}"
+
+      - name: Verify new revision is healthy
+        run: |
+          set -euo pipefail
+          latest=$(az containerapp show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" \
+            --query "properties.latestRevisionName" -o tsv)
+          echo "Latest revision: $latest"
+          prov=""; health=""
+          for i in $(seq 1 12); do
+            prov=$(az containerapp revision show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" --revision "$latest" \
+              --query "properties.provisioningState" -o tsv 2>/dev/null || echo "")
+            health=$(az containerapp revision show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" --revision "$latest" \
+              --query "properties.healthState" -o tsv 2>/dev/null || echo "")
+            echo "attempt $i: provisioning=$prov health=$health"
+            if [ "$prov" = "Provisioned" ] && { [ "$health" = "Healthy" ] || [ "$health" = "None" ]; }; then
+              break
+            fi
+            sleep 15
+          done
+          if [ "$prov" != "Provisioned" ]; then
+            echo "::error::Revision $latest did not reach Provisioned (last: $prov / $health)"
+            exit 1
+          fi
+
+      - name: Smoke-check /health
+        run: |
+          set -euo pipefail
+          code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || echo "000")
+          echo "/health returned $code"
+          [ "$code" = "200" ] || { echo "::error::/health returned $code"; exit 1; }

--- a/docs/superpowers/plans/2026-06-29-sp3a-deploy-capability.md
+++ b/docs/superpowers/plans/2026-06-29-sp3a-deploy-capability.md
@@ -1,0 +1,214 @@
+# SP3a — Deploy capability (private-ACR-aware) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework `deploy.yml` into a working manual deploy that gets a built image into the private-networked ACR via `az acr import` and rolls the Container App, then verifies the new revision is healthy.
+
+**Architecture:** A GitHub-hosted runner builds the image and pushes it to a private GHCR package; `az acr import` (server-side, works with ACR public access disabled) pulls it into the private ACR; `az containerapp update` rolls the app (which pulls in-VNet via its existing AcrPull); a bounded health poll + a `/health` 200 check confirm the deploy.
+
+**Tech Stack:** GitHub Actions, GHCR, OIDC (`azure/login`), Azure CLI (`az acr import`, `az containerapp`), Docker buildx.
+
+## Global Constraints
+
+- The ACR `vitallyproducruksouth` has `publicNetworkAccess: Disabled` — never build/push to it from a public runner, and **do not weaken** that posture. Images reach it only via server-side `az acr import`.
+- Deploy job must use `environment: production` (the OIDC federated credential's subject is `repo:fiscaltec/vitally-mcp:environment:production`).
+- OIDC only — no long-lived Azure credentials. The image carries no secrets (runtime secrets come from Key Vault).
+- Action pins follow the repo convention: `actions/checkout@v6`, `azure/login@v3`, `docker/login-action@v3`, `docker/build-push-action@v6`.
+- GHCR repo path must be lowercase; `github.repository` (`fiscaltec/vitally-mcp`) already is.
+- Fixed names (from repo vars/secrets, already set): ACR `vitallyproducruksouth`, RG `vitally-prod-rg-uksouth`, Container App `vitally-prod-ca-uksouth`, image `vitally-mcp`.
+- UK English; LF line endings. Build/run from repo root; do NOT prefix commands with `cd`.
+
+---
+
+### Task 1: Rework `deploy.yml` to the GHCR → import → update flow
+
+**Files:**
+- Modify (replace contents): `.github/workflows/deploy.yml`
+
+**Interfaces:**
+- Produces: a `workflow_dispatch` workflow named `Deploy` with a `deploy` job (no other task depends on it).
+
+- [ ] **Step 1: Replace the workflow**
+
+Overwrite `.github/workflows/deploy.yml` with:
+```yaml
+name: Deploy
+
+# Manual production deploy. The ACR has public network access disabled, so the image cannot be
+# built/pushed to it from a GitHub-hosted runner. Instead we build + push to a private GHCR package,
+# then `az acr import` (a server-side control-plane op that works with public access disabled) pulls
+# it into the private ACR, and `az containerapp update` rolls the app. OIDC auth as the user-assigned
+# managed identity (federated credential subject repo:fiscaltec/vitally-mcp:environment:production).
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/SHA) to deploy"
+        required: false
+        type: string
+      image_tag:
+        description: "Image tag to publish (default sha-<short-sha> of the chosen ref)"
+        required: false
+        type: string
+
+permissions:
+  id-token: write # OIDC token for azure/login
+  contents: read
+  packages: write # push to GHCR
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build, import to ACR, roll Container App
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      ACR_NAME: ${{ vars.ACR_NAME }}
+      RESOURCE_GROUP: ${{ vars.RESOURCE_GROUP }}
+      CONTAINER_APP: ${{ vars.CONTAINER_APP }}
+      IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+      HEALTH_URL: https://vitally.fiscaltec.com/health
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Resolve image tag and GHCR repo
+        id: vars
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.image_tag }}" ]; then
+            tag="${{ inputs.image_tag }}"
+          else
+            tag="sha-$(git rev-parse --short HEAD)"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "ghcr=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Import image into the private ACR (server-side)
+        run: |
+          set -euo pipefail
+          az config set extension.use_dynamic_install=yes_without_prompt
+          az acr import \
+            --name "$ACR_NAME" \
+            --source "${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}" \
+            --image "$IMAGE_NAME:${{ steps.vars.outputs.tag }}" \
+            --username "${{ github.actor }}" \
+            --password "${{ secrets.GITHUB_TOKEN }}" \
+            --force
+
+      - name: Update Container App revision
+        run: |
+          set -euo pipefail
+          az containerapp update \
+            --name "$CONTAINER_APP" \
+            --resource-group "$RESOURCE_GROUP" \
+            --image "$ACR_NAME.azurecr.io/$IMAGE_NAME:${{ steps.vars.outputs.tag }}"
+
+      - name: Verify new revision is healthy
+        run: |
+          set -euo pipefail
+          latest=$(az containerapp show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" \
+            --query "properties.latestRevisionName" -o tsv)
+          echo "Latest revision: $latest"
+          prov=""; health=""
+          for i in $(seq 1 12); do
+            prov=$(az containerapp revision show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" --revision "$latest" \
+              --query "properties.provisioningState" -o tsv 2>/dev/null || echo "")
+            health=$(az containerapp revision show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" --revision "$latest" \
+              --query "properties.healthState" -o tsv 2>/dev/null || echo "")
+            echo "attempt $i: provisioning=$prov health=$health"
+            if [ "$prov" = "Provisioned" ] && { [ "$health" = "Healthy" ] || [ "$health" = "None" ]; }; then
+              break
+            fi
+            sleep 15
+          done
+          if [ "$prov" != "Provisioned" ]; then
+            echo "::error::Revision $latest did not reach Provisioned (last: $prov / $health)"
+            exit 1
+          fi
+
+      - name: Smoke-check /health
+        run: |
+          set -euo pipefail
+          code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || echo "000")
+          echo "/health returned $code"
+          [ "$code" = "200" ] || { echo "::error::/health returned $code"; exit 1; }
+```
+
+Notes for the implementer:
+- `${GITHUB_REPOSITORY,,}` lowercases the repo path for GHCR (bash parameter expansion).
+- `az acr import --username/--password` are the **source** (GHCR) creds; `github.actor` + `GITHUB_TOKEN` can read the repo's own GHCR package. `--force` overwrites if the tag already exists.
+- `az config set extension.use_dynamic_install=yes_without_prompt` lets the `containerapp` az extension auto-install on the runner without prompting.
+- Do not add a `push:` trigger — SP3b decides automatic triggering. This stays manual.
+
+- [ ] **Step 2: Validate with actionlint**
+
+Run:
+```
+docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/deploy.yml
+```
+Expected: no errors. (If Docker is unavailable in the environment, say so and instead confirm the YAML parses with a YAML parser; do not skip silently.)
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add .github/workflows/deploy.yml
+git commit -m @'
+feat(deploy): private-ACR-aware deploy via GHCR + az acr import (SP3a)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01RWMtSydEfRwSpxDHNY9eH3
+'@
+```
+
+---
+
+## Final verification (controller — after Task 1 merge-ready)
+
+- [ ] `actionlint` clean (Task 1 Step 2).
+- [ ] Open a PR from `feature/sp3a-deploy-capability` into `main`; required checks pass (the `deploy`
+  job does not run on PR — it's `workflow_dispatch` only); resolve any Copilot/CodeQL threads; merge (squash).
+- [ ] **Assign the UAMI roles via az CLI** (scoped to the two resources):
+  ```
+  PRINCIPAL=c57b35e7-19b8-4d25-b762-321de5f4f0cb   # vitally-prod-id-uksouth principalId
+  ACR_ID=$(az acr show -n vitallyproducruksouth --query id -o tsv)
+  CA_ID=$(az containerapp show -g vitally-prod-rg-uksouth -n vitally-prod-ca-uksouth --query id -o tsv)
+  az role assignment create --assignee-object-id "$PRINCIPAL" --assignee-principal-type ServicePrincipal --role Contributor --scope "$ACR_ID"
+  az role assignment create --assignee-object-id "$PRINCIPAL" --assignee-principal-type ServicePrincipal --role Contributor --scope "$CA_ID"
+  ```
+  (Back-fill these into the Terraform repo afterwards.)
+- [ ] **Live deploy:** trigger the workflow against `main`
+  (`gh workflow run Deploy --ref main`), watch it: image builds + lands in GHCR; `az acr import`
+  places it in the private ACR; the Container App rolls to a new revision that reaches `Provisioned`;
+  `https://vitally.fiscaltec.com/health` returns 200. Confirm prod is now running the current build
+  (`az containerapp show -g vitally-prod-rg-uksouth -n vitally-prod-ca-uksouth --query
+  "properties.template.containers[0].image"` no longer shows `v4.0.16`).
+- [ ] If the deploy fails at import/update/health, capture the error, fix forward, and re-run; do not
+  weaken the ACR network posture to work around it.

--- a/docs/superpowers/specs/2026-06-29-sp3a-deploy-capability-design.md
+++ b/docs/superpowers/specs/2026-06-29-sp3a-deploy-capability-design.md
@@ -1,0 +1,119 @@
+# SP3a — Deploy capability (private-ACR-aware)
+
+**Date:** 2026-06-29
+**Status:** Design (approved) — ready for implementation plan.
+**Parent initiative:** Release & supply-chain automation. SP1 (scanning/gating, #59) and SP2
+(auto-merge, #60/#61) are done. SP3 (release train) is split:
+
+- **SP3a — deploy capability** (this spec): a working, push-button deploy of a chosen commit to
+  production, through the private-networked ACR. Delivers value alone (gets prod off the stale
+  `v4.0.16` image onto current `main`).
+- **SP3b — release-train orchestration** (later): scheduled trigger, semver tag + changelog, fuller
+  smoke test, held/abortable release + auto-rollback, layered on SP3a.
+
+## 1. Purpose
+
+`deploy.yml` exists but its `az acr build` step cannot run from a GitHub-hosted runner because the
+ACR (`vitallyproducruksouth`) has `publicNetworkAccess: Disabled` (Premium, private endpoint). The
+management plane (ARM) is public, so `az containerapp update` is fine, but the image can't be built
+or pushed from a public runner. SP3a reworks the deploy so the image reaches the private ACR via a
+server-side **`az acr import`**, giving a reliable manual deploy without weakening the private-network
+posture or standing up new in-VNet compute.
+
+## 2. Prerequisites already in place (from the OIDC groundwork, 2026-06-29)
+
+- Federated credential `github-actions-prod-env` on the reused runtime UAMI
+  `vitally-prod-id-uksouth` (clientId `d93687a0-ef76-4df8-804e-d941067abdeb`), subject
+  `repo:fiscaltec/vitally-mcp:environment:production`.
+- GitHub secrets `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`; vars `ACR_NAME`,
+  `RESOURCE_GROUP`, `CONTAINER_APP`, `IMAGE_NAME`.
+
+## 3. Deploy mechanism (decided): build → private GHCR → `az acr import` → update
+
+A GitHub-hosted runner builds the image and pushes it to a **private GHCR** package; `az acr import`
+(a control-plane operation that runs server-side and works even when the registry's public access is
+disabled) pulls it into the private ACR; then `az containerapp update` rolls the Container App, which
+pulls the new image in-VNet via its existing AcrPull on the UAMI. No new in-VNet compute; the
+private posture is unchanged. The built image transits a **private** GHCR package; no secrets are
+baked into the image (runtime secrets come from Key Vault).
+
+## 4. Workflow design (`.github/workflows/deploy.yml`, reworked)
+
+- **Trigger:** `workflow_dispatch` with inputs:
+  - `ref` (the git ref/branch/tag/SHA to deploy; default the default branch).
+  - `image_tag` (optional; default `sha-<short-sha>` of the checked-out ref).
+- **Job `deploy`:** `runs-on: ubuntu-latest`, `environment: production` (so the OIDC token subject
+  matches the federated credential and any environment protection applies).
+- **Permissions:** `id-token: write` (OIDC), `contents: read`, `packages: write` (GHCR push).
+- **Steps:**
+  1. `actions/checkout` at `inputs.ref`.
+  2. Resolve `IMAGE_TAG` (input or `sha-$(git rev-parse --short HEAD)`); compute lowercase GHCR repo
+     `ghcr.io/${{ github.repository }}` (GHCR requires a lowercase path).
+  3. Log in to GHCR (`docker/login-action` with `github.actor` + `GITHUB_TOKEN`) and build+push
+     `ghcr.io/<owner>/<repo>:<IMAGE_TAG>` from the repo `Dockerfile`.
+  4. `azure/login@v3` with the three Azure ids (OIDC).
+  5. `az acr import --name <ACR_NAME> --source ghcr.io/<owner>/<repo>:<IMAGE_TAG>
+     --image <IMAGE_NAME>:<IMAGE_TAG> --username <github.actor> --password <GITHUB_TOKEN>`
+     (`--force` so re-running the same tag overwrites rather than failing).
+  6. `az containerapp update -g <RESOURCE_GROUP> -n <CONTAINER_APP>
+     --image <ACR_NAME>.azurecr.io/<IMAGE_NAME>:<IMAGE_TAG>`.
+  7. **Post-deploy health check:** poll the Container App's latest revision until
+     `properties.runningState`/health is `Running`/healthy (bounded, e.g. ~10 attempts × 15s); fail
+     the job if it doesn't reach healthy. As a final confirmation, GET `https://vitally.fiscaltec.com/health`
+     and require HTTP 200.
+- **Concurrency:** `group: deploy-production`, `cancel-in-progress: false` (never interrupt an
+  in-flight deploy).
+
+Pin actions to the repo's existing major-version convention (`actions/checkout@v6`,
+`azure/login@v3`, `docker/login-action@v3`, `docker/build-push-action@v6`); Dependabot tracks them.
+
+## 5. UAMI role assignments (applied via az CLI by the controller)
+
+Scoped to the specific resources (not the resource group), least-privilege within the reuse choice:
+
+- **Contributor** on the ACR `vitallyproducruksouth` — `az acr import` needs
+  `Microsoft.ContainerRegistry/registries/importImage/action`, which `AcrPush` does not include;
+  Contributor does. (Custom role with just that action is a future hardening.)
+- **Contributor** on the Container App `vitally-prod-ca-uksouth` — for `Microsoft.App/containerApps/write`.
+
+**Recorded trade-off:** the UAMI is the *runtime* identity (reuse was chosen over a dedicated deploy
+identity), so the running container now also holds Contributor on the ACR + Container App — a wider
+blast radius. Acceptable per the reuse decision; a dedicated deploy identity remains an easy future
+hardening. Both assignments are applied via az CLI and should be **back-filled into the Terraform
+repo** (the team's az-then-Terraform pattern).
+
+## 6. Error handling
+
+- Build/push failures fail the run before any Azure mutation.
+- `az acr import` / `az containerapp update` failures fail the job loudly with the Azure error text.
+- The post-deploy health poll catches an image that deploys but won't start (bad config, broken
+  startup) — the job fails so the operator knows the live revision may be unhealthy. (Automatic
+  rollback to the previous image is SP3b.)
+
+## 7. Non-goals (YAGNI — deferred to SP3b)
+
+- Scheduled/automatic triggering (SP3a is manual `workflow_dispatch` only).
+- Semver tagging + changelog generation.
+- Fuller smoke test (MCP `initialize` / `tools/list`), held/abortable release, and automatic
+  rollback to the previous image on failure.
+- A dedicated deploy identity / custom least-privilege role (future hardening).
+- Terraform authoring of the role assignments here (back-fill happens in the Terraform repo).
+
+## 8. Testing / verification
+
+This is CI/CD + cloud glue, no unit-testable logic. Verification:
+
+- `actionlint` clean on the reworked `deploy.yml`.
+- **Live deploy:** run the workflow against `main`, confirm: the image builds and lands in GHCR;
+  `az acr import` places it in the private ACR (`az acr repository show-tags`); the Container App
+  rolls to the new revision and it reaches healthy; `https://vitally.fiscaltec.com/health` returns
+  200; and the live server reflects current `main` (no longer `v4.0.16`). This live deploy is the
+  acceptance proof.
+
+## 9. Acceptance criteria
+
+- `deploy.yml` (workflow_dispatch) builds → pushes to private GHCR → imports into the private ACR →
+  updates the Container App → verifies revision health + `/health` 200.
+- The UAMI holds Contributor on the ACR and the Container App (via az CLI).
+- A live deploy of `main` succeeds and moves prod off `v4.0.16` onto the current build.
+- `actionlint` clean; the private-network posture is unchanged (ACR public access stays Disabled).


### PR DESCRIPTION
## What & why

SP3a of the release-automation initiative — a working **push-button production deploy** that works through the **private-networked ACR** (`publicNetworkAccess: Disabled`), which `deploy.yml`'s old `az acr build` step couldn't do from a GitHub-hosted runner.

## Mechanism (build → GHCR → `az acr import` → update)

Reworked `deploy.yml` (`workflow_dispatch`, `environment: production`, OIDC):
1. Build the image and push to a **private GHCR** package.
2. `az acr import` (server-side control-plane op — works with ACR public access disabled) pulls it into the private ACR.
3. `az containerapp update` rolls the Container App (which pulls in-VNet via its existing AcrPull).
4. Health-poll the new revision + a `https://vitally.fiscaltec.com/health` 200 smoke-check.

No new in-VNet compute; the private posture is unchanged; OIDC only (no long-lived creds); the image carries no secrets.

## Notes

- OIDC was wired earlier (federated credential on the runtime UAMI, subject `…:environment:production`; repo secrets/vars set).
- **Deploy roles** (Contributor on the ACR + Container App for the UAMI) are applied via `az` post-merge, before the first live deploy — not in this diff.
- The `deploy` job is `workflow_dispatch`-only, so it does **not** run on this PR.
- Review follow-up applied: `image_tag` input is passed via `env` + charset-validated (no shell injection).

## Deferred to SP3b

Scheduled trigger, semver tag + changelog, fuller smoke test (MCP `initialize`), held/abortable release + auto-rollback.

actionlint clean. Spec: `docs/superpowers/specs/2026-06-29-sp3a-deploy-capability-design.md` · Plan: `docs/superpowers/plans/2026-06-29-sp3a-deploy-capability.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
