### PR TITLE
chore(terraform): back-fill deploy OIDC credential + Contributor roles

### DIFF
--- a/infra/terraform/identity.tf
+++ b/infra/terraform/identity.tf
@@ -30,3 +30,30 @@ resource "azurerm_role_assignment" "mi_cmk_crypto" {
 # GroupMember.Read.All (for the live group-membership check). Graph app-role grants are
 # not managed here — assign via Graph/PowerShell or azuread_app_role_assignment in a
 # separate Entra-scoped config.
+
+# CI/CD (GitHub Actions OIDC): GitHub authenticates as this identity to deploy. The federated
+# credential subject matches the deploy workflow's `environment: production` job, so only that
+# environment can mint a token. Audience is the value azure/login requests by default.
+resource "azurerm_federated_identity_credential" "github_actions_prod" {
+  name                = "github-actions-prod-env"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  parent_id           = azurerm_user_assigned_identity.app.id
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = "https://token.actions.githubusercontent.com"
+  subject             = "repo:fiscaltec/vitally-mcp:environment:production"
+}
+
+# Deploy: `az acr import` the built image into the private ACR. AcrPush does NOT include the
+# importImage action, so the deploy identity needs Contributor on the registry.
+resource "azurerm_role_assignment" "mi_acr_contributor" {
+  scope                = azurerm_container_registry.acr.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.app.principal_id
+}
+
+# Deploy: roll the Container App to the new revision (`az containerapp update`).
+resource "azurerm_role_assignment" "mi_ca_contributor" {
+  scope                = azurerm_container_app.app.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.app.principal_id
+}

--- a/infra/terraform/imports.tf
+++ b/infra/terraform/imports.tf
@@ -155,6 +155,21 @@ import {
   id = "/subscriptions/${var.subscription_id}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_uksouth/flowLogs/vitally-prod-vnetflow-uksouth"
 }
 
+# ---- 2026-06-29: CI/CD deploy via GitHub OIDC (SP3a) ----
+# Applied to the live estate via az CLI / az rest; bring under management with these imports.
+import {
+  to = azurerm_federated_identity_credential.github_actions_prod
+  id = "${local.rg_id}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/vitally-prod-id-uksouth/federatedIdentityCredentials/github-actions-prod-env"
+}
+import {
+  to = azurerm_role_assignment.mi_acr_contributor
+  id = "${local.rg_id}/providers/Microsoft.ContainerRegistry/registries/vitallyproducruksouth/providers/Microsoft.Authorization/roleAssignments/bef82daa-b884-45bc-b943-d70efb4854f2"
+}
+import {
+  to = azurerm_role_assignment.mi_ca_contributor
+  id = "${local.rg_id}/providers/Microsoft.App/containerApps/vitally-prod-ca-uksouth/providers/Microsoft.Authorization/roleAssignments/ca439f5e-c348-48de-b515-8b5ced858f00"
+}
+
 # ---- Need a looked-up ID first (uncomment + fill in, then plan) ----
 # Diagnostic settings:  import id = "<target-resource-id>|to-law"
 # Role assignments:     az role assignment list --scope <scope> --query "[].id"  → import "<assignment-id>"


### PR DESCRIPTION
Back-fills into the in-repo Terraform the three IAM resources created live (via az / az rest) for SP3a's deploy:

- **`azurerm_federated_identity_credential.github_actions_prod`** on the runtime UAMI — GitHub OIDC, subject `repo:fiscaltec/vitally-mcp:environment:production`.
- **`azurerm_role_assignment.mi_acr_contributor`** — Contributor on the ACR (for `az acr import`; AcrPush lacks the importImage action).
- **`azurerm_role_assignment.mi_ca_contributor`** — Contributor on the Container App (for `az containerapp update`).

Each has a matching **import block** in `imports.tf` (with the real live resource IDs) so `terraform plan` *adopts* the existing resources rather than recreating them — consistent with the repo's adoption-via-import approach.

`terraform fmt` clean; `terraform validate` passes (Success! The configuration is valid).

Follow-up to the SP3a deploy work (#64) and the OIDC/role setup done via az CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)