### PR TITLE
fix(deploy): retry post-deploy smoke checks through revision warmup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,23 +154,25 @@ jobs:
           # Smoke (with retries): a freshly-swapped single-revision app may take a short while to
           # start serving on the public FQDN, so retry before failing (and triggering a rollback).
           # /health must be 200; unauthenticated /mcp must be 401 (app live + Auth0 gate enforced).
+          # curl already emits "000" as the http_code on a connection failure; `|| true` just stops
+          # set -e aborting the loop so we can retry. No sleep after the final attempt.
           health_code=""
           for i in $(seq 1 6); do
-            health_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || echo "000")
-            echo "/health -> $health_code (attempt $i)"
+            health_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || true)
+            echo "/health -> ${health_code:-000} (attempt $i)"
             [ "$health_code" = "200" ] && break
-            sleep 10
+            [ "$i" -lt 6 ] && sleep 10
           done
-          [ "$health_code" = "200" ] || { echo "::error::/health not 200 after retries (last: $health_code)"; exit 1; }
+          [ "$health_code" = "200" ] || { echo "::error::/health not 200 after retries (last: ${health_code:-000})"; exit 1; }
           mcp_code=""
           for i in $(seq 1 6); do
             mcp_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -X POST "$MCP_URL" \
-              -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' || echo "000")
-            echo "/mcp (unauthenticated) -> $mcp_code (attempt $i)"
+              -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' || true)
+            echo "/mcp (unauthenticated) -> ${mcp_code:-000} (attempt $i)"
             [ "$mcp_code" = "401" ] && break
-            sleep 10
+            [ "$i" -lt 6 ] && sleep 10
           done
-          [ "$mcp_code" = "401" ] || { echo "::error::/mcp unauthenticated not 401 after retries (last: $mcp_code, expected 401)"; exit 1; }
+          [ "$mcp_code" = "401" ] || { echo "::error::/mcp unauthenticated not 401 after retries (last: ${mcp_code:-000}, expected 401)"; exit 1; }
 
       - name: Roll back on failure
         if: ${{ failure() && env.PREV_IMAGE != '' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,14 +151,26 @@ jobs:
             echo "::error::Revision $latest did not become healthy (provisioning=$prov health=$health)"
             exit 1
           fi
-          # Smoke: /health must be 200; unauthenticated /mcp must be 401 (app live + Auth0 gate enforced).
-          health_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || echo "000")
-          echo "/health -> $health_code"
-          [ "$health_code" = "200" ] || { echo "::error::/health returned $health_code"; exit 1; }
-          mcp_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -X POST "$MCP_URL" \
-            -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' || echo "000")
-          echo "/mcp (unauthenticated) -> $mcp_code"
-          [ "$mcp_code" = "401" ] || { echo "::error::/mcp unauthenticated returned $mcp_code (expected 401)"; exit 1; }
+          # Smoke (with retries): a freshly-swapped single-revision app may take a short while to
+          # start serving on the public FQDN, so retry before failing (and triggering a rollback).
+          # /health must be 200; unauthenticated /mcp must be 401 (app live + Auth0 gate enforced).
+          health_code=""
+          for i in $(seq 1 6); do
+            health_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || echo "000")
+            echo "/health -> $health_code (attempt $i)"
+            [ "$health_code" = "200" ] && break
+            sleep 10
+          done
+          [ "$health_code" = "200" ] || { echo "::error::/health not 200 after retries (last: $health_code)"; exit 1; }
+          mcp_code=""
+          for i in $(seq 1 6); do
+            mcp_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -X POST "$MCP_URL" \
+              -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' || echo "000")
+            echo "/mcp (unauthenticated) -> $mcp_code (attempt $i)"
+            [ "$mcp_code" = "401" ] && break
+            sleep 10
+          done
+          [ "$mcp_code" = "401" ] || { echo "::error::/mcp unauthenticated not 401 after retries (last: $mcp_code, expected 401)"; exit 1; }
 
       - name: Roll back on failure
         if: ${{ failure() && env.PREV_IMAGE != '' }}


### PR DESCRIPTION
The first nightly release-train run (#66) cut **v4.1.0** and deployed it, but the post-deploy smoke rolled it back on a **false negative**: the just-swapped single-revision app wasn't yet serving on the public FQDN when the single `/health` curl fired — it got `000` (connection failure), not a bad status. Auto-rollback then correctly restored the previous image (prod is healthy on `sha-518a8cb`).

This makes the smoke **retry through warmup**: `/health` (200) and `/mcp` (401) each retry up to 6× with 10s backoff before failing (and only then rolling back). The rollback mechanism itself worked exactly as designed — this just stops a brief warmup window from triggering it.

actionlint clean. After merge, the next `Release` run cuts a patch (v4.1.1) and should deploy cleanly with the retrying smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)