### PR TITLE
fix(infra): keep one warm replica to eliminate cold-start latency

### DIFF
--- a/infra/terraform/containerapps.tf
+++ b/infra/terraform/containerapps.tf
@@ -61,7 +61,12 @@ resource "azurerm_container_app" "app" {
   }
 
   template {
-    min_replicas = 0
+    # Keep one replica always warm: scale-to-zero (min 0) made every request after an idle
+    # gap pay a cold start (scheduling + ACR image pull over the private endpoint + .NET boot
+    # + first-time Key Vault/Graph token acquisitions), pushing interactive requests to 1-2 min.
+    # A warm replica also keeps the token/JWKS/Key Vault caches hot. Trade-off: one 0.5 vCPU /
+    # 1Gi replica is billed continuously at the idle rate instead of scaling to zero.
+    min_replicas = 1
     max_replicas = 3
 
     container {

--- a/infra/terraform/containerapps.tf
+++ b/infra/terraform/containerapps.tf
@@ -61,11 +61,13 @@ resource "azurerm_container_app" "app" {
   }
 
   template {
-    # Keep one replica always warm: scale-to-zero (min 0) made every request after an idle
-    # gap pay a cold start (scheduling + ACR image pull over the private endpoint + .NET boot
-    # + first-time Key Vault/Graph token acquisitions), pushing interactive requests to 1-2 min.
-    # A warm replica also keeps the token/JWKS/Key Vault caches hot. Trade-off: one 0.5 vCPU /
-    # 1Gi replica is billed continuously at the idle rate instead of scaling to zero.
+    # Keep one replica always warm. With scale-to-zero (min 0), a request arriving after an
+    # idle gap paid a server-side cold start (scheduling + ACR image pull over the private
+    # endpoint + .NET boot + first-time Key Vault/Graph managed-identity token acquisitions) —
+    # ~5s worst case in the logs, of which the first Graph token alone was ~3s. A warm replica
+    # also keeps the token/JWKS/Key Vault caches hot. NOTE: this only affects the server-side
+    # slice; client-perceived MCP latency is dominated by model inference, not this change.
+    # Trade-off: one 0.5 vCPU / 1Gi replica is billed continuously at the idle rate.
     min_replicas = 1
     max_replicas = 3
 


### PR DESCRIPTION
## What

Sets `min_replicas = 1` on the Container App (`vitally-prod-ca-uksouth`) in Terraform, matching a change already applied live via `az containerapp update --min-replicas 1`.

## Why

Scale-to-zero (`min_replicas = 0`) meant every request after an idle gap paid a full cold start — container scheduling + ACR image pull over the private endpoint + .NET boot + first-time Key Vault/Graph managed-identity token acquisitions. A warm replica also keeps the token/JWKS/Key Vault caches hot, removing the ~3.3s first managed-identity token acquisition seen in the console logs.

## Scope / honesty note

This addresses the **server-side** cold-start and warm-up cost (observed worst case ~5s). It does **not** address end-to-end latency seen in MCP *clients* (e.g. Claude Code "brewed for ~1.5 min"), which is dominated by model inference over the tool result and conversation context, not the server — the server itself responds in ~5s. This change is a standalone infra correctness/consistency improvement (keeps live infra in sync with IaC) rather than a fix for client-perceived latency.

## Trade-off

One 0.5 vCPU / 1Gi replica is now billed continuously at the Container Apps idle rate instead of scaling to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)