### PR TITLE
docs(access): document the FISCAL IT Auth0 sign-in gate (department group)

### DIFF
--- a/ACCESS.md
+++ b/ACCESS.md
@@ -49,11 +49,23 @@ Group object IDs (for IT reference):
 | `sg-vitally-editors` | `19b9d659-284c-4f93-b1c3-a6354db1027c` |
 | `sg-vitally-admins`  | `70b48a20-d4b1-47dc-a132-21bc99272a86` |
 
+### Signing in is gated too (department group)
+
+Before a permission tier even applies, you must be able to **authenticate**. Sign-in is
+gated by the Auth0 → Entra federation app **"FISCAL IT Auth0"** (an Entra enterprise
+application): only users whose **department group** is assigned to that app can sign in. If
+your department isn't assigned, the Microsoft sign-in fails and you never reach the server —
+regardless of any `sg-vitally-*` membership.
+
+So access requires **both**: your department assigned to *FISCAL IT Auth0* (sign-in), **and**
+membership of an `sg-vitally-*` group (permission tier). Departments assigned today: Product,
+IT & Security, Project Management, Customer Operations, Customer Account Management.
+
 ## Getting access
 
 **As a user:** request membership of the group for the tier you need (most people need `sg-vitally-readers`) from the **IT & Security team**. Once added, you have access within about a minute — no need to reconnect or sign in again.
 
-**As an admin (granting/changing access):** add or remove the person from the relevant `sg-vitally-*` group in Entra. The server re-reads live group membership on each call (cached ~60 seconds), so:
+**As an admin (granting/changing access):** first confirm the person's **department group is assigned to the "FISCAL IT Auth0" enterprise application** (Entra → Enterprise applications → FISCAL IT Auth0 → Users and groups) so they can sign in — assign it if their department is new. Then add or remove the person from the relevant `sg-vitally-*` group in Entra. The server re-reads live group membership on each call (cached ~60 seconds), so:
 
 - **Granting** a tier takes effect within ~60s of adding the user to the group.
 - **Changing** tier = move the user to a different group (e.g. readers → editors).

--- a/ACCESS.md
+++ b/ACCESS.md
@@ -57,15 +57,17 @@ application): only users whose **department group** is assigned to that app can 
 your department isn't assigned, the Microsoft sign-in fails and you never reach the server —
 regardless of any `sg-vitally-*` membership.
 
-So access requires **both**: your department assigned to *FISCAL IT Auth0* (sign-in), **and**
-membership of an `sg-vitally-*` group (permission tier). Departments assigned today: Product,
-IT & Security, Project Management, Customer Operations, Customer Account Management.
+So access requires **both**: your department assigned to **"FISCAL IT Auth0"** (sign-in),
+**and** membership of an `sg-vitally-*` group (permission tier). The current list of assigned
+departments is maintained in the IT helpdesk article
+*Vitally MCP – access & administration (IT)* and can be verified live in
+Entra → Enterprise applications → **FISCAL IT Auth0** → Users and groups.
 
 ## Getting access
 
 **As a user:** request membership of the group for the tier you need (most people need `sg-vitally-readers`) from the **IT & Security team**. Once added, you have access within about a minute — no need to reconnect or sign in again.
 
-**As an admin (granting/changing access):** first confirm the person's **department group is assigned to the "FISCAL IT Auth0" enterprise application** (Entra → Enterprise applications → FISCAL IT Auth0 → Users and groups) so they can sign in — assign it if their department is new. Then add or remove the person from the relevant `sg-vitally-*` group in Entra. The server re-reads live group membership on each call (cached ~60 seconds), so:
+**As an admin (granting/changing access):** first confirm the person's **department group is assigned to the "FISCAL IT Auth0" enterprise application** (Entra → Enterprise applications → FISCAL IT Auth0 → Users and groups) so they can sign in — assign that department group to the app if it isn't already listed. Then add or remove the person from the relevant `sg-vitally-*` group in Entra. The server re-reads live group membership on each call (cached ~60 seconds), so:
 
 - **Granting** a tier takes effect within ~60s of adding the user to the group.
 - **Changing** tier = move the user to a different group (e.g. readers → editors).


### PR DESCRIPTION
## What

ACCESS.md previously described only the `sg-vitally-*` permission tiers (Gate 2). It didn't mention that **authentication itself is gated**: a user's **department group** must be assigned to the **"FISCAL IT Auth0"** Entra enterprise application, or the Auth0 → Entra sign-in fails before any tier check runs.

This PR documents that as **Gate 1** in the access model and adds the matching admin fulfilment step, so the repo agrees with the newly-updated helpdesk KB articles.

## Changes

- **Access model** — new "Signing in is gated too (department group)" subsection explaining the two-gate model (department on *FISCAL IT Auth0* to sign in **+** `sg-vitally-*` membership for a tier), and the departments currently assigned.
- **Getting access (admin)** — the fulfilment steps now start with confirming/assigning the requester's department on *FISCAL IT Auth0* before adding them to a tier group.

## Notes

- Docs-only; no code or behaviour change.
- Details verified against the live tenant (the "FISCAL IT Auth0" enterprise app's assigned groups) on 2026-07-07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)