### PR TITLE
ci: gate the release train's deploy on an AUTO_DEPLOY variable so a freeze does not also stop versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 # Nightly release train: if main changed since the last tag, compute the next semver from
 # conventional commits, create the tag + a GitHub Release (the changelog), and — only when the
-# repository variable AUTO_DEPLOY is exactly "true" — deploy it via the reusable deploy workflow,
-# which self-rolls-back on a failed smoke test.
+# repository variable AUTO_DEPLOY has the value true (lowercase, no quotes) — deploy it via the
+# reusable deploy workflow, which self-rolls-back on a failed smoke test.
 #
 # Versioning and deploying are deliberately on separate switches. Freezing deploys by disabling this
 # whole workflow (`gh workflow disable release.yml`) also stops tagging and Releases, so the changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,19 @@
 name: Release
 
 # Nightly release train: if main changed since the last tag, compute the next semver from
-# conventional commits, create the tag + a GitHub Release (the changelog), and deploy it via the
-# reusable deploy workflow. Fully automatic; the deploy self-rolls-back on a failed smoke test.
+# conventional commits, create the tag + a GitHub Release (the changelog), and — only when the
+# repository variable AUTO_DEPLOY is exactly "true" — deploy it via the reusable deploy workflow,
+# which self-rolls-back on a failed smoke test.
+#
+# Versioning and deploying are deliberately on separate switches. Freezing deploys by disabling this
+# whole workflow (`gh workflow disable release.yml`) also stops tagging and Releases, so the changelog
+# record silently pauses too — that happened on 2026-08-26 and is what #111 fixed. To freeze deploys,
+# set AUTO_DEPLOY=false and leave the workflow enabled.
+#
+# AUTO_DEPLOY defaults to off: an unset variable does NOT deploy. Production deploys should require an
+# explicit opt-in rather than inheriting one from a missing value. The deploy-skipped job below emits a
+# run annotation whenever a tag was cut but not shipped, so an unintentionally long freeze is visible
+# in the run log rather than looking like nothing happened.
 on:
   schedule:
     - cron: "0 2 * * *" # 02:00 UTC nightly
@@ -47,7 +58,9 @@ jobs:
 
   deploy:
     needs: release
-    if: ${{ needs.release.outputs.new_tag != '' }}
+    # `vars` is available in a job-level `if`, so the gate costs nothing at runtime. Compared against
+    # the literal string 'true' — an unset variable is the empty string and therefore does not deploy.
+    if: ${{ needs.release.outputs.new_tag != '' && vars.AUTO_DEPLOY == 'true' }}
     permissions:
       id-token: write # OIDC for azure/login in the called deploy
       contents: read
@@ -60,3 +73,24 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  # A reusable-workflow job (`uses:`) cannot carry extra steps, so the "why didn't it deploy?" notice
+  # has to be its own job. Without it a frozen train looks identical to a train with nothing to ship:
+  # the deploy job is simply absent from the run, which is exactly how a freeze outlives its purpose.
+  deploy-skipped:
+    name: Deploy skipped (AUTO_DEPLOY not enabled)
+    needs: release
+    if: ${{ needs.release.outputs.new_tag != '' && vars.AUTO_DEPLOY != 'true' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Explain why nothing was deployed
+        # Both values go through env rather than being interpolated into the script. Repository
+        # variables are maintainer-set so the risk is slight, but `${{ }}` inside `run:` is a script
+        # injection shape and there is no reason to write one.
+        env:
+          NEW_TAG: ${{ needs.release.outputs.new_tag }}
+          AUTO_DEPLOY: ${{ vars.AUTO_DEPLOY }}
+        run: |
+          set -euo pipefail
+          echo "::notice title=Deploy skipped::Tagged ${NEW_TAG} and published the Release, but did not deploy - repository variable AUTO_DEPLOY is '${AUTO_DEPLOY:-<unset>}' and must be exactly 'true'. To ship this tag now: gh workflow run deploy.yml -f ref=${NEW_TAG}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,7 +619,30 @@ The deployment shape is **Azure Container Apps + Azure Key Vault + Auth0** (with
 | Image registry | Azure Container Registry (Premium SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
 | Logs | Log Analytics (attached to the CAE) | + Application Insights for traces |
 | Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Resource Server identifier `https://vitally.fiscaltec.com/` (trailing slash — identifiers are exact-match and immutable); post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation |
-| CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback); nightly `release.yml` cuts a semver tag + GitHub Release and deploys it; OIDC, no long-lived secrets in GitHub |
+| CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it **only when the repo variable `AUTO_DEPLOY` is exactly `"true"`** — see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
 | IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
+
+### Freezing deploys without freezing releases
+
+`release.yml` cuts the tag and Release, then calls `deploy.yml` — but the deploy job is gated on the
+repository variable `AUTO_DEPLOY`, which must be exactly the string `"true"`. **An unset variable does
+not deploy**: a production deploy should require an explicit opt-in rather than inherit one from a
+missing value.
+
+**To freeze deploys, set `AUTO_DEPLOY=false` and leave the workflow enabled.** Do *not* reach for
+`gh workflow disable release.yml` — that is the whole train, so it silently stops semver tagging and
+GitHub Releases too, and the changelog record pauses along with the deploys. That is exactly what
+happened on 2026-08-26 (to hold the queued OAuth work back from an unattended 02:00 UTC deploy) and it
+is the reason this switch exists (#111).
+
+When a tag is cut but not shipped, the `deploy-skipped` job emits a run annotation naming the tag and
+the `gh workflow run deploy.yml -f ref=<tag>` command to ship it manually. That annotation is the only
+thing distinguishing a deliberate freeze from a train with nothing to release, so don't remove it — a
+frozen train otherwise looks identical to an idle one, which is how a freeze outlives its purpose.
+
+An **attended** deploy is always available via `deploy.yml`'s own `workflow_dispatch`, regardless of
+`AUTO_DEPLOY`. That is the intended route while a freeze is in place, and it is what the #102 migration
+needs: #108 is gated on its predecessors being *deployed*, not merely merged, so a blanket freeze would
+deadlock it.
 
 Infrastructure-as-code is in this repo at `infra/terraform/` — the table above documents the runtime contract for what `deploy.yml` expects. Anyone replicating can swap Container Apps for App Service, ACR for GHCR, Auth0 for Keycloak, etc., without touching the application code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,15 +619,16 @@ The deployment shape is **Azure Container Apps + Azure Key Vault + Auth0** (with
 | Image registry | Azure Container Registry (Premium SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
 | Logs | Log Analytics (attached to the CAE) | + Application Insights for traces |
 | Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Resource Server identifier `https://vitally.fiscaltec.com/` (trailing slash — identifiers are exact-match and immutable); post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation |
-| CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it **only when the repo variable `AUTO_DEPLOY` is exactly `"true"`** — see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
+| CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it **only when the repo variable `AUTO_DEPLOY` is set to `true`** — see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
 | IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
 
 ### Freezing deploys without freezing releases
 
 `release.yml` cuts the tag and Release, then calls `deploy.yml` — but the deploy job is gated on the
-repository variable `AUTO_DEPLOY`, which must be exactly the string `"true"`. **An unset variable does
-not deploy**: a production deploy should require an explicit opt-in rather than inherit one from a
-missing value.
+repository variable `AUTO_DEPLOY`, whose value must be exactly `true` — lowercase, with no quotes
+around it (`gh variable set AUTO_DEPLOY --body true`; a value of `"true"` that includes the quote
+characters does not match). **An unset variable does not deploy**: a production deploy should require
+an explicit opt-in rather than inherit one from a missing value.
 
 **To freeze deploys, set `AUTO_DEPLOY=false` and leave the workflow enabled.** Do *not* reach for
 `gh workflow disable release.yml` — that is the whole train, so it silently stops semver tagging and


### PR DESCRIPTION
Closes #111.

Freezing production deploys previously meant `gh workflow disable release.yml` — the whole train — so
semver tagging and GitHub Releases stopped too. That is what happened on **2026-08-26**, to hold the
queued OAuth work (#100, #101, #103, #104) back from an unattended 02:00 UTC deploy while #102 is in
progress. The intent was "don't deploy tonight"; the effect also included "stop cutting versions", and
that has been quietly accruing since.

## The change

`release.yml`'s `deploy` job is now gated on the repository variable `AUTO_DEPLOY`:

```yaml
if: ${{ needs.release.outputs.new_tag != '' && vars.AUTO_DEPLOY == 'true' }}
```

Compared against the literal string `'true'`, so **an unset variable does not deploy**. That default is
deliberate: a production deploy should require an explicit opt-in rather than inherit one from a missing
value.

A second job, `deploy-skipped`, runs on the complementary condition and emits a `::notice::` naming the
tag and the `gh workflow run deploy.yml -f ref=<tag>` command to ship it by hand. It exists because a
frozen train and a train with nothing to release look **identical** in the run list — the deploy job is
simply absent from both — and that ambiguity is how a freeze outlives its purpose. It has to be its own
job rather than a step, because a reusable-workflow call (`uses:`) cannot carry extra steps.

## Rollout — needs a hand from you

This PR alone changes nothing observable, because `release.yml` is still disabled. To land the intended
end state:

1. Merge this.
2. `gh variable set AUTO_DEPLOY --body false`
3. `gh workflow enable release.yml`

Tagging and Releases resume that night; nothing deploys. **Order matters** — enabling the workflow
before setting the variable would be harmless here (unset ≠ `true`, so it still would not deploy), but
setting it explicitly is what makes the freeze legible to the next reader rather than implicit in an
absent value.

Flip to `AUTO_DEPLOY=true` once **#110** has landed. With the deploy smoke test currently blind to OAuth
metadata regressions, an unattended nightly deploy of auth changes has no real safety net — that is the
honest precondition, not this PR.

## What is not in scope

- **The queued deploy itself.** Production stays on `v4.2.1` (pre-#100) until someone runs an attended
  `deploy.yml`. This PR does not ship it.
- **Hardening the smoke test.** #110.
- **A `workflow_dispatch` override to force a deploy.** `deploy.yml` already has its own
  `workflow_dispatch`, which is the attended route and is unaffected by `AUTO_DEPLOY` — a second
  override would be a duplicate escape hatch.

## Verification

YAML parses, and the two gates are complementary — exactly one of `deploy` / `deploy-skipped` can run
for any given `(new_tag, AUTO_DEPLOY)` pair:

| `new_tag` | `AUTO_DEPLOY` | `deploy` | `deploy-skipped` |
|---|---|---|---|
| `''` | any | no | no |
| set | `'true'` | **yes** | no |
| set | `'false'` | no | **yes** |
| set | unset | no | **yes** |

No application code changed, so the test suite is untouched.

Note the CI on this PR **cannot** prove the deploy path works — the gated job only runs on the schedule
against `main`. The first real evidence is the next nightly run's annotation, which is another reason
the `deploy-skipped` notice matters.

## Docs

`CLAUDE.md` gains a *Freezing deploys without freezing releases* subsection under *Deployment*, stating
the convention explicitly (`AUTO_DEPLOY=false`, **not** `gh workflow disable`), why the default is off,
why the notice job must not be removed, and that `deploy.yml`'s own `workflow_dispatch` remains the
attended route — which #108 needs, since it is gated on its predecessors being *deployed* and a blanket
freeze would deadlock it. The CI/CD row in the component table now mentions the variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoVcPDWpriH46jsTUXrvTn