### PR TITLE
feat(release): nightly release train — version, GitHub Release, deploy (SP3b)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,10 @@ jobs:
           prev=$(az containerapp show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" \
             --query "properties.template.containers[0].image" -o tsv)
           echo "Previous image: $prev"
+          if [ -z "$prev" ]; then
+            echo "::error::Could not determine the current image; aborting before deploy so rollback stays possible."
+            exit 1
+          fi
           echo "PREV_IMAGE=$prev" >> "$GITHUB_ENV"
 
       - name: Import image into the private ACR (server-side)
@@ -143,8 +147,8 @@ jobs:
             fi
             sleep 15
           done
-          if [ "$prov" != "Provisioned" ]; then
-            echo "::error::Revision $latest did not reach Provisioned (last state: $prov)"
+          if [ "$prov" != "Provisioned" ] || { [ "$health" != "Healthy" ] && [ "$health" != "None" ]; }; then
+            echo "::error::Revision $latest did not become healthy (provisioning=$prov health=$health)"
             exit 1
           fi
           # Smoke: /health must be 200; unauthenticated /mcp must be 401 (app live + Auth0 gate enforced).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,24 @@
 name: Deploy
 
-# Manual production deploy. The ACR has public network access disabled, so the image cannot be
-# built/pushed to it from a GitHub-hosted runner. Instead we build + push to a private GHCR package,
-# then `az acr import` (a server-side control-plane op that works with public access disabled) pulls
-# it into the private ACR, and `az containerapp update` rolls the app. OIDC auth as the user-assigned
-# managed identity (federated credential subject repo:fiscaltec/vitally-mcp:environment:production).
+# Production deploy. The ACR has public network access disabled, so the image cannot be built/pushed
+# to it from a GitHub-hosted runner. Instead we build + push to a private GHCR package, then
+# `az acr import` (server-side, works with public access disabled) pulls it into the private ACR, and
+# `az containerapp update` rolls the app. OIDC auth as the user-assigned managed identity (federated
+# credential subject repo:fiscaltec/vitally-mcp:environment:production). Callable manually
+# (workflow_dispatch) or by the release train (workflow_call). On a failed health/smoke check it rolls
+# the Container App back to the previous image.
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/SHA) to deploy"
+        required: false
+        type: string
+      image_tag:
+        description: "Image tag to publish (default sha-<short-sha> of the chosen ref)"
+        required: false
+        type: string
+  workflow_call:
     inputs:
       ref:
         description: "Git ref (branch/tag/SHA) to deploy"
@@ -37,6 +49,7 @@ jobs:
       CONTAINER_APP: ${{ vars.CONTAINER_APP }}
       IMAGE_NAME: ${{ vars.IMAGE_NAME }}
       HEALTH_URL: https://vitally.fiscaltec.com/health
+      MCP_URL: https://vitally.fiscaltec.com/mcp
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -45,9 +58,6 @@ jobs:
 
       - name: Resolve image tag and GHCR repo
         id: vars
-        # The input is passed via env (not inlined as ${{ }}) to avoid shell injection, and the
-        # resolved tag is validated against the container-tag charset so it is safe to interpolate
-        # into the later az/docker steps.
         env:
           INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
@@ -86,10 +96,18 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Import image into the private ACR (server-side)
+      - name: Capture current image (for rollback)
         run: |
           set -euo pipefail
           az config set extension.use_dynamic_install=yes_without_prompt
+          prev=$(az containerapp show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" \
+            --query "properties.template.containers[0].image" -o tsv)
+          echo "Previous image: $prev"
+          echo "PREV_IMAGE=$prev" >> "$GITHUB_ENV"
+
+      - name: Import image into the private ACR (server-side)
+        run: |
+          set -euo pipefail
           az acr import \
             --name "$ACR_NAME" \
             --source "${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}" \
@@ -106,13 +124,13 @@ jobs:
             --resource-group "$RESOURCE_GROUP" \
             --image "$ACR_NAME.azurecr.io/$IMAGE_NAME:${{ steps.vars.outputs.tag }}"
 
-      - name: Verify new revision is healthy
+      - name: Verify deployment (revision health + smoke)
         run: |
           set -euo pipefail
           latest=$(az containerapp show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" \
             --query "properties.latestRevisionName" -o tsv)
           echo "Latest revision: $latest"
-          prov=""; health=""
+          prov=""
           for i in $(seq 1 12); do
             prov=$(az containerapp revision show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" --revision "$latest" \
               --query "properties.provisioningState" -o tsv 2>/dev/null || echo "")
@@ -125,13 +143,26 @@ jobs:
             sleep 15
           done
           if [ "$prov" != "Provisioned" ]; then
-            echo "::error::Revision $latest did not reach Provisioned (last: $prov / $health)"
+            echo "::error::Revision $latest did not reach Provisioned (last state: $prov)"
             exit 1
           fi
+          # Smoke: /health must be 200; unauthenticated /mcp must be 401 (app live + Auth0 gate enforced).
+          health_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || echo "000")
+          echo "/health -> $health_code"
+          [ "$health_code" = "200" ] || { echo "::error::/health returned $health_code"; exit 1; }
+          mcp_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -X POST "$MCP_URL" \
+            -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' || echo "000")
+          echo "/mcp (unauthenticated) -> $mcp_code"
+          [ "$mcp_code" = "401" ] || { echo "::error::/mcp unauthenticated returned $mcp_code (expected 401)"; exit 1; }
 
-      - name: Smoke-check /health
+      - name: Roll back on failure
+        if: ${{ failure() && env.PREV_IMAGE != '' }}
         run: |
           set -euo pipefail
-          code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || echo "000")
-          echo "/health returned $code"
-          [ "$code" = "200" ] || { echo "::error::/health returned $code"; exit 1; }
+          echo "::warning::Deploy verification failed — rolling back to $PREV_IMAGE"
+          az containerapp update \
+            --name "$CONTAINER_APP" \
+            --resource-group "$RESOURCE_GROUP" \
+            --image "$PREV_IMAGE"
+          echo "::error::Deploy failed and was rolled back to $PREV_IMAGE"
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,6 +131,7 @@ jobs:
             --query "properties.latestRevisionName" -o tsv)
           echo "Latest revision: $latest"
           prov=""
+          health=""
           for i in $(seq 1 12); do
             prov=$(az containerapp revision show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" --revision "$latest" \
               --query "properties.provisioningState" -o tsv 2>/dev/null || echo "")

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       MCP_URL: https://vitally.fiscaltec.com/mcp
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+# Nightly release train: if main changed since the last tag, compute the next semver from
+# conventional commits, create the tag + a GitHub Release (the changelog), and deploy it via the
+# reusable deploy workflow. Fully automatic; the deploy self-rolls-back on a failed smoke test.
+on:
+  schedule:
+    - cron: "0 2 * * *" # 02:00 UTC nightly
+  workflow_dispatch:
+
+permissions:
+  contents: write # create tag + GitHub Release
+
+concurrency:
+  group: release-train
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Cut version + GitHub Release
+    runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag.outputs.new_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute and create tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
+          custom_release_rules: "feat:minor,fix:patch,build:patch,ci:patch,chore:patch,refactor:patch,perf:patch"
+
+      - name: Create GitHub Release
+        if: ${{ steps.tag.outputs.new_tag != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+          gh release create "$NEW_TAG" --generate-notes --latest
+
+  deploy:
+    needs: release
+    if: ${{ needs.release.outputs.new_tag != '' }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      ref: ${{ needs.release.outputs.new_tag }}
+      image_tag: ${{ needs.release.outputs.new_tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,8 @@ on:
     - cron: "0 2 * * *" # 02:00 UTC nightly
   workflow_dispatch:
 
-permissions:
-  contents: write # create tag + GitHub Release
-
+# Permissions are set per-job: a reusable workflow's token is CAPPED by the caller, so the deploy
+# job must itself grant id-token/packages or the called deploy.yml would be denied them at runtime.
 concurrency:
   group: release-train
   cancel-in-progress: false
@@ -19,6 +18,8 @@ jobs:
   release:
     name: Cut version + GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create tag + GitHub Release
     outputs:
       new_tag: ${{ steps.tag.outputs.new_tag }}
     steps:
@@ -47,6 +48,10 @@ jobs:
   deploy:
     needs: release
     if: ${{ needs.release.outputs.new_tag != '' }}
+    permissions:
+      id-token: write # OIDC for azure/login in the called deploy
+      contents: read
+      packages: write # GHCR push in the called deploy
     uses: ./.github/workflows/deploy.yml
     with:
       ref: ${{ needs.release.outputs.new_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       new_tag: ${{ steps.tag.outputs.new_tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/docs/superpowers/plans/2026-06-29-sp3b-release-train.md
+++ b/docs/superpowers/plans/2026-06-29-sp3b-release-train.md
@@ -1,0 +1,332 @@
+# SP3b — Release train — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A nightly release train that cuts a semver tag + GitHub Release from conventional commits on `main` and deploys it, on top of a hardened, reusable, self-rolling-back `deploy.yml`.
+
+**Architecture:** Task 1 makes `deploy.yml` callable (`workflow_call`) and self-protecting (capture previous image → deploy → health+smoke → auto-rollback on failure). Task 2 adds `release.yml`: a nightly scheduled job computes the next version from conventional commits, creates the tag + GitHub Release, then calls the reusable `deploy.yml` with the new tag.
+
+**Tech Stack:** GitHub Actions (reusable workflows, `schedule`), `mathieudutour/github-tag-action`, `gh release create --generate-notes`, Azure CLI, OIDC, GHCR.
+
+## Global Constraints
+
+- ACR public access is Disabled — image reaches ACR only via server-side `az acr import` (unchanged from SP3a). Never weaken that.
+- Deploy job keeps `environment: production` (OIDC federated subject `repo:fiscaltec/vitally-mcp:environment:production`).
+- Fully automatic: no manual approval gate. Safety = pre-merge CI + post-deploy smoke + auto-rollback.
+- Versioning from conventional commits since the last tag; **dependency commits must release** — `feat`→minor, `fix`/`build`/`ci`/`chore`/`refactor`/`perf`→patch, breaking→major, no-bump otherwise.
+- Changelog lives in the **GitHub Release** (`--generate-notes`); do NOT commit `CHANGELOG.md` to `main` (the ruleset has no bypass actor — a workflow can't push to `main`).
+- Tag prefix `v` (matches existing `v4.0.12`).
+- Action pins follow the repo convention (`actions/checkout@v6`, `azure/login@v3`, `docker/login-action@v3`, `docker/build-push-action@v6`); verify any NEW action's latest release tag before pinning (learned from a wrong-version pin earlier).
+- UK English; LF line endings. Build/run from repo root; do NOT prefix commands with `cd`. Docker is available for `actionlint` (use `MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd -W):/repo" -w /repo rhysd/actionlint:latest -color <file>`).
+
+---
+
+### Task 1: Harden `deploy.yml` — reusable + capture/smoke/rollback
+
+**Files:**
+- Modify (replace contents): `.github/workflows/deploy.yml`
+
+**Interfaces:**
+- Produces: `deploy.yml` gains `on: workflow_call` (inputs `ref`, `image_tag`) so `release.yml` (Task 2) can `uses: ./.github/workflows/deploy.yml` with `secrets: inherit`.
+
+- [ ] **Step 1: Replace the workflow**
+
+Overwrite `.github/workflows/deploy.yml` with (this preserves the SP3a flow and adds `workflow_call`, previous-image capture, the `/mcp` smoke, and the rollback step):
+```yaml
+name: Deploy
+
+# Production deploy. The ACR has public network access disabled, so the image cannot be built/pushed
+# to it from a GitHub-hosted runner. Instead we build + push to a private GHCR package, then
+# `az acr import` (server-side, works with public access disabled) pulls it into the private ACR, and
+# `az containerapp update` rolls the app. OIDC auth as the user-assigned managed identity (federated
+# credential subject repo:fiscaltec/vitally-mcp:environment:production). Callable manually
+# (workflow_dispatch) or by the release train (workflow_call). On a failed health/smoke check it rolls
+# the Container App back to the previous image.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/SHA) to deploy"
+        required: false
+        type: string
+      image_tag:
+        description: "Image tag to publish (default sha-<short-sha> of the chosen ref)"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/SHA) to deploy"
+        required: false
+        type: string
+      image_tag:
+        description: "Image tag to publish (default sha-<short-sha> of the chosen ref)"
+        required: false
+        type: string
+
+permissions:
+  id-token: write # OIDC token for azure/login
+  contents: read
+  packages: write # push to GHCR
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build, import to ACR, roll Container App
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      ACR_NAME: ${{ vars.ACR_NAME }}
+      RESOURCE_GROUP: ${{ vars.RESOURCE_GROUP }}
+      CONTAINER_APP: ${{ vars.CONTAINER_APP }}
+      IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+      HEALTH_URL: https://vitally.fiscaltec.com/health
+      MCP_URL: https://vitally.fiscaltec.com/mcp
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Resolve image tag and GHCR repo
+        id: vars
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_IMAGE_TAG" ]; then
+            tag="$INPUT_IMAGE_TAG"
+          else
+            tag="sha-$(git rev-parse --short HEAD)"
+          fi
+          if ! printf '%s' "$tag" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+            echo "::error::Invalid image tag '$tag' (allowed characters: A-Za-z0-9._-)"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "ghcr=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Capture current image (for rollback)
+        run: |
+          set -euo pipefail
+          az config set extension.use_dynamic_install=yes_without_prompt
+          prev=$(az containerapp show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" \
+            --query "properties.template.containers[0].image" -o tsv)
+          echo "Previous image: $prev"
+          echo "PREV_IMAGE=$prev" >> "$GITHUB_ENV"
+
+      - name: Import image into the private ACR (server-side)
+        run: |
+          set -euo pipefail
+          az acr import \
+            --name "$ACR_NAME" \
+            --source "${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}" \
+            --image "$IMAGE_NAME:${{ steps.vars.outputs.tag }}" \
+            --username "${{ github.actor }}" \
+            --password "${{ secrets.GITHUB_TOKEN }}" \
+            --force
+
+      - name: Update Container App revision
+        run: |
+          set -euo pipefail
+          az containerapp update \
+            --name "$CONTAINER_APP" \
+            --resource-group "$RESOURCE_GROUP" \
+            --image "$ACR_NAME.azurecr.io/$IMAGE_NAME:${{ steps.vars.outputs.tag }}"
+
+      - name: Verify deployment (revision health + smoke)
+        run: |
+          set -euo pipefail
+          latest=$(az containerapp show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" \
+            --query "properties.latestRevisionName" -o tsv)
+          echo "Latest revision: $latest"
+          prov=""
+          for i in $(seq 1 12); do
+            prov=$(az containerapp revision show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" --revision "$latest" \
+              --query "properties.provisioningState" -o tsv 2>/dev/null || echo "")
+            health=$(az containerapp revision show -g "$RESOURCE_GROUP" -n "$CONTAINER_APP" --revision "$latest" \
+              --query "properties.healthState" -o tsv 2>/dev/null || echo "")
+            echo "attempt $i: provisioning=$prov health=$health"
+            if [ "$prov" = "Provisioned" ] && { [ "$health" = "Healthy" ] || [ "$health" = "None" ]; }; then
+              break
+            fi
+            sleep 15
+          done
+          if [ "$prov" != "Provisioned" ]; then
+            echo "::error::Revision $latest did not reach Provisioned (last state: $prov)"
+            exit 1
+          fi
+          # Smoke: /health must be 200; unauthenticated /mcp must be 401 (app live + Auth0 gate enforced).
+          health_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || echo "000")
+          echo "/health -> $health_code"
+          [ "$health_code" = "200" ] || { echo "::error::/health returned $health_code"; exit 1; }
+          mcp_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -X POST "$MCP_URL" \
+            -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' || echo "000")
+          echo "/mcp (unauthenticated) -> $mcp_code"
+          [ "$mcp_code" = "401" ] || { echo "::error::/mcp unauthenticated returned $mcp_code (expected 401)"; exit 1; }
+
+      - name: Roll back on failure
+        if: ${{ failure() && env.PREV_IMAGE != '' }}
+        run: |
+          set -euo pipefail
+          echo "::warning::Deploy verification failed — rolling back to $PREV_IMAGE"
+          az containerapp update \
+            --name "$CONTAINER_APP" \
+            --resource-group "$RESOURCE_GROUP" \
+            --image "$PREV_IMAGE"
+          echo "::error::Deploy failed and was rolled back to $PREV_IMAGE"
+          exit 1
+```
+
+Notes:
+- The rollback step's `if: ${{ failure() && env.PREV_IMAGE != '' }}` runs only when a prior step failed AND the previous image was captured — so a pre-capture failure (e.g. build) doesn't attempt a rollback. Its trailing `exit 1` keeps the job red after rolling back.
+- `/mcp` unauthenticated returns 401 because the endpoint requires a Bearer token (JwtBearer + `RequireAuthorization`). If the live check ever shows a different code, the controller adjusts the expected value — do not relax it speculatively.
+
+- [ ] **Step 2: Validate with actionlint**
+
+Run: `MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd -W):/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/deploy.yml`
+Expected: exit 0, no errors. (If Docker is down, say so and confirm the YAML parses with `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"`.)
+
+- [ ] **Step 3: Commit**
+
+```powershell
+git add .github/workflows/deploy.yml
+git commit -m @'
+feat(deploy): make deploy reusable + add smoke test and auto-rollback (SP3b)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01RWMtSydEfRwSpxDHNY9eH3
+'@
+```
+
+---
+
+### Task 2: `release.yml` — nightly version + deploy
+
+**Files:**
+- Create: `.github/workflows/release.yml`
+
+**Interfaces:**
+- Consumes: the reusable `deploy.yml` from Task 1 (`workflow_call`, inputs `ref`/`image_tag`).
+
+- [ ] **Step 1: Verify the tag action's current version**
+
+The release step uses `mathieudutour/github-tag-action`. Confirm its latest release tag before pinning:
+`gh release view -R mathieudutour/github-tag-action --json tagName -q .tagName` (at time of writing `v6.2`). Use whatever it returns as the pin in Step 2 (do NOT guess — a wrong pin fails the run, as happened with a different action earlier).
+
+- [ ] **Step 2: Create the workflow**
+
+Create `.github/workflows/release.yml` (replace `@v6.2` with the verified latest tag from Step 1 if different):
+```yaml
+name: Release
+
+# Nightly release train: if main changed since the last tag, compute the next semver from
+# conventional commits, create the tag + a GitHub Release (the changelog), and deploy it via the
+# reusable deploy workflow. Fully automatic; the deploy self-rolls-back on a failed smoke test.
+on:
+  schedule:
+    - cron: "0 2 * * *" # 02:00 UTC nightly
+  workflow_dispatch:
+
+permissions:
+  contents: write # create tag + GitHub Release
+
+concurrency:
+  group: release-train
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Cut version + GitHub Release
+    runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag.outputs.new_tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute and create tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
+          custom_release_rules: "feat:minor,fix:patch,build:patch,ci:patch,chore:patch,refactor:patch,perf:patch"
+
+      - name: Create GitHub Release
+        if: ${{ steps.tag.outputs.new_tag != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+          gh release create "$NEW_TAG" --generate-notes --latest
+
+  deploy:
+    needs: release
+    if: ${{ needs.release.outputs.new_tag != '' }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      ref: ${{ needs.release.outputs.new_tag }}
+      image_tag: ${{ needs.release.outputs.new_tag }}
+    secrets: inherit
+```
+
+Notes:
+- `default_bump: false` means a night with no releasable commits (e.g. docs-only) creates no tag → `new_tag` is empty → the Release and deploy steps/jobs are skipped (nothing to release).
+- The custom rules make `build`/`ci`/`chore` (dependency/security PRs) a patch bump, so auto-merged updates do reach prod.
+- `default tag_prefix` is `v`, matching `v4.0.12`.
+- The `deploy` job calls the reusable `deploy.yml`; `secrets: inherit` passes `AZURE_*` + `GITHUB_TOKEN`. `deploy.yml` declares its own `id-token`/`packages` permissions for the called job.
+
+- [ ] **Step 3: Validate with actionlint**
+
+Run: `MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd -W):/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/release.yml`
+Expected: exit 0, no errors. (Docker-down fallback: YAML parse as in Task 1.)
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add .github/workflows/release.yml
+git commit -m @'
+feat(release): nightly release train — version, GitHub Release, deploy (SP3b)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01RWMtSydEfRwSpxDHNY9eH3
+'@
+```
+
+---
+
+## Final verification (controller — after both tasks merge-ready)
+
+- [ ] `actionlint` clean on both workflows.
+- [ ] Open a PR from `feature/sp3b-release-train` into `main`; required checks pass (neither workflow runs on PR — `deploy` is dispatch/call only, `release` is schedule/dispatch); resolve any Copilot/CodeQL threads; merge (squash).
+- [ ] **Live proof:** `gh workflow run Release --ref main`, then watch: the `release` job computes the next tag (a **minor** bump past `v4.0.12` — there are `feat`s on main, expect `v4.1.0`), creates the GitHub Release with generated notes, and the `deploy` job deploys that tag through the hardened `deploy.yml`. Confirm: a new tag + GitHub Release exist (`gh release list`); prod is running the new tag (`az containerapp show … --query "properties.template.containers[0].image"`); the deploy's `/health` (200) and `/mcp` (401) smoke both passed in the run log; no rollback fired.
+- [ ] If the `/mcp` smoke returns a code other than 401 against the (known-good) freshly-deployed image, correct the expected code in `deploy.yml` (fix-forward) rather than leaving a false-rollback path.

--- a/docs/superpowers/plans/2026-06-29-sp3b-release-train.md
+++ b/docs/superpowers/plans/2026-06-29-sp3b-release-train.md
@@ -16,7 +16,7 @@
 - Versioning from conventional commits since the last tag; **dependency commits must release** — `feat`→minor, `fix`/`build`/`ci`/`chore`/`refactor`/`perf`→patch, breaking→major, no-bump otherwise.
 - Changelog lives in the **GitHub Release** (`--generate-notes`); do NOT commit `CHANGELOG.md` to `main` (the ruleset has no bypass actor — a workflow can't push to `main`).
 - Tag prefix `v` (matches existing `v4.0.12`).
-- Action pins follow the repo convention (`actions/checkout@v6`, `azure/login@v3`, `docker/login-action@v3`, `docker/build-push-action@v6`); verify any NEW action's latest release tag before pinning (learned from a wrong-version pin earlier).
+- Action pins follow the repo convention (`actions/checkout@v7`, `azure/login@v3`, `docker/login-action@v3`, `docker/build-push-action@v6`); verify any NEW action's latest release tag before pinning (learned from a wrong-version pin earlier).
 - UK English; LF line endings. Build/run from repo root; do NOT prefix commands with `cd`. Docker is available for `actionlint` (use `MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd -W):/repo" -w /repo rhysd/actionlint:latest -color <file>`).
 
 ---
@@ -87,7 +87,7 @@ jobs:
       MCP_URL: https://vitally.fiscaltec.com/mcp
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -268,7 +268,7 @@ jobs:
       new_tag: ${{ steps.tag.outputs.new_tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/docs/superpowers/specs/2026-06-29-sp3b-release-train-design.md
+++ b/docs/superpowers/specs/2026-06-29-sp3b-release-train-design.md
@@ -1,0 +1,123 @@
+# SP3b — Release train (scheduled version + deploy)
+
+**Date:** 2026-06-29
+**Status:** Design (approved) — ready for implementation plan.
+**Parent initiative:** Release & supply-chain automation. The final sub-project. SP1 (scanning/gating,
+#59), SP2 (auto-merge + grouping, #60/#61), SP3a (deploy capability, #64) and the Terraform back-fill
+(#65) are done. SP3b layers the scheduled, versioned, self-verifying release on top of SP3a's deploy.
+
+## 1. Purpose
+
+SP3a gave a working manual deploy. SP3b makes releases **automatic**: a nightly job cuts a versioned
+release of `main` (semver tag + GitHub Release notes from conventional commits) and deploys it, with
+a post-deploy smoke test and automatic rollback. Combined with SP1/SP2, merged changes — including
+auto-merged dependency/security updates — reach production within about a day, hands-off, with a
+safety net.
+
+## 2. Decisions
+
+- **Cadence:** nightly (only releases when `main` changed since the last release).
+- **Approval:** fully automatic — no human gate; safety is the pre-merge CI gate + a post-deploy
+  smoke test + automatic rollback to the previous image on failure.
+- **Versioning:** semver derived from conventional commits since the last tag.
+
+## 3. Part 1 — Harden `deploy.yml` (reusable + self-protecting)
+
+Extend the existing `deploy.yml` (do not replace its SP3a behaviour):
+
+- **Add `on: workflow_call`** with the same inputs (`ref`, `image_tag`) alongside the existing
+  `workflow_dispatch`, so `release.yml` can call it (`uses: ./.github/workflows/deploy.yml`,
+  `secrets: inherit`). The job keeps `environment: production` and the existing permissions.
+- **Capture the current image** before `az containerapp update`:
+  `PREV_IMAGE=$(az containerapp show … --query "properties.template.containers[0].image" -o tsv)`.
+- **Fuller smoke test** (after the existing revision-health poll), all bounded with `--max-time`:
+  - `GET https://vitally.fiscaltec.com/health` → require **200**.
+  - unauthenticated `POST https://vitally.fiscaltec.com/mcp` (JSON body) → require **401** (proves the
+    MCP endpoint is live *and* the Auth0 gate is enforced; needs no token/secret).
+- **Auto-rollback:** if the health poll or either smoke check fails, run
+  `az containerapp update --image "$PREV_IMAGE"` to roll back, then `exit 1` so the run fails loudly.
+  Single-revision replace is accepted (brief unhealthy window on a bad deploy); zero-downtime
+  multi-revision traffic-splitting is a non-goal.
+
+The rollback + smoke live in `deploy.yml` so they protect **both** manual dispatch and the scheduled
+train.
+
+## 4. Part 2 — `release.yml` (the nightly train)
+
+New `.github/workflows/release.yml`:
+
+- **Triggers:** `schedule` nightly at `0 2 * * *` UTC + `workflow_dispatch` (ad-hoc/testing).
+- **Permissions:** `contents: write` (create tag + GitHub Release). The deploy is delegated to
+  `deploy.yml` (which declares its own `id-token`/`packages` permissions for the called job).
+- **Concurrency:** `group: release-train`, `cancel-in-progress: false`.
+- **Job `release`** (`runs-on: ubuntu-latest`):
+  1. `actions/checkout` with `fetch-depth: 0` (full history + tags).
+  2. **Compute + create the next tag** with `mathieudutour/github-tag-action` (pinned; Dependabot
+     tracks it), configured with custom release rules so dependency commits still release:
+     `feat`→minor, `fix`/`build`/`ci`/`chore`/`refactor`/`perf`→patch, breaking→major,
+     `default_bump: false`. It outputs `new_tag` / `new_version` / `previous_tag`. If `new_tag` is
+     empty (no releasable commits since the last tag), the remaining steps are skipped — nothing to
+     release.
+  3. **Create the GitHub Release** for `new_tag` with auto-generated notes:
+     `gh release create "$NEW_TAG" --generate-notes --latest`. The Release body is the canonical
+     changelog; `CHANGELOG.md` is **not** committed to `main` (the ruleset has no bypass actor, so a
+     workflow cannot push to `main`).
+  4. **Deploy `new_tag`** via a second job that `needs: release`, guarded on `new_tag != ''`, calling
+     the reusable deploy:
+     ```yaml
+     deploy:
+       needs: release
+       if: ${{ needs.release.outputs.new_tag != '' }}
+       uses: ./.github/workflows/deploy.yml
+       with:
+         ref: ${{ needs.release.outputs.new_tag }}
+         image_tag: ${{ needs.release.outputs.new_tag }}
+       secrets: inherit
+     ```
+     (The `release` job exposes `new_tag` as a job output.)
+
+## 5. Versioning rules rationale
+
+Dependency/security updates arrive as `build:`/`ci:`/`chore:` commits (Dependabot + the grouping from
+SP2). The default semantic-release ruleset would NOT bump on those, so a week of only-dependency
+updates would never release — defeating the vuln-remediation goal. The custom rules therefore make
+those types a **patch** bump so every artifact-affecting merge produces a release. `docs:`/`style:`
+need not bump (no artifact change); the action's `default_bump: false` means an all-docs night
+produces no release, which is correct.
+
+## 6. Error handling
+
+- Tag/release-creation failure fails the `release` job before any deploy.
+- The deploy's own health-poll + smoke + auto-rollback handle a bad image (Part 1).
+- A failed nightly run is visible in Actions. Wiring a proactive alert (e.g. the Teams webhook the
+  `vitally-prod-secscan` job already uses) is noted as a future follow-up, not built here.
+
+## 7. Testing / verification
+
+CI/CD + cloud glue; no unit-testable logic. Verification:
+
+- `actionlint` clean on both `deploy.yml` and `release.yml`.
+- **Live proof:** a manual `workflow_dispatch` of `release.yml` — it should compute the first
+  auto-release (a **minor** bump past `v4.0.12`, since there are `feat`s on `main`), publish the
+  GitHub Release with generated notes, then deploy that tag through the hardened `deploy.yml`
+  (exercising the new prev-image capture, `/health` + `/mcp` 401 smoke, and — only if it failed — the
+  rollback). Confirm prod is running the new tag and `/health` is 200.
+
+## 8. Non-goals (YAGNI)
+
+- Committing `CHANGELOG.md` back to `main` (blocked by the ruleset; the GitHub Release is the
+  changelog).
+- Zero-downtime multi-revision traffic-splitting / canary (single-revision replace + rollback suffices).
+- A bespoke alerting/notification integration (noted for later).
+- A manual approval gate (explicitly chosen against — fully automatic).
+- Per-environment (staging) promotion — single prod environment only.
+
+## 9. Acceptance criteria
+
+- `deploy.yml` is callable via `workflow_call`, captures the previous image, runs the `/health` +
+  `/mcp` 401 smoke, and rolls back to the previous image on health/smoke failure.
+- `release.yml` runs nightly + on dispatch; when `main` changed it creates a semver tag (dependency
+  commits included in the bump rules) + a GitHub Release with notes, and deploys that tag; when `main`
+  is unchanged since the last tag it does nothing.
+- `actionlint` clean; a live dispatch produces the first auto-release and deploys it with the smoke
+  test passing.


### PR DESCRIPTION
## What & why

The final piece of the release-automation initiative: a **nightly release train** on top of SP3a's deploy. Merged changes (including SP2's auto-merged dependency/security updates) now reach production automatically, versioned, with a post-deploy smoke test and auto-rollback.

## Changes

**`deploy.yml` — now reusable + self-protecting:**
- Added `on: workflow_call` (inputs `ref`/`image_tag`) so the release train can call it.
- Captures the current image before updating; after the revision-health poll, smoke-tests `/health` → 200 **and** unauthenticated `POST /mcp` → 401 (proves the app + Auth0 gate are live, no token needed).
- **Auto-rollback:** on a failed health/smoke check, rolls the Container App back to the previous image and fails loudly. Protects both manual and scheduled deploys.

**`release.yml` — new nightly train:**
- `schedule` 02:00 UTC + `workflow_dispatch`.
- Computes the next semver from conventional commits since the last tag (`mathieudutour/github-tag-action`, verified-pinned). Custom rules make `build`/`ci`/`chore` a **patch** bump so auto-merged dependency/security updates do release; `default_bump: false` means a no-op night creates nothing.
- Creates the GitHub Release with auto-generated notes (`gh release create --generate-notes`); the Release is the changelog (no `CHANGELOG.md` commit — the ruleset has no bypass actor).
- Deploys the new tag by calling the reusable `deploy.yml` (`secrets: inherit`).

## Decisions

Nightly cadence; fully automatic (no approval gate) with auto-rollback as the safety net (on top of the pre-merge CI gate + SP1 vuln gates). Single prod environment.

## Notes for reviewers

- `checkout` aligned to `@v7` (repo standard since #49); other action pins follow the repo's tag-pinning convention (Dependabot-tracked). Repo-wide SHA-pinning of third-party actions is noted as a future hardening.
- Neither workflow runs on PR (`deploy` is dispatch/call-only; `release` is schedule/dispatch).
- actionlint clean on both.

## Verification

A manual `workflow_dispatch` of `release.yml` post-merge will cut the first auto-release (expect a **minor** bump past `v4.0.12` — there are `feat`s on main → `v4.1.0`), publish the Release, and deploy it through the hardened deploy (exercising the new smoke + rollback path).

Spec: `docs/superpowers/specs/2026-06-29-sp3b-release-train-design.md` · Plan: `docs/superpowers/plans/2026-06-29-sp3b-release-train.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
