### PR TITLE
chore: remove the last SuppressMessage attributes naming CodeQL rule ids

### DIFF
--- a/VitallyMcp/VitallyService.cs
+++ b/VitallyMcp/VitallyService.cs
@@ -629,10 +629,12 @@ public class VitallyService
         writer.WriteEndObject();
     }
 
+    // CodeQL raises cs/linq/missed-where on the foreach here and in WriteFilteredTraits below.
+    // That cannot be suppressed in source — SuppressMessage is a Roslyn mechanism and CodeQL never
+    // reads it, so an attribute naming a cs/* rule id suppresses nothing. Both are dismissed as
+    // won't-fix on the alerts themselves; reinstating attributes here would only look like it works.
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1860",
         Justification = "JsonElement.TryGetProperty uses an out parameter that LINQ Where cannot expose without a redundant second call. The explicit foreach is clearer and more efficient than the LINQ rewrite.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "cs/linq/missed-where",
-        Justification = "Same as above — TryGetProperty out parameter pattern.")]
     private static void WriteFilteredFields(Utf8JsonWriter writer, JsonElement element, string[] fields, string[]? requestedTraits)
     {
         foreach (var field in fields)
@@ -653,8 +655,6 @@ public class VitallyService
         }
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "cs/linq/missed-where",
-        Justification = "JsonElement.TryGetProperty out parameter doesn't translate to LINQ Where without a redundant second call.")]
     private static void WriteFilteredTraits(Utf8JsonWriter writer, JsonElement traitsElement, string[] requestedTraits)
     {
         writer.WriteStartObject();


### PR DESCRIPTION
Finishes the cleanup begun in #98, which was deliberately scoped to the test project. These are the two remaining offenders, both in `VitallyMcp/VitallyService.cs`.

## Why they were dead code

`SuppressMessage` is a Roslyn mechanism; CodeQL never reads it. So an attribute naming a `cs/*` rule id suppresses nothing, however plausible it looks. The evidence is in the alert history — what actually silenced these two findings was dismissing them on the alerts themselves:

| Alert | Rule | Location at the time | State |
|---|---|---|---|
| #11 | `cs/linq/missed-where` | `VitallyService.cs:638` (`WriteFilteredFields`) | dismissed — won't fix |
| #10 | `cs/linq/missed-where` | `VitallyService.cs:662` (`WriteFilteredTraits`) | dismissed — won't fix |

Both map exactly to the two methods whose attributes are removed here.

## What stays

The `[SuppressMessage("Performance", "CA1860")]` on `WriteFilteredFields` — a genuine Roslyn rule id, untouched. Its justification now carries a short note covering both methods, explaining that the CodeQL equivalent can only be dismissed on the alert. That puts the reason in the one place someone will look before reinstating an attribute that cannot work.

Note `WriteFilteredTraits` had **only** the inert attribute, no `CA1860` pairing, so it is left with none. That changes nothing: alert #10 is already dismissed, and had Roslyn any complaint there it would already be firing, since nothing was suppressing it.

## Verification

Release build clean (0 warnings, 0 errors) and the full suite passes:

```
Test run summary: Passed!
  total: 388
  failed: 0
  succeeded: 388
  skipped: 0
```

Comment-and-attribute change only — no behaviour change, no test code touched. After this, no `SuppressMessage` attribute anywhere in the repo names a CodeQL rule id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qvafk8DkdTEVcGge8vP61Q