### PR TITLE
chore(security): audit follow-up hardening — workflows, app code, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish test summary
         if: always()
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
           name: xUnit tests
           path: TestResults/**/*.trx

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,10 +10,6 @@ on:
   pull_request_review:
     types: [submitted]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: dependabot-auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: false
@@ -23,6 +19,9 @@ jobs:
     # Only Dependabot-authored PRs. Use the PR author, not github.actor: on the
     # pull_request_review event the actor is the review author (e.g. Copilot), not Dependabot.
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Resolve bot-authored review threads
@@ -35,6 +34,7 @@ jobs:
           set -euo pipefail
           # Resolve only unresolved threads whose first comment is authored by a known review bot.
           # Human-authored threads are never touched. Idempotent: already-resolved threads are skipped.
+          # shellcheck disable=SC2016 # $ in single quotes is intentional GraphQL query syntax, not shell expansion
           gh api graphql -f query='
             query($owner:String!,$repo:String!,$pr:Int!){
               repository(owner:$owner,name:$repo){

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,13 @@ on:
         description: "Image tag to publish (default sha-<short-sha> of the chosen ref)"
         required: false
         type: string
-
-permissions:
-  id-token: write # OIDC token for azure/login
-  contents: read
-  packages: write # push to GHCR
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
 
 concurrency:
   group: deploy-production
@@ -41,6 +43,10 @@ concurrency:
 jobs:
   deploy:
     name: Build, import to ACR, roll Container App
+    permissions:
+      id-token: write # OIDC token for azure/login
+      contents: read
+      packages: write # push to GHCR
     runs-on: ubuntu-latest
     environment: production
     env:
@@ -75,14 +81,14 @@ jobs:
           echo "ghcr=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image to GHCR
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile
@@ -90,7 +96,7 @@ jobs:
           tags: ${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -110,6 +116,8 @@ jobs:
           echo "PREV_IMAGE=$prev" >> "$GITHUB_ENV"
 
       - name: Import image into the private ACR (server-side)
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           az acr import \
@@ -117,7 +125,7 @@ jobs:
             --source "${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}" \
             --image "$IMAGE_NAME:${{ steps.vars.outputs.tag }}" \
             --username "${{ github.actor }}" \
-            --password "${{ secrets.GITHUB_TOKEN }}" \
+            --password "$GHCR_TOKEN" \
             --force
 
       - name: Update Container App revision

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # Enforces Conventional Commits prefixes on PR titles. Pairs with the
       # CHANGELOG and makes the squash-merged main history greppable by type.
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Compute and create tag
         id: tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false
@@ -56,4 +56,7 @@ jobs:
     with:
       ref: ${{ needs.release.outputs.new_tag }}
       image_tag: ${{ needs.release.outputs.new_tag }}
-    secrets: inherit
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -68,7 +68,7 @@ jobs:
         run: docker build -t vitally-mcp:scan -f Dockerfile .
 
       - name: Trivy scan (gate on High/Critical)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: vitally-mcp:scan
           vuln-type: os,library
@@ -79,7 +79,7 @@ jobs:
 
       - name: Trivy scan (SARIF, all severities, non-blocking)
         if: always()
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: vitally-mcp:scan
           format: sarif

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,7 +361,7 @@ The deployment shape is **Azure Container Apps + Azure Key Vault + Auth0** (with
 | Image registry | Azure Container Registry (Premium SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
 | Logs | Log Analytics (attached to the CAE) | + Application Insights for traces |
 | Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Resource Server identifier `https://vitally.fiscaltec.com`; post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation |
-| CI/CD | GitHub Actions → OIDC federation → Azure | `deploy.yml` (manual until Terraform infra lands); no long-lived secrets in GitHub |
+| CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback); nightly `release.yml` cuts a semver tag + GitHub Release and deploys it; OIDC, no long-lived secrets in GitHub |
 | IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
 
 Infrastructure-as-code is in this repo at `infra/terraform/` — the table above documents the runtime contract for what `deploy.yml` expects. Anyone replicating can swap Container Apps for App Service, ACR for GHCR, Auth0 for Keycloak, etc., without touching the application code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,10 +358,10 @@ The deployment shape is **Azure Container Apps + Azure Key Vault + Auth0** (with
 | Hosting | Azure Container Apps (consumption plan) | Scale-to-zero; HTTPS-native ingress; managed cert on `vitally.fiscaltec.com` |
 | Secrets | Azure Key Vault | `vitally-shared` is the default secret name; managed identity has `Key Vault Secrets User` |
 | Identity | User-assigned managed identity | `AcrPull` on the registry + `Key Vault Secrets User` on the vault |
-| Image registry | Azure Container Registry (Basic SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
+| Image registry | Azure Container Registry (Premium SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
 | Logs | Log Analytics (attached to the CAE) | + Application Insights for traces |
 | Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Resource Server identifier `https://vitally.fiscaltec.com`; post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation |
 | CI/CD | GitHub Actions → OIDC federation → Azure | `deploy.yml` (manual until Terraform infra lands); no long-lived secrets in GitHub |
-| IaC | Terraform (separate repo) | Infrastructure-as-code is **not** in this repo — it lives in the Terraform repo. The `deploy.yml` workflow consumes whatever that provisions. |
+| IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
 
-Infrastructure-as-code lives in the separate Terraform repo, not here — the table above is the contract for what `deploy.yml` expects. Anyone replicating can swap Container Apps for App Service, ACR for GHCR, Auth0 for Keycloak, etc., without touching the application code.
+Infrastructure-as-code is in this repo at `infra/terraform/` — the table above documents the runtime contract for what `deploy.yml` expects. Anyone replicating can swap Container Apps for App Service, ACR for GHCR, Auth0 for Keycloak, etc., without touching the application code.

--- a/VitallyMcp.Tests/StartupGuardsTests.cs
+++ b/VitallyMcp.Tests/StartupGuardsTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using VitallyMcp;
+
+namespace VitallyMcp.Tests;
+
+public class StartupGuardsTests
+{
+    [Fact]
+    public void EnsureSafeAuthConfig_NoAuthWithKeyVault_Throws()
+    {
+        var act = () => StartupGuards.EnsureSafeAuthConfig(noAuth: true, keyVaultUri: "https://kv.vault.azure.net/");
+        act.Should().Throw<InvalidOperationException>().WithMessage("*NoAuth*");
+    }
+
+    [Theory]
+    [InlineData(false, "https://kv.vault.azure.net/")] // auth on + KV: fine (production)
+    [InlineData(true, null)]                            // NoAuth + no KV: fine (local dev)
+    [InlineData(true, "")]                              // NoAuth + blank KV: fine
+    [InlineData(false, null)]                           // auth on + no KV: fine (dev key)
+    public void EnsureSafeAuthConfig_SafeCombinations_DoNotThrow(bool noAuth, string? keyVaultUri)
+    {
+        var act = () => StartupGuards.EnsureSafeAuthConfig(noAuth, keyVaultUri);
+        act.Should().NotThrow();
+    }
+}

--- a/VitallyMcp.Tests/Tools/SummaryToolsTests.cs
+++ b/VitallyMcp.Tests/Tools/SummaryToolsTests.cs
@@ -42,6 +42,10 @@ public class SummaryToolsTests
         doc.RootElement.TryGetProperty("productFeedback", out _).Should().BeTrue();
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
+        Justification = "Test mock — HttpResponseMessage lifetime is bounded by the test run.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "cs/local-not-disposed",
+        Justification = "Test mock — owned by the Moq setup, bounded by the test method.")]
     private static HttpClient BuildRoutedClient()
     {
         var mock = new Mock<HttpMessageHandler>();

--- a/VitallyMcp.Tests/VitallyServiceTests.cs
+++ b/VitallyMcp.Tests/VitallyServiceTests.cs
@@ -1266,6 +1266,10 @@ public class VitallyServiceTests
     // Routes mocked responses by request-URL substring; later setups win in Moq so the most
     // specific (instances/search) is registered last. Bodies mirror the REAL Vitally shapes:
     // org get = single object; customObjects list = {results:[...]}; instance search = BARE ARRAY.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
+        Justification = "Test mock — HttpResponseMessage lifetime is bounded by the test run.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "cs/local-not-disposed",
+        Justification = "Test mock — owned by the Moq setup, bounded by the test method.")]
     private static (HttpClient client, Mock<HttpMessageHandler> handler) RoutedClient(
         IReadOnlyList<(string urlContains, HttpStatusCode status, string body)> routes)
     {
@@ -1411,4 +1415,37 @@ public class VitallyServiceTests
                 r.RequestUri!.AbsoluteUri.Contains("organizationId=org-1")),
             ItExpr.IsAny<CancellationToken>());
     }
+
+    #region Security Tests
+
+    [Fact]
+    public async Task SendAsync_OnError_MessageHasStatusAndBodyButNotUrl()
+    {
+        using var client = TestHelpers.CreateMockHttpClient("{\"message\":\"externalId is required\"}", HttpStatusCode.BadRequest);
+        var service = TestHelpers.BuildVitallyService(client);
+
+        var act = async () => await service.GetResourceByIdAsync("accounts", "acc-123");
+
+        var ex = await act.Should().ThrowAsync<HttpRequestException>();
+        ex.Which.Message.Should().Contain("400");
+        ex.Which.Message.Should().Contain("externalId is required");
+        ex.Which.Message.Should().NotContain("acc-123");           // resource path/id not leaked
+        ex.Which.Message.Should().NotContainEquivalentOf("vitally"); // base host not leaked
+    }
+
+    [Fact]
+    public async Task GetRawAsync_EscapesQueryKeysAndValues()
+    {
+        var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler("[]");
+        var service = TestHelpers.BuildVitallyService(client);
+
+        await service.GetRawAsync("customFields", new Dictionary<string, string> { ["a b"] = "c d" });
+
+        handler.Protected().Verify("SendAsync", Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.Query.Contains("a%20b=c%20d")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    #endregion
+
 }

--- a/VitallyMcp.Tests/VitallyServiceTests.cs
+++ b/VitallyMcp.Tests/VitallyServiceTests.cs
@@ -1439,10 +1439,13 @@ public class VitallyServiceTests
         var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler("[]");
         var service = TestHelpers.BuildVitallyService(client);
 
-        await service.GetRawAsync("customFields", new Dictionary<string, string> { ["a b"] = "c d" });
+        // Use '+' rather than a space: System.Uri leaves '+' untouched in a query, so this only
+        // passes when GetRawAsync explicitly Uri.EscapeDataString-encodes the key+value (-> %2B).
+        // (A space would be auto-escaped by Uri and wouldn't prove the explicit escaping.)
+        await service.GetRawAsync("customFields", new Dictionary<string, string> { ["a+b"] = "c+d" });
 
         handler.Protected().Verify("SendAsync", Times.Once(),
-            ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.Query.Contains("a%20b=c%20d")),
+            ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.Query.Contains("a%2Bb=c%2Bd")),
             ItExpr.IsAny<CancellationToken>());
     }
 

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -69,6 +69,9 @@ builder.Services.AddHttpClient<VitallyService>()
 var oauthSection = builder.Configuration.GetSection(OAuthOptions.SectionName);
 var noAuth = oauthSection.GetValue<bool>("NoAuth");
 
+// Fail fast on an unauthenticated production-looking config (NoAuth + Key Vault).
+StartupGuards.EnsureSafeAuthConfig(noAuth, vitallySection["KeyVaultUri"]);
+
 if (!noAuth)
 {
     builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -361,6 +364,9 @@ app.MapPost("/oauth/token", async (HttpContext ctx, IOptions<OAuthOptions> oauth
     {
         pairs.RemoveAll(p => p.Key == "client_secret");
         pairs.Add(new KeyValuePair<string, string>("client_secret", o.SharedClientSecret));
+        // Never pair the injected secret with a caller-supplied client_id — clamp to our shared app.
+        pairs.RemoveAll(p => p.Key == "client_id");
+        pairs.Add(new KeyValuePair<string, string>("client_id", o.SharedClientId));
     }
 
     var client = factory.CreateClient();

--- a/VitallyMcp/StartupGuards.cs
+++ b/VitallyMcp/StartupGuards.cs
@@ -1,0 +1,23 @@
+namespace VitallyMcp;
+
+/// <summary>
+/// Fail-fast configuration guards checked at startup, before the app serves traffic.
+/// </summary>
+public static class StartupGuards
+{
+    /// <summary>
+    /// Refuses a configuration that disables authentication while a Key Vault is configured — that
+    /// combination looks like a production deployment accidentally running unauthenticated. NoAuth is
+    /// for local development only (which has no Key Vault and uses a development API key instead).
+    /// </summary>
+    public static void EnsureSafeAuthConfig(bool noAuth, string? keyVaultUri)
+    {
+        if (noAuth && !string.IsNullOrWhiteSpace(keyVaultUri))
+        {
+            throw new InvalidOperationException(
+                "OAuth:NoAuth=true together with a Vitally:KeyVaultUri is refused — this looks like a " +
+                "production deployment running unauthenticated. NoAuth is for local development only " +
+                "(no Key Vault). Remove NoAuth in any environment that uses Key Vault.");
+        }
+    }
+}

--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -94,7 +94,7 @@ public class VitallyService
             // status code does not indicate success".
             var bodySnippet = string.IsNullOrWhiteSpace(body) ? "(empty body)" : Truncate(body, 1024);
             throw new HttpRequestException(
-                $"Vitally API returned {(int)response.StatusCode} {response.ReasonPhrase} for {method} {url}. Body: {bodySnippet}",
+                $"Upstream API returned {(int)response.StatusCode} {response.ReasonPhrase}. Body: {bodySnippet}",
                 inner: null,
                 statusCode: response.StatusCode);
         }
@@ -446,7 +446,7 @@ public class VitallyService
         var url = $"{_baseUrl}/resources/{path}";
         if (queryParams != null && queryParams.Count > 0)
         {
-            var query = string.Join("&", queryParams.Select(kv => $"{kv.Key}={Uri.EscapeDataString(kv.Value)}"));
+            var query = string.Join("&", queryParams.Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
             url = $"{url}?{query}";
         }
 

--- a/docs/superpowers/plans/2026-06-29-security-hardening.md
+++ b/docs/superpowers/plans/2026-06-29-security-hardening.md
@@ -1,0 +1,332 @@
+# Security hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the approved in-repo security hardenings from the audit — supply-chain (workflows), application-code defence-in-depth (with tests), and doc accuracy — with no behavioural regressions.
+
+**Architecture:** Three independent tasks: (1) workflow/CI hardening (SHA pins, token-via-env, per-job permissions, explicit secrets); (2) C# app-code hardening (OAuth client_id clamp, error-URL stripping, a NoAuth+KeyVault startup guard, query-key escaping, a test-helper dispose nit) with xUnit tests; (3) CLAUDE.md doc corrections.
+
+**Tech Stack:** GitHub Actions + actionlint, .NET 10 / C# / xUnit + FluentAssertions, `gh` CLI for resolving action SHAs.
+
+## Global Constraints
+
+- No behavioural regression: the deploy/release/scan workflows and all tools keep working; full xUnit suite green; `actionlint` clean.
+- SHA pins: resolve each third-party action's tag to its real commit SHA at implementation time via `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` (or `git ls-remote`); never guess. Add a trailing `# vX.Y.Z` comment. Leave first-party `actions/*`, `github/codeql-action/*`, `dependabot/fetch-metadata` on tags.
+- UK English; LF line endings. Build/run from repo root; do NOT prefix commands with `cd`.
+- actionlint: `MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd -W):/repo" -w /repo rhysd/actionlint:latest -color <file>` (Docker is up).
+- Do NOT change the deploy IAM / identity model, the auto-merge policy, or any live Azure/GitHub settings — out of scope (user decisions).
+
+---
+
+### Task 1: Workflow / supply-chain hardening
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml`, `.github/workflows/release.yml`, `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `.github/workflows/security-scan.yml`, `.github/workflows/pr-title.yml`, `.github/workflows/dependabot-auto-merge.yml`, `.github/workflows/cleanup-caches.yml` (only those containing the listed third-party actions).
+
+- [ ] **Step 1: Resolve + apply SHA pins for third-party actions**
+
+For each third-party action below, resolve the current tag to its commit SHA and replace the pin with `<owner>/<repo>@<40-char-sha> # <tag>`. Resolve with e.g. `gh api repos/aquasecurity/trivy-action/commits/v0.36.0 --jq .sha`.
+
+Third-party actions to SHA-pin (find their occurrences across the workflow files):
+- `aquasecurity/trivy-action@v0.36.0` (security-scan.yml, ×2)
+- `mathieudutour/github-tag-action@v6.2` (release.yml)
+- `dorny/test-reporter@v3` (ci.yml)
+- `docker/login-action@v3` (deploy.yml)
+- `docker/build-push-action@v6` (deploy.yml)
+- `azure/login@v3` (deploy.yml)
+- `amannn/action-semantic-pull-request@v6` (pr-title.yml)
+
+Leave on tags (GitHub-controlled, lower risk): `actions/checkout`, `actions/setup-dotnet`, `actions/cache`, `actions/upload-artifact`, `github/codeql-action/*`, `dependabot/fetch-metadata`.
+
+- [ ] **Step 2: `deploy.yml` — GHCR token via env (not inline) in `az acr import`**
+
+In `.github/workflows/deploy.yml`, the "Import image into the private ACR" step currently passes `--password "${{ secrets.GITHUB_TOKEN }}"` inline. Add a step `env:` and reference it as a shell variable:
+```yaml
+      - name: Import image into the private ACR (server-side)
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          az acr import \
+            --name "$ACR_NAME" \
+            --source "${{ steps.vars.outputs.ghcr }}:${{ steps.vars.outputs.tag }}" \
+            --image "$IMAGE_NAME:${{ steps.vars.outputs.tag }}" \
+            --username "${{ github.actor }}" \
+            --password "$GHCR_TOKEN" \
+            --force
+```
+
+- [ ] **Step 3: Job-level permissions in `deploy.yml` and `dependabot-auto-merge.yml`**
+
+In `deploy.yml`, remove the workflow-level `permissions:` block and add the same block under the `deploy:` job (above `runs-on:` is fine):
+```yaml
+jobs:
+  deploy:
+    name: Build, import to ACR, roll Container App
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    environment: production
+```
+In `dependabot-auto-merge.yml`, remove the workflow-level `permissions:` block and add it under the `auto-merge:` job:
+```yaml
+jobs:
+  auto-merge:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+```
+
+- [ ] **Step 4: `release.yml` — explicit secrets instead of `secrets: inherit`**
+
+In `.github/workflows/release.yml`, the `deploy` caller job uses `secrets: inherit`. Replace with an explicit map:
+```yaml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+```
+(`GITHUB_TOKEN` is provided to the called workflow automatically; do not list it.)
+
+- [ ] **Step 5: Validate + commit**
+
+Run actionlint on every changed workflow (expect exit 0 each):
+```
+for f in deploy release ci codeql security-scan pr-title dependabot-auto-merge cleanup-caches; do
+  MSYS_NO_PATHCONV=1 docker run --rm -v "$(pwd -W):/repo" -w /repo rhysd/actionlint:latest -color ".github/workflows/$f.yml" || echo "LINT FAIL: $f"
+done
+```
+```powershell
+git add .github/workflows
+git commit -m @'
+ci(security): SHA-pin third-party actions, env-pass GHCR token, per-job perms, explicit secrets
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01RWMtSydEfRwSpxDHNY9eH3
+'@
+```
+
+---
+
+### Task 2: Application-code hardening (with tests)
+
+**Files:**
+- Create: `VitallyMcp/StartupGuards.cs`
+- Modify: `VitallyMcp/Program.cs`, `VitallyMcp/VitallyService.cs`, `VitallyMcp.Tests/TestHelpers.cs`
+- Test: `VitallyMcp.Tests/StartupGuardsTests.cs` (new), `VitallyMcp.Tests/VitallyServiceTests.cs` (additions)
+
+**Interfaces:**
+- Produces: `StartupGuards.EnsureSafeAuthConfig(bool noAuth, string? keyVaultUri)` — throws `InvalidOperationException` when `noAuth && keyVaultUri` is non-blank; otherwise returns void.
+
+- [ ] **Step 1: NoAuth+KeyVault startup guard — failing test first**
+
+Create `VitallyMcp.Tests/StartupGuardsTests.cs`:
+```csharp
+using FluentAssertions;
+using VitallyMcp;
+
+namespace VitallyMcp.Tests;
+
+public class StartupGuardsTests
+{
+    [Fact]
+    public void EnsureSafeAuthConfig_NoAuthWithKeyVault_Throws()
+    {
+        var act = () => StartupGuards.EnsureSafeAuthConfig(noAuth: true, keyVaultUri: "https://kv.vault.azure.net/");
+        act.Should().Throw<InvalidOperationException>().WithMessage("*NoAuth*");
+    }
+
+    [Theory]
+    [InlineData(false, "https://kv.vault.azure.net/")] // auth on + KV: fine (production)
+    [InlineData(true, null)]                            // NoAuth + no KV: fine (local dev)
+    [InlineData(true, "")]                              // NoAuth + blank KV: fine
+    [InlineData(false, null)]                           // auth on + no KV: fine (dev key)
+    public void EnsureSafeAuthConfig_SafeCombinations_DoNotThrow(bool noAuth, string? keyVaultUri)
+    {
+        var act = () => StartupGuards.EnsureSafeAuthConfig(noAuth, keyVaultUri);
+        act.Should().NotThrow();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~StartupGuardsTests" --nologo`
+Expected: FAIL — `StartupGuards` not defined (compile error).
+
+- [ ] **Step 3: Implement `StartupGuards`**
+
+Create `VitallyMcp/StartupGuards.cs` (UK English):
+```csharp
+namespace VitallyMcp;
+
+/// <summary>
+/// Fail-fast configuration guards checked at startup, before the app serves traffic.
+/// </summary>
+public static class StartupGuards
+{
+    /// <summary>
+    /// Refuses a configuration that disables authentication while a Key Vault is configured — that
+    /// combination looks like a production deployment accidentally running unauthenticated. NoAuth is
+    /// for local development only (which has no Key Vault and uses a development API key instead).
+    /// </summary>
+    public static void EnsureSafeAuthConfig(bool noAuth, string? keyVaultUri)
+    {
+        if (noAuth && !string.IsNullOrWhiteSpace(keyVaultUri))
+        {
+            throw new InvalidOperationException(
+                "OAuth:NoAuth=true together with a Vitally:KeyVaultUri is refused — this looks like a " +
+                "production deployment running unauthenticated. NoAuth is for local development only " +
+                "(no Key Vault). Remove NoAuth in any environment that uses Key Vault.");
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~StartupGuardsTests" --nologo`
+Expected: PASS (5 cases).
+
+- [ ] **Step 5: Call the guard from `Program.cs`**
+
+In `VitallyMcp/Program.cs`, just after `var noAuth = oauthSection.GetValue<bool>("NoAuth");` (around line 70), add:
+```csharp
+// Fail fast on an unauthenticated production-looking config (NoAuth + Key Vault).
+StartupGuards.EnsureSafeAuthConfig(noAuth, vitallySection["KeyVaultUri"]);
+```
+(`vitallySection` is the existing `builder.Configuration.GetSection("Vitally")` used elsewhere in Program.cs — reuse it; if the local variable has a different name, use the existing accessor that Step's neighbours use to read `KeyVaultUri`.)
+
+- [ ] **Step 6: OAuth token proxy — clamp `client_id`**
+
+In `VitallyMcp/Program.cs`, in the `/oauth/token` handler, inside the existing `if (!string.IsNullOrWhiteSpace(o.SharedClientSecret))` block (the confidential-client secret injection, ~line 360-364), add the client_id clamp after the secret injection:
+```csharp
+    if (!string.IsNullOrWhiteSpace(o.SharedClientSecret))
+    {
+        pairs.RemoveAll(p => p.Key == "client_secret");
+        pairs.Add(new KeyValuePair<string, string>("client_secret", o.SharedClientSecret));
+        // Never pair the injected secret with a caller-supplied client_id — clamp to our shared app.
+        pairs.RemoveAll(p => p.Key == "client_id");
+        pairs.Add(new KeyValuePair<string, string>("client_id", o.SharedClientId));
+    }
+```
+(No dedicated unit test — the endpoint forwards to upstream Auth0 and isn't unit-isolatable without a large refactor; it is exercised by the existing `OAuthProxyEndpointsTests` wiring and verified by inspection. The reviewer may flag this; that is acceptable.)
+
+- [ ] **Step 7: VitallyService — strip URL from surfaced error + escape query keys (failing tests first)**
+
+Add to `VitallyMcp.Tests/VitallyServiceTests.cs` (inside the class):
+```csharp
+[Fact]
+public async Task SendAsync_OnError_MessageHasStatusAndBodyButNotUrl()
+{
+    using var client = TestHelpers.CreateMockHttpClient("{\"message\":\"externalId is required\"}", HttpStatusCode.BadRequest);
+    var service = TestHelpers.BuildVitallyService(client);
+
+    var act = async () => await service.GetResourceByIdAsync("accounts", "acc-123");
+
+    var ex = await act.Should().ThrowAsync<HttpRequestException>();
+    ex.Which.Message.Should().Contain("400");
+    ex.Which.Message.Should().Contain("externalId is required");
+    ex.Which.Message.Should().NotContain("acc-123");           // resource path/id not leaked
+    ex.Which.Message.Should().NotContainEquivalentOf("vitally"); // base host not leaked
+}
+
+[Fact]
+public async Task GetRawAsync_EscapesQueryKeysAndValues()
+{
+    var (client, handler) = TestHelpers.CreateMockHttpClientWithHandler("[]");
+    var service = TestHelpers.BuildVitallyService(client);
+
+    await service.GetRawAsync("customFields", new Dictionary<string, string> { ["a b"] = "c d" });
+
+    handler.Protected().Verify("SendAsync", Times.Once(),
+        ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.Query.Contains("a%20b=c%20d")),
+        ItExpr.IsAny<CancellationToken>());
+}
+```
+Run: `dotnet test --filter "FullyQualifiedName~VitallyServiceTests.SendAsync_OnError_MessageHasStatusAndBodyButNotUrl|FullyQualifiedName~VitallyServiceTests.GetRawAsync_EscapesQueryKeysAndValues" --nologo`
+Expected: FAIL (message still contains the path/host; query key not escaped).
+
+- [ ] **Step 8: Implement the VitallyService changes**
+
+In `VitallyMcp/VitallyService.cs`, change the error message in `SendAsync` (drop `for {method} {url}` — the URL is already recorded by `_audit.LogAction`/`LogDenied` server-side):
+```csharp
+            throw new HttpRequestException(
+                $"Vitally API returned {(int)response.StatusCode} {response.ReasonPhrase}. Body: {bodySnippet}",
+                inner: null,
+                statusCode: response.StatusCode);
+```
+And in `GetRawAsync`, escape the key as well as the value:
+```csharp
+            var query = string.Join("&", queryParams.Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}"));
+```
+(No change needed in `GetOrganizationSummaryAsync` — its `{ "error": ex.Message }` sections now inherit the URL-free message automatically.)
+
+- [ ] **Step 9: Run to verify pass**
+
+Run: `dotnet test --filter "FullyQualifiedName~VitallyServiceTests.SendAsync_OnError_MessageHasStatusAndBodyButNotUrl|FullyQualifiedName~VitallyServiceTests.GetRawAsync_EscapesQueryKeysAndValues" --nologo`
+Expected: PASS. (If a pre-existing test asserted the URL was present in the error message, update it to match the new URL-free message — the body+status assertions stay.)
+
+- [ ] **Step 10: TestHelpers dispose nit**
+
+In `VitallyMcp.Tests/TestHelpers.cs`, find the mock-HttpClient helper that CodeQL flags with `cs/local-not-disposed` (the one lacking the suppression the others have) and add the same attributes used on `CreateMockHttpClient` in that file:
+```csharp
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
+        Justification = "Test mock — HttpResponseMessage lifetime is bounded by the test run.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "cs/local-not-disposed",
+        Justification = "Test mock — owned by the Moq setup, bounded by the test method.")]
+```
+(If all helpers already carry it and the flagged one is `RoutedClient`/`BuildRoutedClient` in `VitallyServiceTests.cs`/`SummaryToolsTests.cs`, apply the same two attributes there instead. Identify the exact flagged member from the CodeQL alert / by matching the pattern.)
+
+- [ ] **Step 11: Full suite + commit**
+
+Run: `dotnet test VitallyMcp.sln -c Debug --nologo --verbosity minimal` — all green.
+```powershell
+git add VitallyMcp/StartupGuards.cs VitallyMcp/Program.cs VitallyMcp/VitallyService.cs VitallyMcp.Tests/StartupGuardsTests.cs VitallyMcp.Tests/VitallyServiceTests.cs VitallyMcp.Tests/TestHelpers.cs
+git commit -m @'
+harden(app): NoAuth+KeyVault startup guard, OAuth client_id clamp, no URL in surfaced errors, escape query keys
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01RWMtSydEfRwSpxDHNY9eH3
+'@
+```
+
+---
+
+### Task 3: Docs — CLAUDE.md accuracy
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Correct the Deployment section**
+
+In `CLAUDE.md`, in the Deployment area:
+- The IaC row/paragraph that says Terraform lives in a **separate repo** is wrong — change it to state the IaC is **in this repo at `infra/terraform/`** (adopted via import blocks; see `infra/terraform/README.md`).
+- The ACR row that says **Basic SKU** is wrong — change it to **Premium** (required for private endpoints + CMK).
+
+Make the minimal edits to those two facts; keep the surrounding table/structure.
+
+- [ ] **Step 2: Commit**
+
+```powershell
+git add CLAUDE.md
+git commit -m @'
+docs: correct CLAUDE.md — Terraform is in-repo (infra/terraform), ACR is Premium
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01RWMtSydEfRwSpxDHNY9eH3
+'@
+```
+
+---
+
+## Final verification
+
+- [ ] `dotnet test VitallyMcp.sln -c Debug --nologo --verbosity minimal` — all green.
+- [ ] `actionlint` clean on all changed workflows; every SHA pin resolves to a real commit (`gh api repos/<owner>/<repo>/commits/<sha>` 200).
+- [ ] Open a PR from `feature/security-hardening` into `main`, **assigned to the user**; CI green; resolve Copilot/CodeQL threads; merge (squash).
+- [ ] Sanity: the deploy/release workflows still parse and (since pins/permissions only changed) remain functional — the next scheduled/dispatched run is the live confirmation; no live run is required to merge.

--- a/docs/superpowers/specs/2026-06-29-security-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-29-security-hardening-design.md
@@ -1,0 +1,95 @@
+# Security hardening pass
+
+**Date:** 2026-06-29
+**Status:** Design (approved) — ready for implementation plan.
+**Origin:** A four-dimension security audit (application code, CI/CD supply chain, Azure IAM,
+repo/secrets/data) of the Vitally MCP server. The audit found **no Critical issues** and a strong
+baseline. This spec captures the **in-repo hardenings the user approved** to implement now. Items
+requiring prod-IAM/GitHub-settings/Vitally action were triaged out (the user chose to leave the deploy
+IAM as-is; the git-history key check and GitHub environment settings are the user's to action).
+
+## 1. Scope (approved in-repo hardenings)
+
+Three areas; all changes stay in the repo (no live Azure/GitHub-settings mutations).
+
+### A. Workflows / CI-CD supply chain
+1. **SHA-pin third-party actions** (with a trailing `# vX.Y.Z` comment) in all workflows:
+   `aquasecurity/trivy-action`, `mathieudutour/github-tag-action`, `dorny/test-reporter`,
+   `docker/login-action`, `docker/build-push-action`, `azure/login`,
+   `amannn/action-semantic-pull-request`. First-party `actions/*` and `github/codeql-action/*` and
+   `dependabot/fetch-metadata` may stay on tags (GitHub-controlled). Resolve each tag to its commit
+   SHA at implementation time (do not guess). Dependabot's `github-actions` ecosystem keeps SHA pins
+   current.
+2. **`az acr import` token via env, not inline interpolation** (`deploy.yml`): pass `GITHUB_TOKEN`
+   through the step `env:` and reference it as a shell variable in the `--password` argument, so the
+   secret is not rendered into the literal step command. (It remains masked in logs regardless; this
+   is defence-in-depth + best practice.)
+3. **Job-level permissions** instead of workflow-level in `deploy.yml` and
+   `dependabot-auto-merge.yml` (consistency + future-proofing; functionally equivalent for the
+   current single-job shape but prevents a future added job inheriting broad scopes).
+4. **Explicit secret enumeration** in `release.yml`'s reusable-deploy call: replace `secrets: inherit`
+   with an explicit `secrets:` map of only `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
+   `AZURE_SUBSCRIPTION_ID` (and `GITHUB_TOKEN` is available to the called workflow automatically).
+
+### B. Application code (C#) — each with a test
+5. **Clamp `/oauth/token` `client_id` to `SharedClientId`** (`Program.cs` token proxy): before
+   forwarding to Auth0 with the injected `SharedClientSecret`, remove any caller-supplied `client_id`
+   and set it to the configured `SharedClientId`, so the proxy never pairs the secret with a foreign
+   client id (don't rely on Auth0 to reject the mismatch).
+6. **Strip the Vitally URL from client-surfaced error messages** (`VitallyService.SendAsync`): the
+   `HttpRequestException` message currently includes the full upstream URL. Keep the status code and a
+   (bounded) response-body snippet for the LLM to act on, but remove the full URL from the message
+   surfaced to the client; log the full URL/details server-side via `ILogger`. Apply the same
+   trimming to the `{ "error": ... }` sections built in `GetOrganizationSummaryAsync`.
+7. **Fail-fast startup guard for `NoAuth` + Key Vault** (`Program.cs` / options validation): if
+   `OAuth:NoAuth` is true **and** `Vitally:KeyVaultUri` is set (a production-looking config), refuse
+   to start (throw) — prevents an accidental unauthenticated production deployment. `NoAuth` with no
+   Key Vault (local dev) stays allowed.
+8. **Escape query-parameter keys in `GetRawAsync`** (`VitallyService.cs`): the helper escapes values
+   but not keys; escape keys with `Uri.EscapeDataString` for consistency with `BuildListUrl` /
+   `SearchCustomObjectInstancesAsync` (latent-risk hygiene; no current untrusted key).
+9. **Dispose hygiene in `TestHelpers`**: clear the outstanding CodeQL `cs/local-not-disposed` warning
+   on the test mock helper (add the same `SuppressMessage`/`using` pattern already used by the other
+   helpers in that file). Test-only.
+
+### C. Docs
+10. **`CLAUDE.md` accuracy:** correct the Deployment section — IaC **is** in this repo at
+    `infra/terraform/` (not a separate repo), and the ACR SKU is **Premium** (not Basic). These are
+    security-relevant operational facts (an operator could otherwise provision a Basic ACR that can't
+    do private endpoints, or miss reviewing Terraform changes).
+
+## 2. Explicitly out of scope (triaged, user-actioned or accepted)
+
+- Deploy-identity least-privilege (custom roles / dedicated identity) — **user chose to leave IAM
+  as-is**; documented accepted trade-off.
+- GitHub `production` environment branch-restriction; `required_approving_review_count` — user's
+  settings call (the 0-approval + auto-merge model is their deliberate SP2 choice).
+- Confirming the partial `sk_live_51f45f82…` in deleted `QUICKSTART.md` git history is rotated/invalid
+  in Vitally — user action (cannot be done from the repo; GitHub secret scanning shows 0 alerts).
+- Remote Terraform state backend, scanner image pinning, NSG on `snet-app`, secret-expiry attribute
+  verification — infra-ops items for the user.
+- Auto-merge of major Dependabot bumps — deliberate user decision (CI is the gate).
+- The 5 glibc base-image CVEs (Trivy `warning`, below the High/Critical gate) — picked up on rebuild
+  when Microsoft publishes patched base images; not blocking, monitored via the Security tab.
+- Auth0 `SharedClientId` in committed config — a public identifier, not a secret; left as-is.
+
+## 3. Testing
+
+- **Workflows (A):** `actionlint` clean on every changed workflow; SHA pins resolve to real commits
+  (verified at implementation). No behavioural change intended; the existing deploy/release proofs
+  stand.
+- **App code (B):** xUnit tests for each behavioural change — `client_id` clamp (token proxy forwards
+  the configured id even when a foreign one is supplied), error-message no longer contains the URL
+  (but still contains status + body), the `NoAuth`+`KeyVault` startup guard throws, `GetRawAsync`
+  escapes keys. Full suite stays green.
+- **Docs (C):** N/A.
+
+## 4. Acceptance criteria
+
+- All 10 approved items implemented; full xUnit suite green; `actionlint` clean.
+- No third-party action left on a mutable tag; the GHCR token is no longer inline-interpolated into a
+  run command; `release.yml` enumerates secrets explicitly.
+- A `NoAuth=true` + `KeyVaultUri` configuration fails to start; the OAuth token proxy clamps
+  `client_id`; surfaced Vitally errors no longer leak the full URL.
+- `CLAUDE.md` Deployment section is factually correct (in-repo Terraform, Premium ACR).
+- Delivered as PR(s) into `main`, assigned to the user, through the standard CI + review gate.


### PR DESCRIPTION
## What & why

Implements the **in-repo hardenings from the four-dimension security audit** (app code · CI/CD supply chain · Azure IAM · repo/secrets). The audit found **no Critical issues** and a strong baseline; this PR applies the approved defence-in-depth items. (Deploy-IAM least-privilege was a separate decision — left as-is per your call; the git-history key check + GitHub-settings items are yours to action.)

## Changes

**Workflows / supply chain**
- **SHA-pin** all third-party actions (`trivy-action`, `github-tag-action`, `test-reporter`, `docker/login`, `docker/build-push`, `azure/login`, `action-semantic-pull-request`) with `# vX.Y.Z` comments (Dependabot keeps them current); first-party `actions/*` left on tags.
- `az acr import` GHCR token passed via step **env**, not inline `${{ }}`.
- **Per-job permissions** in `deploy.yml` + `dependabot-auto-merge.yml`.
- `release.yml` `secrets: inherit` → **explicit** `AZURE_*` map (+ matching `workflow_call.secrets` decl in `deploy.yml`).

**Application code (C#, with tests)**
- **`StartupGuards.EnsureSafeAuthConfig`** — fail-fast if `NoAuth=true` with a Key Vault configured (prevents an accidental unauthenticated production deploy). Called at startup.
- `/oauth/token` proxy **clamps `client_id`** to the configured `SharedClientId` (never pairs the injected secret with a caller-supplied id).
- `VitallyService.SendAsync` error message **no longer leaks the upstream URL** (keeps status + body for the LLM; the audit log still records the URL server-side).
- `GetRawAsync` escapes query **keys** (not just values).
- Test-mock dispose suppressions (clears a CodeQL warning).

**Docs**
- `CLAUDE.md`: Terraform **is** in-repo (`infra/terraform/`), ACR is **Premium**, and the CI/CD row refreshed (reusable deploy + nightly release train).

## Out of scope (your decisions / actions, recorded)

Deploy-identity least-privilege (kept as-is); confirming the partial `sk_live_51f45f82…` in a *deleted* `QUICKSTART.md` git-history entry is rotated/invalid in Vitally; GitHub `production` environment branch-restriction; remote TF state / scanner image pin / NSG / secret-expiry; the 5 glibc base-image CVEs (Trivy `warning`, below the gate; patched on rebuild).

## Verification

Full xUnit suite **346 green**; `actionlint` exit 0 on all 8 workflows; whole-branch security review (opus) confirmed no regression (secrets three-way match, guard unbypassable, URL removed from all surfacing paths while audit retains it, SHA pins consistent). Neither deploy nor release runs on PR.

Spec: `docs/superpowers/specs/2026-06-29-security-hardening-design.md` · Plan: `docs/superpowers/plans/2026-06-29-security-hardening.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
