### PR TITLE
fix: make the OAuth proxy a complete authorisation-server façade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,57 +197,54 @@ The server uses ASP.NET Core 10 with `WebApplication.CreateBuilder` + `Microsoft
 - MCP server registered via `AddMcpServer().WithHttpTransport(o => o.Stateless = true).WithToolsFromAssembly()`.
 - Publishes server-level usage guidance in the MCP `initialize` response via `McpServerOptions.ServerInstructions` (text in `VitallyServerInstructions.Text`): steers clients toward organisation-level data, the traits-vs-custom-objects distinction, the name/date-range filters, and the read-only/permission model.
 - OAuth proxy endpoints (only active when `OAuth:SharedClientId` is set):
-  - `GET /.well-known/oauth-protected-resource` — RFC 9728 metadata.
-  - `GET /.well-known/oauth-authorization-server` — RFC 8414 metadata pointing `registration_endpoint` at our DCR shim.
+  - `GET /.well-known/oauth-protected-resource` — RFC 9728 metadata, serialised with `McpJsonUtilities.DefaultOptions`. That is load-bearing, not incidental: the ASP.NET Core defaults write every unset optional as an explicit `null`, and RFC 9728 §3.2 requires an unused parameter to be *omitted* — strict clients reject the whole document over the difference.
+  - `GET /.well-known/oauth-authorization-server` — RFC 8414 metadata declaring **our own origin** as `issuer` (see the façade section below), pointing `authorization_endpoint` / `token_endpoint` / `registration_endpoint` at our own proxy endpoints, and advertising `authorization_response_iss_parameter_supported: true`. `userinfo_endpoint` and `jwks_uri` still point at Auth0, which issues the tokens.
   - `GET /oauth/authorize` — validates the client `redirect_uri` against `OAuth:AllowedClientRedirectUris` (plus implicit loopback exemption), stashes it keyed by `state`, and proxies to Auth0 with our own fixed callback.
-  - `GET /oauth/callback` — reverses the stash, redirects to the original client URI.
+  - `GET /oauth/callback` — reverses the stash, **replaces any upstream `iss` with our own origin**, and redirects to the original client URI.
   - `POST /oauth/token` — proxies code/refresh exchanges to Auth0, server-side-injecting `SharedClientSecret`.
   - `POST /oauth/register` — RFC 7591 DCR shim returning `SharedClientId` plus filtered `redirect_uris`.
 - `MapMcp("/mcp").RequireAuthorization()` — auth requirement is dropped when `NoAuth=true`.
 - The 401 challenge on `/mcp` carries a single `WWW-Authenticate` value pointing at the protected-resource metadata document (`resource_metadata="{PublicBaseUrl}/.well-known/oauth-protected-resource/mcp"`), adding `error="invalid_token"` when a token was presented and failed validation. The metadata document is served from both `/.well-known/oauth-protected-resource` and the `/mcp`-suffixed path (`ProtectedResourceMetadataBuilder.MetadataPath`). The status stays exactly 401 — `.github/workflows/deploy.yml` smoke-tests that and rolls back if it changes, so don't alter it.
 
 
-### Known limitation: strict RFC 8414 clients cannot complete the OAuth flow
+### The OAuth proxy is a complete authorisation-server façade
 
-The proxy serves RFC 8414 authorisation-server metadata **from our own origin** while declaring
-**Auth0's** issuer:
+From a client's point of view this server *is* the authorisation server: `/oauth/authorize`,
+`/oauth/token` and `/oauth/register` are all ours. So the RFC 8414 document declares **our own
+origin** as `issuer` (`PublicBaseUrl`, falling back to the request origin) — the same string
+`ProtectedResourceMetadataBuilder` publishes as `authorization_servers`. Auth0 still issues the
+tokens and `jwks_uri` / `userinfo_endpoint` still point there; the façade covers identity and
+discovery, not issuance.
 
-- served from `https://vitally.fiscaltec.com/.well-known/oauth-authorization-server`
-- declares `"issuer": "https://fiscal-it.uk.auth0.com/"`
+It previously declared **Auth0's** issuer while being served from our origin, which violates RFC 8414
+§3.3 (an anti-mix-up control: a metadata document can only ever speak for itself) and made strict
+clients — including **MCP Inspector** — abort before reaching DCR. Fixed 2026-08-21 (#90).
 
-RFC 8414 §3.3 requires the issuer to correspond to the URL the document was fetched from — an
-anti-mix-up control, so a metadata document can only ever speak for itself. The TypeScript MCP SDK
-enforces it and aborts:
+**Three pieces that must stay together.** Changing any one alone breaks the flow:
 
-```
-Issuer mismatch in authorization server metadata (RFC 8414 §3.3):
-expected "<our origin>/", received "https://fiscal-it.uk.auth0.com/"
-```
+| Piece | Why |
+|---|---|
+| `issuer` = our origin | RFC 8414 §3.3. Must equal `authorization_servers` in the RFC 9728 document byte for byte — the check is simple string equality, tolerating only a trailing slash *on the expected value*. |
+| `/oauth/callback` strips any upstream `iss` and appends our own | RFC 9207. **Mandatory, not defensive.** Clients compare a *present* `iss` against the metadata `issuer` even when support is not advertised — so an Auth0 `iss` forwarded through would now be a hard failure, and appending ours alongside would leave two values. |
+| `authorization_response_iss_parameter_supported: true` | Honest only because of the row above. Advertising it and then omitting `iss` reads as a stripped-parameter attack and the client aborts. |
 
-**So MCP Inspector cannot connect to this server — production included.** Verified against both a
-local container and a live staging deployment on 2026-08-12. Everything before that point works: the
-401 challenge, the `resource_metadata` pointer, the protected-resource document (parsed successfully)
-and the AS metadata fetch. It halts only at issuer validation, before DCR.
+**Verified 2026-08-21** against `@modelcontextprotocol/client` 2.0.0 — the package MCP Inspector 2.3.0
+actually depends on — driving a local container: the RFC 9728 document parses, `discoverAuthorizationServerMetadata`
+passes §3.3, **DCR is reached and returns the shared `client_id`** (it was never called before), and
+`validateAuthorizationResponseIssuer` accepts the `iss` we emit. A control assertion confirms the same
+function still rejects Auth0's issuer, so the passes are not a skipped check.
 
-**Why production works anyway:** Claude's clients do not enforce §3.3, so they take our endpoints and
-proceed. This is a latent problem rather than an outage — but the 2026-07-28 revision tightens OAuth,
-so a client that starts enforcing it would break every user at once.
+Two things were verified rather than assumed, both of which the design had flagged as open:
 
-**Why it is not a one-line fix.** Declaring our own origin as `issuer` satisfies §3.3 but collides
-with RFC 9207, where the client checks the `iss` returned on the authorization response — Auth0
-returns its own. Any fix must reconcile both, or stop proxying `/oauth/authorize` and `/oauth/token`,
-which would give up the DCR shim that exists to converge every client on one pre-registered app.
+- **No client validates the access token's `iss` against the metadata `issuer`.** The SDK's client
+  auth module never decodes a JWT or fetches JWKS — access tokens are opaque to it — so `jwks_uri`
+  pointing at Auth0 while we claim the issuer is safe. Our own `JwtBearer` validates against Auth0's
+  `Authority` internally and is unaffected either way.
+- **The published SDK 1.x does not enforce §3.3 at all**; the enforcement ships in the 2.x packages.
+  So this was latent for Claude Desktop / Claude Code and immediately fatal for anything on 2.x.
 
-The likely shape (designed, **not** validated): make the proxy a complete authorisation-server façade
-— declare our own origin as `issuer`, have `/oauth/callback` **inject** `iss` set to our origin
-(injecting unconditionally is more robust than rewriting, since whether Auth0 sends `iss` depends on
-tenant config), and advertise `authorization_response_iss_parameter_supported: true`. Check first
-whether any client validates an access token's `iss` against the metadata `issuer`; MCP clients treat
-access tokens as opaque, so this is probably safe, but verify rather than assume. Our own JwtBearer
-validates against Auth0's `Authority` internally and is unaffected either way.
-
-Fixing this would also make **MCP Inspector a usable test client**, which materially cheapens future
-validation work — the practical argument, rather than RFC pedantry.
+**If you touch this,** re-run that validation rather than reasoning about it — `npx @modelcontextprotocol/inspector`
+against a local container is now a working end-to-end client, which is the practical payoff.
 
 ### Configuration (VitallyServerOptions.cs + OAuthOptions.cs)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,8 +243,26 @@ Two things were verified rather than assumed, both of which the design had flagg
 - **The published SDK 1.x does not enforce §3.3 at all**; the enforcement ships in the 2.x packages.
   So this was latent for Claude Desktop / Claude Code and immediately fatal for anything on 2.x.
 
+**Validated against the live Auth0 tenant on 2026-08-22**, which the local run could not cover. MCP
+Inspector 2.3.0 completed the whole flow against the server behind an HTTPS tunnel with
+`PublicBaseUrl` set: metadata 200, DCR `201`, real Auth0→Entra sign-in, `/oauth/callback` 302 carrying
+`iss=<our origin>` which the client *accepted*, `/oauth/token` 200, and authenticated `POST /mcp` 200.
+That is the acceptance test in #90, and it is past the point where the flow previously aborted.
+
 **If you touch this,** re-run that validation rather than reasoning about it — `npx @modelcontextprotocol/inspector`
 against a local container is now a working end-to-end client, which is the practical payoff.
+
+**Two traps when validating against a throwaway Auth0 audience** (both cost time on 2026-08-22):
+
+- **`tools/list` will be empty, and that is expected.** The post-login Action `Vitally MCP claims`
+  opens with `if (event.resource_server?.identifier !== 'https://vitally.fiscaltec.com/') return;`,
+  so no `permissions` claim is minted for any other audience and every tool is filtered out. It looks
+  exactly like an authorisation failure at the moment you are least able to dismiss it. Set
+  `Authorization:Enabled=false` to confirm the rest of the path, or accept the empty list as evidence
+  the RBAC discovery filter fails closed.
+- **Auth0 API identifiers are immutable and must equal the server origin** (the client throws if the
+  RFC 9728 `resource` does not match), so an ephemeral tunnel URL orphans one API per run. Use a
+  stable hostname, or budget for the cleanup.
 
 ### Configuration (VitallyServerOptions.cs + OAuthOptions.cs)
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ When `OAuth:SharedClientId` is set the server runs an OAuth 2.0 proxy in front o
 | Endpoint | Purpose |
 |---|---|
 | `GET /.well-known/oauth-protected-resource` | RFC 9728 protected-resource metadata — clients use it to discover the authorisation server. |
-| `GET /.well-known/oauth-authorization-server` | RFC 8414 authorisation-server metadata — points `authorization_endpoint` and `token_endpoint` at the proxy and `registration_endpoint` at our DCR shim. |
+| `GET /.well-known/oauth-authorization-server` | RFC 8414 authorisation-server metadata — declares this server's own origin as `issuer` and points `authorization_endpoint`, `token_endpoint` and `registration_endpoint` at the proxy. `jwks_uri` and `userinfo_endpoint` still point at Auth0, which issues the tokens. |
 | `GET /oauth/authorize` | Captures the client's `redirect_uri`, swaps it for our fixed `/oauth/callback`, and 302s the user upstream to Auth0. Validates the client `redirect_uri` against the loopback + allowlist rules before stashing. |
 | `GET /oauth/callback` | Receives the Auth0 redirect, looks up the original client `redirect_uri` from `state`, and 302s the user back to it with the code. |
 | `POST /oauth/token` | Forwards the code-exchange to Auth0 and injects `SharedClientSecret` so the shared app stays confidential without exposing the secret to MCP clients. |
@@ -212,16 +212,13 @@ Full per-tool descriptions are auto-generated from the `[McpServerTool]` attribu
 - HTTPS is terminated at the platform ingress (Container Apps managed cert) — the server itself doesn't ship TLS.
 - The OAuth proxy validates every client `redirect_uri` against `OAuth:AllowedClientRedirectUris` (plus the implicit RFC 8252 loopback rule). Without this check, an attacker could exfiltrate authorisation codes via the proxy's `/oauth/callback` reflector; with it, the proxy refuses anything that isn't a loopback URI or an explicitly-allowlisted hosted callback.
 
-### Known limitation: strict RFC 8414 clients
+### Standards conformance of the OAuth proxy
 
-The OAuth proxy serves authorisation-server metadata from this server's own origin while declaring
-Auth0's `issuer`. RFC 8414 §3.3 requires those to match, so a client enforcing it — including **MCP
-Inspector** — aborts before dynamic client registration and cannot connect. Claude Desktop and Claude
-Code do not enforce it, which is why they work.
-
-Everything up to that point is correct: the 401 challenge, the `resource_metadata` pointer and both
-metadata documents. Fixing it properly collides with RFC 9207 `iss` validation and is tracked
-separately; see the *Known limitation* section in `CLAUDE.md` for the analysis and the proposed shape.
+The proxy presents itself as a complete authorisation server: it declares its own origin as `issuer`
+(RFC 8414 §3.3), and `/oauth/callback` replaces any upstream `iss` with that same origin so the
+authorization response is consistent with the metadata (RFC 9207). Auth0 remains the token issuer.
+Strict clients — including **MCP Inspector** — complete the flow; see the *complete
+authorisation-server façade* section in `CLAUDE.md` for what was verified and how.
 
 ## Licence
 

--- a/VitallyMcp.Tests/OAuthProxyEndpointsTests.cs
+++ b/VitallyMcp.Tests/OAuthProxyEndpointsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -129,6 +130,139 @@ public class OAuthProxyEndpointsTests : IClassFixture<OAuthProxyEndpointsTests.F
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var json = await response.Content.ReadAsStringAsync();
         json.Should().Contain("unsupported_grant_type");
+    }
+
+    [Fact]
+    public async Task AuthorizationServerMetadata_DeclaresTheServingOriginAsIssuer()
+    {
+        // RFC 8414 §3.3: the `issuer` in the document must be identical to the issuer identifier
+        // used to build the well-known URL. It is an anti-mix-up control — without it, anyone able
+        // to serve you a metadata document could point you at another issuer's endpoints while you
+        // believe you are talking to the issuer you trust. We serve this document from our own
+        // origin and front /oauth/authorize, /oauth/token and /oauth/register ourselves, so our own
+        // origin is the honest answer; declaring Auth0's made strict clients (the TypeScript MCP
+        // SDK, hence MCP Inspector) abort before ever reaching DCR.
+        using var client = _factory.CreateClient();
+
+        using var doc = JsonDocument.Parse(await client.GetStringAsync("/.well-known/oauth-authorization-server"));
+
+        doc.RootElement.GetProperty("issuer").GetString().Should().Be("http://localhost");
+        doc.RootElement.GetProperty("issuer").GetString().Should().NotContain("auth0.com",
+            "the upstream authority still issues the tokens, but it is not what this document speaks for");
+    }
+
+    [Theory]
+    [InlineData("/.well-known/oauth-protected-resource")]
+    [InlineData("/.well-known/oauth-protected-resource/mcp")]
+    public async Task AuthorizationServerMetadata_IssuerMatchesTheAuthorizationServerAdvertisedToClients(string resourceMetadataPath)
+    {
+        // The pairing a strict client actually checks: it reads `authorization_servers` out of the
+        // protected-resource document, uses that string verbatim to build the well-known URL, and
+        // requires the returned `issuer` to equal it. Asserting each document in isolation would
+        // let the two drift apart while both still looked correct, so pin them together.
+        using var client = _factory.CreateClient();
+
+        using var resourceDoc = JsonDocument.Parse(await client.GetStringAsync(resourceMetadataPath));
+        var advertisedAuthorizationServer = resourceDoc.RootElement
+            .GetProperty("authorization_servers").EnumerateArray().Single().GetString();
+
+        using var asDoc = JsonDocument.Parse(await client.GetStringAsync("/.well-known/oauth-authorization-server"));
+
+        asDoc.RootElement.GetProperty("issuer").GetString().Should().Be(advertisedAuthorizationServer);
+    }
+
+    [Fact]
+    public async Task AuthorizationServerMetadata_AdvertisesIssParameterSupport()
+    {
+        // Honest only because /oauth/callback injects `iss` unconditionally. Advertising support
+        // while omitting the parameter is itself an error a strict client reports, so this
+        // assertion and Callback_AddsIssMatchingTheMetadataIssuer are two halves of one contract.
+        using var client = _factory.CreateClient();
+
+        using var doc = JsonDocument.Parse(await client.GetStringAsync("/.well-known/oauth-authorization-server"));
+
+        doc.RootElement.GetProperty("authorization_response_iss_parameter_supported").GetBoolean()
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Callback_AddsIssMatchingTheMetadataIssuer()
+    {
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        using var metadata = JsonDocument.Parse(await client.GetStringAsync("/.well-known/oauth-authorization-server"));
+        var expectedIssuer = metadata.RootElement.GetProperty("issuer").GetString();
+
+        var location = await AuthorizeThenCallbackAsync(client, state: "iss-added");
+
+        var iss = QueryHelpers.ParseQuery(location.Query)["iss"];
+        iss.Count.Should().Be(1);
+        iss[0].Should().Be(expectedIssuer,
+            "clients compare the two with simple string equality — no trailing-slash or percent-encoding normalisation");
+    }
+
+    [Fact]
+    public async Task Callback_ReplacesAnUpstreamIssWithOurOwn()
+    {
+        // Auth0 sends `iss` naming itself when the tenant is configured for RFC 9207, and whether
+        // it does is tenant configuration we do not control. Forwarding that value — or appending
+        // ours alongside it — breaks strict clients: the SDK compares a *present* `iss` against the
+        // metadata issuer even when support is not advertised. So the upstream value must be
+        // dropped rather than kept, and there must be exactly one `iss` on the way out.
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var location = await AuthorizeThenCallbackAsync(client, state: "iss-replaced",
+            upstreamExtras: "&iss=" + Uri.EscapeDataString("https://example.auth0.com/"));
+
+        var iss = QueryHelpers.ParseQuery(location.Query)["iss"];
+        iss.Count.Should().Be(1, "a duplicated parameter lets a client read whichever one it happens to pick first");
+        iss[0].Should().Be("http://localhost");
+        location.Query.Should().NotContain("auth0.com");
+    }
+
+    [Fact]
+    public async Task Callback_PreservesTheAuthorizationCodeAndState()
+    {
+        // Guards the iss handling against over-reach: rewriting the query string must not disturb
+        // the parameters the client actually needs to complete the code exchange.
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var location = await AuthorizeThenCallbackAsync(client, state: "iss-passthrough");
+
+        var query = QueryHelpers.ParseQuery(location.Query);
+        query["code"].ToString().Should().Be("test-code");
+        query["state"].ToString().Should().Be("iss-passthrough");
+    }
+
+    /// <summary>
+    /// Drives the real two-hop proxy flow: /oauth/authorize stores the state→redirect_uri mapping
+    /// that /oauth/callback reverses, so the callback cannot be exercised in isolation. Returns the
+    /// absolute URI the callback redirects the client to.
+    /// </summary>
+    private static async Task<Uri> AuthorizeThenCallbackAsync(HttpClient client, string state, string upstreamExtras = "")
+    {
+        const string clientRedirectUri = "http://localhost:54321/callback";
+
+        var authorize = await client.GetAsync(
+            $"/oauth/authorize?response_type=code&client_id=test&state={state}&redirect_uri={Uri.EscapeDataString(clientRedirectUri)}");
+        authorize.StatusCode.Should().Be(HttpStatusCode.Redirect);
+
+        var callback = await client.GetAsync($"/oauth/callback?code=test-code&state={state}{upstreamExtras}");
+        callback.StatusCode.Should().Be(HttpStatusCode.Redirect);
+
+        var location = callback.Headers.Location;
+        location.Should().NotBeNull();
+        location!.ToString().Should().StartWith(clientRedirectUri);
+        return location;
     }
 
     public class Factory : WebApplicationFactory<Program>

--- a/VitallyMcp.Tests/OAuthProxyEndpointsTests.cs
+++ b/VitallyMcp.Tests/OAuthProxyEndpointsTests.cs
@@ -227,6 +227,30 @@ public class OAuthProxyEndpointsTests : IClassFixture<OAuthProxyEndpointsTests.F
     }
 
     [Fact]
+    public async Task Callback_ReplacesAnUpstreamIssRegardlessOfItsCasing()
+    {
+        // IQueryCollection lookups are case-insensitive but enumeration preserves the casing as
+        // parsed, so an exact-match skip would forward a differently-cased `ISS` alongside ours.
+        // A conformant client would never read it — OAuth parameter names are case-sensitive, so
+        // only the lowercase `iss` is ever compared — but leaving it there means the next reader
+        // has to derive that for themselves before concluding the redirect is safe.
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var location = await AuthorizeThenCallbackAsync(client, state: "iss-mixed-case",
+            upstreamExtras: "&ISS=" + Uri.EscapeDataString("https://example.auth0.com/"));
+
+        var issLike = QueryHelpers.ParseQuery(location.Query)
+            .Where(kv => string.Equals(kv.Key, "iss", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(kv => kv.Value.ToArray())
+            .ToArray();
+
+        issLike.Should().BeEquivalentTo(new[] { "http://localhost" });
+    }
+
+    [Fact]
     public async Task Callback_PreservesTheAuthorizationCodeAndState()
     {
         // Guards the iss handling against over-reach: rewriting the query string must not disturb

--- a/VitallyMcp.Tests/OAuthProxyPublicOriginTests.cs
+++ b/VitallyMcp.Tests/OAuthProxyPublicOriginTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace VitallyMcp.Tests;
+
+/// <summary>
+/// The production shape, which <see cref="OAuthProxyEndpointsTests"/> cannot cover: there
+/// <c>OAuth:PublicBaseUrl</c> is set, so the canonical origin is <em>not</em> the request
+/// <c>Host</c>. Every identity we publish — the protected-resource document's
+/// <c>authorization_servers</c>, the authorization-server document's <c>issuer</c>, and the
+/// <c>iss</c> injected on the callback — must be that one configured origin. A regression that
+/// silently fell back to the request host would still pass the sibling class's assertions, because
+/// there the two values coincide.
+/// </summary>
+public class OAuthProxyPublicOriginTests : IClassFixture<OAuthProxyPublicOriginTests.Factory>
+{
+    private const string PublicOrigin = "https://vitally.example.com";
+
+    private readonly Factory _factory;
+
+    public OAuthProxyPublicOriginTests(Factory factory) => _factory = factory;
+
+    [Fact]
+    public async Task AuthorizationServerMetadata_DeclaresThePublicBaseUrlAsIssuer()
+    {
+        using var client = _factory.CreateClient();
+
+        using var doc = JsonDocument.Parse(await client.GetStringAsync("/.well-known/oauth-authorization-server"));
+
+        doc.RootElement.GetProperty("issuer").GetString().Should().Be(PublicOrigin,
+            "a spoofed Host header must never be able to steer the identity we publish");
+    }
+
+    [Fact]
+    public async Task AuthorizationServerMetadata_IssuerMatchesTheAuthorizationServerAdvertisedToClients()
+    {
+        using var client = _factory.CreateClient();
+
+        using var resourceDoc = JsonDocument.Parse(
+            await client.GetStringAsync("/.well-known/oauth-protected-resource"));
+        var advertisedAuthorizationServer = resourceDoc.RootElement
+            .GetProperty("authorization_servers").EnumerateArray().Single().GetString();
+
+        using var asDoc = JsonDocument.Parse(await client.GetStringAsync("/.well-known/oauth-authorization-server"));
+
+        advertisedAuthorizationServer.Should().Be(PublicOrigin);
+        asDoc.RootElement.GetProperty("issuer").GetString().Should().Be(advertisedAuthorizationServer);
+    }
+
+    [Fact]
+    public async Task Callback_InjectsIssMatchingThePublicBaseUrl()
+    {
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        const string clientRedirectUri = "http://localhost:54321/callback";
+        const string state = "public-origin";
+
+        var authorize = await client.GetAsync(
+            $"/oauth/authorize?response_type=code&client_id=test&state={state}&redirect_uri={Uri.EscapeDataString(clientRedirectUri)}");
+        authorize.StatusCode.Should().Be(HttpStatusCode.Redirect);
+
+        var callback = await client.GetAsync(
+            $"/oauth/callback?code=test-code&state={state}&iss={Uri.EscapeDataString("https://example.auth0.com/")}");
+        callback.StatusCode.Should().Be(HttpStatusCode.Redirect);
+
+        var iss = QueryHelpers.ParseQuery(callback.Headers.Location!.Query)["iss"];
+        iss.Count.Should().Be(1);
+        iss[0].Should().Be(PublicOrigin);
+    }
+
+    public class Factory : WebApplicationFactory<Program>
+    {
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            builder.UseEnvironment(Environments.Development);
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["OAuth:NoAuth"] = "true",
+                    ["OAuth:Authority"] = "https://example.auth0.com/",
+                    ["OAuth:Audience"] = PublicOrigin,
+                    ["OAuth:PublicBaseUrl"] = PublicOrigin,
+                    ["OAuth:SharedClientId"] = "test-client-id",
+                    ["Vitally:Region"] = "EU",
+                    ["Vitally:DevelopmentApiKey"] = "sk_test_dummy"
+                });
+            });
+            return base.CreateHost(builder);
+        }
+    }
+}

--- a/VitallyMcp.Tests/README.md
+++ b/VitallyMcp.Tests/README.md
@@ -4,7 +4,7 @@ Automated test suite for the Vitally MCP server.
 
 ## Coverage
 
-**388 tests, all passing** (xUnit + FluentAssertions + Moq + ASP.NET Core
+**400 tests, all passing** (xUnit + FluentAssertions + Moq + ASP.NET Core
 test host), running fully in-process — no live API calls, no real Auth0
 tenant, no Key Vault.
 
@@ -26,7 +26,8 @@ tenant, no Key Vault.
 | `VitallyServiceTests` | Field/trait filtering, pagination, resource-specific defaults across every resource type, plus full coverage of `GetResourcesAsync`, `GetResourceByIdAsync`, `CreateResourceAsync`, `UpdateResourceAsync`, `DeleteResourceAsync`, `GetRawAsync` (with URL-encoded query params), `PostRawAsync`, `DeleteRawAsync`. Includes HTTP-verb, path, and Basic-auth header verification via Moq's `Protected().Verify(...)`. Also asserts that the response body is surfaced in `HttpRequestException` on non-2xx responses (regression guard). |
 | `VitallyRateLimitHandlerTests` | 429 retry behaviour, `Retry-After`/`X-RateLimit-Reset` header parsing, low-remaining warnings. |
 | `OAuthOptionsTests` | `IsRedirectUriAllowed` — RFC 8252 loopback any-port acceptance, https-loopback rejection, allowlist matching with subdomain/path-segment spoof guards, validation normalisation. |
-| `OAuthProxyEndpointsTests` | Integration test (via `WebApplicationFactory<Program>`) for `/oauth/authorize` and `/oauth/register`: rejects disallowed `redirect_uri`, accepts loopback + allowlisted hosted callbacks, filters partially-disallowed registration requests. |
+| `OAuthProxyEndpointsTests` | Integration test (via `WebApplicationFactory<Program>`) for the proxy endpoints: rejects disallowed `redirect_uri`, accepts loopback + allowlisted hosted callbacks, filters partially-disallowed registration requests, refuses unsupported grants. Also pins the RFC 8414 façade — `issuer` equals the serving origin *and* the `authorization_servers` value in the protected-resource document (asserted against each other, so the two documents cannot drift apart while both still look right), `authorization_response_iss_parameter_supported` is advertised, and `/oauth/callback` emits exactly one `iss` naming us, replacing any upstream value. |
+| `OAuthProxyPublicOriginTests` | The production shape `OAuthProxyEndpointsTests` cannot reach: with `OAuth:PublicBaseUrl` set, the published identity must be that configured origin and not the request `Host`. Its sibling's assertions would pass even on a regression to Host-derived values, because there the two coincide. |
 | `Tools/AccountsToolsTests` | List / get / create / update / delete + status filter + traits + list-by-organisation |
 | `Tools/SummaryToolsTests` | `Get_organization_summary` — the read-only composite (org get-by-id with curated rollup traits, object-name resolution, two organisation-scoped instance searches) and its per-sub-call error isolation |
 | `Tools/OrganizationsToolsTests` | CRUD + traits |
@@ -47,7 +48,7 @@ tenant, no Key Vault.
 | `ToolAuthorizePolicyCoverageTests` | Every tool carries exactly one `[Authorize]` whose policy matches its annotations, plus the exact 56 / 25 / 12 read / write / delete distribution. Pairs with the count assertion so neither can pass vacuously. |
 | `AuthorizationFilterToolsListTests` | The load-bearing authorisation suite. Per-tier `tools/list` filtering (exact 56 / 81 / 93 partition, subset relations, and the two off-prefix tools by name), the no-permissions caller seeing nothing, NoAuth dev mode seeing all 93 unfiltered, a reader's write call being refused, and exactly one audit-deny record per refused call. Also pins that whitespace in a configured permission cannot desync discovery from enforcement. |
 | `VitallyPermissionHandlerTests` | The ASP.NET Core authorisation handler: succeeds when the caller holds the permission, does not when they lack it, and short-circuits to success when authorisation is bypassed (RBAC off or `NoAuth`) so local dev is never filtered to an empty list. |
-| `ResourceMetadataDiscoveryTests` | The 401 challenge carries exactly **one** `WWW-Authenticate` value with a `resource_metadata` pointer, adds `error="invalid_token"` when a token was presented, and keeps the status at exactly 401 — which `.github/workflows/deploy.yml` smoke-tests. Both well-known metadata paths serve, asserted with exact collection counts rather than `Contain`, since `ProtectedResourceMetadata` ships `BearerMethodsSupported` pre-populated and an append would silently duplicate it. |
+| `ResourceMetadataDiscoveryTests` | The 401 challenge carries exactly **one** `WWW-Authenticate` value with a `resource_metadata` pointer, adds `error="invalid_token"` when a token was presented, and keeps the status at exactly 401 — which `.github/workflows/deploy.yml` smoke-tests. Both well-known metadata paths serve, asserted with exact collection counts rather than `Contain`, since `ProtectedResourceMetadata` ships `BearerMethodsSupported` pre-populated and an append would silently duplicate it. Also asserts no property is serialised as `null`: RFC 9728 §3.2 requires an unused parameter to be omitted, and a strict client rejects the whole document over the difference — invisible to a test that only reads the properties it expects to find. |
 | `ToolsListCachingTests` | Asserts the serialised wire form of the cache hints — `ttlMs` as integer milliseconds and `cacheScope` as `"private"` — deliberately on the raw JSON rather than the SDK's CLR properties, so an SDK rename is caught here rather than by clients. |
 | `IntegrationTestCollection` | Not a test — the xUnit collection definition serialising every class that mutates process-wide environment variables. See the note above; membership is mandatory for such classes. |
 | `CapturingLogger` / `CapturingLoggerProvider` | Test helper capturing `ILogger` output so audit assertions can be made against what `AuditLogger` actually recorded. |
@@ -57,7 +58,7 @@ tenant, no Key Vault.
 - **xUnit** — test framework
 - **Moq** — `HttpClient` mocking (`Mock<HttpMessageHandler>` + `Protected()`)
 - **FluentAssertions** — readable assertions
-- **Microsoft.AspNetCore.Mvc.Testing** — in-process integration host for `OAuthProxyEndpointsTests` (uses `WebApplicationFactory<Program>`)
+- **Microsoft.AspNetCore.Mvc.Testing** — in-process integration host for `OAuthProxyEndpointsTests`, `OAuthProxyPublicOriginTests` and the other integration classes (uses `WebApplicationFactory<Program>`)
 - **Microsoft.Testing.Extensions.CodeCoverage** — code coverage (`--coverage`)
 - **Microsoft.Testing.Extensions.TrxReport** — TRX output for the CI test summary (`--report-trx`)
 

--- a/VitallyMcp.Tests/ResourceMetadataDiscoveryTests.cs
+++ b/VitallyMcp.Tests/ResourceMetadataDiscoveryTests.cs
@@ -109,6 +109,29 @@ public class ResourceMetadataDiscoveryTests : IClassFixture<ResourceMetadataDisc
                 "the advertised scopes must match the builder's list exactly, with no duplicates");
     }
 
+    [Theory]
+    [InlineData("/.well-known/oauth-protected-resource")]
+    [InlineData("/.well-known/oauth-protected-resource/mcp")]
+    public async Task ProtectedResourceMetadata_OmitsUnsetOptionalFieldsRatherThanEmittingNull(string path)
+    {
+        // RFC 9728 §3.2: a metadata parameter that is not used is omitted. Serialising it as an
+        // explicit null is not the same thing, and strict clients reject the whole document for it
+        // — @modelcontextprotocol/client 2.0.0 (what MCP Inspector 2.3.0 depends on) types
+        // jwks_uri as a string and fails schema validation on a null, before any part of the OAuth
+        // flow is reached. That made this a second, earlier blocker than the issuer mismatch, and
+        // it is invisible to a test that only reads the properties it expects to be present.
+        using var client = _factory.CreateClient();
+
+        using var doc = JsonDocument.Parse(await client.GetStringAsync(path));
+
+        var nulls = doc.RootElement.EnumerateObject()
+            .Where(p => p.Value.ValueKind == JsonValueKind.Null)
+            .Select(p => p.Name)
+            .ToArray();
+
+        nulls.Should().BeEmpty("unused metadata parameters must be absent, not null");
+    }
+
     public class Factory : WebApplicationFactory<Program>
     {
         protected override IHost CreateHost(IHostBuilder builder)

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -416,7 +416,10 @@ app.MapGet("/oauth/callback", (HttpContext ctx, IOptions<OAuthOptions> oauth, IM
         // would leave the client two values to choose between. Clients compare a *present* `iss`
         // against the metadata issuer even when the parameter is not advertised, so both shapes
         // fail rather than degrade.
-        if (kv.Key == "iss") continue;
+        // OrdinalIgnoreCase, not ==: IQueryCollection lookups are case-insensitive but enumeration
+        // yields keys as they were parsed, so an exact match would forward a differently-cased
+        // `ISS` alongside the one we append below.
+        if (string.Equals(kv.Key, "iss", StringComparison.OrdinalIgnoreCase)) continue;
         foreach (var v in kv.Value)
         {
             sb.Append(Uri.EscapeDataString(kv.Key)).Append('=').Append(Uri.EscapeDataString(v ?? string.Empty)).Append('&');

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using ModelContextProtocol;
 using VitallyMcp;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -286,18 +287,26 @@ static string GetServerBaseUrl(HttpContext ctx, string? publicBaseUrl)
 // server, which for the DCR-proxy variant is *us* (so we can intercept registration). The actual
 // token issuance still happens at Auth0 — our discovery doc points to Auth0's endpoints for
 // everything except registration_endpoint.
+// Serialised with the SDK's own options rather than the ASP.NET Core defaults, because those
+// write every unset optional property as an explicit `null`. RFC 9728 §3.2 says an unused
+// metadata parameter is *omitted*, and strict clients enforce the difference: the published
+// @modelcontextprotocol/client schema types `jwks_uri` as a string and rejects the whole
+// document on a null, before any part of the OAuth flow is reached.
 var resourceMetadataHandler = (HttpContext ctx, IOptions<OAuthOptions> oauth) =>
-    Results.Json(ProtectedResourceMetadataBuilder.Build(
-        oauth.Value,
-        GetServerBaseUrl(ctx, oauth.Value.PublicBaseUrl)));
+    Results.Json(
+        ProtectedResourceMetadataBuilder.Build(oauth.Value, GetServerBaseUrl(ctx, oauth.Value.PublicBaseUrl)),
+        McpJsonUtilities.DefaultOptions);
 
 app.MapGet(ProtectedResourceMetadataBuilder.MetadataPath, resourceMetadataHandler);
 app.MapGet($"{ProtectedResourceMetadataBuilder.MetadataPath}/mcp", resourceMetadataHandler);
 
 // RFC 8414 — Authorization Server Metadata, served by us when the DCR proxy is enabled.
-// Auth0 still issues tokens (its endpoints are what `authorization_endpoint`/`token_endpoint`
-// point at), but `registration_endpoint` points at our own /oauth/register that hands every
-// caller a pre-registered shared client_id (see POST /oauth/register below).
+// `issuer` names our *own* origin, not Auth0's. §3.3 requires the issuer to correspond to the URL
+// the document was fetched from (an anti-mix-up control), and from the client's point of view we
+// genuinely are the authorization server: authorize, token and register are all ours. Auth0 still
+// issues the tokens, which is why `jwks_uri` and `userinfo_endpoint` remain upstream. Declaring our
+// origin here is coupled to the `iss` injection in /oauth/callback below — see the façade section
+// in CLAUDE.md before changing either.
 app.MapGet("/.well-known/oauth-authorization-server", (HttpContext ctx, IOptions<OAuthOptions> oauth) =>
 {
     var o = oauth.Value;
@@ -310,7 +319,7 @@ app.MapGet("/.well-known/oauth-authorization-server", (HttpContext ctx, IOptions
     var ourBase = GetServerBaseUrl(ctx, o.PublicBaseUrl);
     return Results.Json(new
     {
-        issuer = authority + "/",
+        issuer = ourBase,
         authorization_endpoint = $"{ourBase}/oauth/authorize",
         token_endpoint = $"{ourBase}/oauth/token",
         userinfo_endpoint = $"{authority}/userinfo",
@@ -320,7 +329,11 @@ app.MapGet("/.well-known/oauth-authorization-server", (HttpContext ctx, IOptions
         response_types_supported = new[] { "code" },
         grant_types_supported = new[] { "authorization_code", "refresh_token" },
         token_endpoint_auth_methods_supported = new[] { "none" },
-        code_challenge_methods_supported = new[] { "S256" }
+        code_challenge_methods_supported = new[] { "S256" },
+        // RFC 9207. Honest only because /oauth/callback injects `iss` unconditionally — a client
+        // that sees this flag and then no `iss` on the authorization response treats the absence
+        // as a stripped-parameter attack and aborts, so the two must ship together.
+        authorization_response_iss_parameter_supported = true
     });
 });
 
@@ -379,7 +392,7 @@ app.MapGet("/oauth/authorize", (HttpContext ctx, IOptions<OAuthOptions> oauth, I
     return Results.Redirect(sb.ToString());
 });
 
-app.MapGet("/oauth/callback", (HttpContext ctx, IMemoryCache cache) =>
+app.MapGet("/oauth/callback", (HttpContext ctx, IOptions<OAuthOptions> oauth, IMemoryCache cache) =>
 {
     var state = ctx.Request.Query["state"].ToString();
     if (string.IsNullOrWhiteSpace(state))
@@ -397,11 +410,22 @@ app.MapGet("/oauth/callback", (HttpContext ctx, IMemoryCache cache) =>
     var sb = new System.Text.StringBuilder(clientRedirectUri).Append(separator);
     foreach (var kv in ctx.Request.Query)
     {
+        // Drop any upstream `iss` — ours is appended below. Auth0 sends one naming itself when the
+        // tenant is configured for RFC 9207, and whether it does is tenant configuration we don't
+        // control. Forwarding it would contradict the issuer we publish; appending ours alongside
+        // would leave the client two values to choose between. Clients compare a *present* `iss`
+        // against the metadata issuer even when the parameter is not advertised, so both shapes
+        // fail rather than degrade.
+        if (kv.Key == "iss") continue;
         foreach (var v in kv.Value)
         {
             sb.Append(Uri.EscapeDataString(kv.Key)).Append('=').Append(Uri.EscapeDataString(v ?? string.Empty)).Append('&');
         }
     }
+    // RFC 9207 §2 — name ourselves as the issuer of this authorization response. Must match the
+    // `issuer` in our RFC 8414 document byte for byte: the comparison is simple string equality,
+    // with no scheme/host case folding, trailing-slash or percent-encoding normalisation applied.
+    sb.Append("iss=").Append(Uri.EscapeDataString(GetServerBaseUrl(ctx, oauth.Value.PublicBaseUrl)));
     return Results.Redirect(sb.ToString().TrimEnd('&'));
 });
 


### PR DESCRIPTION
Closes #90

The RFC 8414 metadata document was served from our own origin while declaring **Auth0's** `issuer`.
§3.3 requires those to correspond — an anti-mix-up control, so a metadata document can only ever
speak for itself — and strict clients abort at that check, before DCR is ever attempted.

From a client's point of view this server genuinely *is* the authorisation server: `/oauth/authorize`,
`/oauth/token` and `/oauth/register` are all ours. It now says so.

## Three coupled changes

| Change | Why it can't ship alone |
|---|---|
| `issuer` = our own origin (`PublicBaseUrl`, else the request origin) | Must equal the `authorization_servers` string in the RFC 9728 document byte for byte — the check is simple string equality. |
| `/oauth/callback` strips any upstream `iss` and appends our own | **Mandatory, not defensive.** Clients compare a *present* `iss` against the metadata issuer even when support is not advertised, so a forwarded Auth0 `iss` would now fail outright — and appending ours alongside would leave two values. |
| `authorization_response_iss_parameter_supported: true` | Honest only because of the row above. Advertising it and then omitting `iss` reads as a stripped-parameter attack. |

Auth0 remains the token issuer, so `jwks_uri` / `userinfo_endpoint` stay upstream.

## A second blocker, found by doing the verification

The issue asked for each design step to be confirmed rather than trusted. Doing that surfaced an
independent defect on the same path: the RFC 9728 document serialised **every unset optional as an
explicit `null`**, and §3.2 requires an unused parameter to be *omitted*. The strict client's schema
rejects the whole document over it:

```
ZodError: jwks_uri: expected string, received null
          resource_signing_alg_values_supported: expected array, received null
          … 9 fields in total
```

So it failed *before* reaching the issuer check. Serialising with the SDK's own
`McpJsonUtilities.DefaultOptions` omits them. Included here rather than split out because fixing only
the issuer half would leave the issue's stated acceptance test failing, for a reason that looks
unrelated to anyone reading it later.

## Verification

End to end against `@modelcontextprotocol/client` 2.0.0 — the package **MCP Inspector 2.3.0 actually
depends on** — driving a local container:

| Step | Result |
|---|---|
| RFC 9728 document parses | ✅ (was `ZodError` on 9 null fields) |
| `discoverAuthorizationServerMetadata` — §3.3 | ✅ |
| RFC 7591 DCR | ✅ reached, returns the shared `client_id` — **previously never called** |
| `validateAuthorizationResponseIssuer` on the `iss` we emit | ✅ with an upstream Auth0 `iss` present and replaced |
| Control: same function against Auth0's issuer | ✅ throws `IssuerMismatchError` — so the passes above are not a skipped check |

Two things the issue flagged as unvalidated, now checked against SDK source rather than assumed:

- **Nothing validates the access token's `iss` against the metadata `issuer`.** The client auth module
  never decodes a JWT or fetches JWKS — tokens are opaque to it. Our own `JwtBearer` validates against
  Auth0's `Authority` internally and is unaffected either way.
- **The published 1.x SDK does not enforce §3.3 at all**; enforcement ships in the 2.x packages. That
  is why this was latent for Claude Desktop / Claude Code rather than an outage — and why a client
  moving to 2.x would have broken every user at once.

## Tests

`400 passing` (was 388). New coverage, all written failing first:

- `issuer` equals the serving origin, **and** equals `authorization_servers` from the protected-resource
  document — asserted against each other, so the two documents cannot drift apart while both still
  look individually correct.
- `authorization_response_iss_parameter_supported` is advertised.
- `/oauth/callback` emits exactly one `iss` naming us, replacing an upstream Auth0 value, without
  disturbing `code`/`state`.
- New `OAuthProxyPublicOriginTests` covers the production shape with `OAuth:PublicBaseUrl` set, where
  the canonical origin is *not* the request `Host`. Its sibling class cannot catch a regression to
  Host-derived values, because there the two coincide.
- No property in the RFC 9728 document serialises as `null` — invisible to a test that only reads the
  properties it expects to find.

The `deploy.yml` smoke contract is untouched: it asserts `/health` 200 and unauthenticated `/mcp` 401,
both unchanged.

## Docs

`CLAUDE.md`'s *Known limitation: strict RFC 8414 clients* section is replaced with *The OAuth proxy is
a complete authorisation-server façade*, recording the three-way coupling and what was verified;
`README.md`'s short version likewise. `VitallyMcp.Tests/README.md` updated for the new counts and classes.

## Validated against the live tenant (2026-08-22)

The caveat this section originally carried — local-container validation only — has been discharged.
MCP Inspector 2.3.0 completed the whole flow against the live Auth0 tenant with the real Entra
federation, driving the server behind an HTTPS tunnel with `PublicBaseUrl` set:

| Stage | Observed |
|---|---|
| RFC 9728 + RFC 8414 metadata | `200` on all three paths |
| RFC 7591 DCR | `POST /oauth/register` → **201** — previously never reached |
| Auth0 → Entra sign-in | completed interactively |
| RFC 9207 | `/oauth/callback` → `302` carrying `iss=<our origin>`, **accepted by the client** |
| Token exchange | `POST /oauth/token` → **200** |
| Authenticated MCP | `POST /mcp` → **401** pre-auth, then **200** |

Two limits on what that run covers, stated rather than glossed: the temporary Auth0 client was a
**public** client (to keep a secret out of the session transcript), so confidential-client secret
injection at `/oauth/token` was not exercised — that code is untouched here and the exchange still
returned 200; and there is no Container Apps ingress in a tunnel run, which `PublicBaseUrl` and
`OAuthProxyPublicOriginTests` between them make a non-issue.

`tools/list` came back empty during the run. That is **not** a defect in this change: the post-login
Action is hard-scoped to production's audience (`if (event.resource_server?.identifier !==
'https://vitally.fiscaltec.com/') return;`), so a throwaway audience mints no `permissions` claim and
every tool is correctly filtered out — incidentally good evidence that the RBAC discovery filter
fails closed. `CLAUDE.md` now records this trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qvafk8DkdTEVcGge8vP61Q


