### PR TITLE
docs(access): grant Exec Leadership write tier + clarify enforced sign-in gate

### DIFF
--- a/ACCESS.md
+++ b/ACCESS.md
@@ -49,6 +49,18 @@ Group object IDs (for IT reference):
 | `sg-vitally-editors` | `19b9d659-284c-4f93-b1c3-a6354db1027c` |
 | `sg-vitally-admins`  | `70b48a20-d4b1-47dc-a132-21bc99272a86` |
 
+### Departments currently granted a tier
+
+Tiers are granted to whole teams by **nesting a department group** inside the relevant
+`sg-vitally-*` group, rather than adding people one by one. As of 2026-07-09 (Entra is the
+live source of truth — verify there if in doubt):
+
+| Tier | Departments |
+|---|---|
+| Read (`sg-vitally-readers`) | Product |
+| Write (`sg-vitally-editors`) | Customer Account Management, Customer Operations, Executive Leadership Team, Project Management |
+| Delete (`sg-vitally-admins`) | *(granted to individuals, not by department)* |
+
 ### Signing in is gated too (department group)
 
 Before a permission tier even applies, you must be able to **authenticate**. Sign-in is
@@ -62,6 +74,15 @@ So access requires **both**: your department assigned to **"FISCAL IT Auth0"** (
 departments is maintained in the IT helpdesk article
 *Vitally MCP – access & administration (IT)* and can be verified live in
 Entra → Enterprise applications → **FISCAL IT Auth0** → Users and groups.
+
+> **Direct assignment only (important).** The app requires assignment
+> (`appRoleAssignmentRequired = true`), and Entra honours only **direct** members of an
+> assigned group for sign-in — **nested groups do not count here**. This is the opposite of the
+> permission tier below, which *is* evaluated transitively. Assign the **department group
+> itself** to the app (the dynamic `*-Department` groups qualify, since their members are direct
+> members). Nesting a department inside an `sg-vitally-*` group grants the *tier* but **not**
+> sign-in, so a team needs both: the department nested in `sg-vitally-editors`/etc. **and** that
+> same department directly assigned to *FISCAL IT Auth0*.
 
 ## Getting access
 

--- a/docs/runbooks/read-only-and-rbac-rollout.md
+++ b/docs/runbooks/read-only-and-rbac-rollout.md
@@ -22,6 +22,12 @@ The server-side RBAC backstop already exists (`ToolAuthorizer` maps HTTP verb �
    `GroupMember.Read.All`. Membership is evaluated **transitively** (Graph `transitiveMembers`), so a
    user who inherits a tier via a **nested/department group** inside an `sg-vitally-*` group is
    authorised — you can assign tiers by nesting groups, not only by adding users directly.
+   > **Sign-in gate is separate and direct-only.** Authorising a tier (above) is transitive, but
+   > *authenticating* is gated by the **FISCAL IT Auth0** enterprise app, which has
+   > `appRoleAssignmentRequired = true` and honours only **direct** members of assigned groups —
+   > nested groups do **not** grant sign-in. So each department that should have access must be
+   > **directly assigned** to *FISCAL IT Auth0* as well as nested into its `sg-vitally-*` tier.
+   > See `ACCESS.md` (canonical) for the full model.
 3. **Auth0 (alternative/auxiliary — the token-claim fallback):** a post-login Action
    (`Vitally MCP claims`) maps Entra group membership to the `vitally:*` permissions, written to the
    namespaced `Authorization:CustomPermissionsClaim`. This path runs only when the live Graph lookup


### PR DESCRIPTION
## What

Documents an operational access change made in Entra: the **Executive Leadership Team Department** now has the **write** tier on the Vitally MCP server.

- **Write tier** — the department is nested inside `sg-vitally-editors` (transitive RBAC), so its members inherit `vitally:write`.
- **Sign-in** — the department is directly assigned to the *FISCAL IT Auth0* enterprise app (Gate 1).

## Doc changes

- **`ACCESS.md`** — lists Executive Leadership Team under the Write tier in the "Departments currently granted a tier" table, and adds a **"Direct assignment only"** callout: the sign-in gate is now enforced (`appRoleAssignmentRequired = true`) and honours only **direct** members of assigned groups, unlike the **transitive** RBAC tier. So a team needs both the department nested in `sg-vitally-editors` **and** directly assigned to *FISCAL IT Auth0*.
- **`docs/runbooks/read-only-and-rbac-rollout.md`** — adds the matching sign-in-gate caveat so the runbook doesn't imply nesting alone grants access.

## Notes

- The Entra changes and the Zendesk KB article (`Vitally MCP – access & administration (IT)`) were already applied/published out-of-band; this PR brings the in-repo docs in sync.
- No application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)