### PR TITLE
ci: verify the OAuth metadata documents in the deploy smoke test so the rollback can see auth regressions

### DIFF
--- a/.github/scripts/verify-oauth-metadata.sh
+++ b/.github/scripts/verify-oauth-metadata.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# Verifies the OAuth metadata documents a running Vitally MCP server publishes.
+#
+# WHY THIS EXISTS. deploy.yml's other smoke assertions are `/health` == 200 and unauthenticated
+# `/mcp` == 401. Both of those pass while the metadata documents are wrong -- wrong `issuer`, a
+# broken `issuer` <-> `authorization_servers` pairing, a bad `jwks_uri`, `/oauth/authorize` pointed
+# at the wrong upstream, a dropped `iss` flag, failing DCR. Every one of those breaks MCP clients at
+# their next re-authentication while the deploy reports success, so the auto-rollback used to read as
+# assurance it did not provide. See issue #110.
+#
+# Usage:  verify-oauth-metadata.sh <public-origin>
+#   e.g.  verify-oauth-metadata.sh https://vitally.fiscaltec.com
+#         verify-oauth-metadata.sh http://localhost:5099      # local run, for testing this script
+#
+# Exits non-zero with a ::error:: annotation listing every failed assertion. Deliberately runnable
+# outside CI against any origin: a check that can only be exercised by deploying to production is a
+# check nobody validates before relying on it.
+set -euo pipefail
+
+ORIGIN="${1:?usage: verify-oauth-metadata.sh <public-origin>}"
+ORIGIN="${ORIGIN%/}"          # tolerate a trailing slash on the argument only
+
+ATTEMPTS="${ATTEMPTS:-6}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-10}"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+failures=0
+
+fail() {
+  echo "::error::$*"
+  failures=$((failures + 1))
+}
+
+# Fetch a document, retrying because a freshly-swapped revision can take a moment to serve on the
+# public FQDN. curl emits "000" as the http_code on a connection failure; `|| true` stops `set -e`
+# aborting the loop so the retry can happen. No sleep after the final attempt.
+fetch_json() {
+  local url="$1" out="$2" code=""
+  local i
+  for i in $(seq 1 "$ATTEMPTS"); do
+    code=$(curl -s -o "$out" -w "%{http_code}" --max-time 20 "$url" || true)
+    if [ "$code" = "200" ]; then
+      if jq -e . "$out" >/dev/null 2>&1; then
+        return 0
+      fi
+      fail "$url returned 200 but the body is not valid JSON"
+      return 1
+    fi
+    echo "  GET $url -> ${code:-000} (attempt $i/$ATTEMPTS)"
+    if [ "$i" -lt "$ATTEMPTS" ]; then sleep "$SLEEP_SECONDS"; fi
+  done
+  fail "$url did not return 200 after $ATTEMPTS attempts (last: ${code:-000})"
+  return 1
+}
+
+# Compare a JSON string field against an expected value with plain equality. No normalisation is
+# applied anywhere in this script, deliberately: clients compare these strings literally, so a check
+# that tolerated a trailing slash or a case difference would pass configurations clients reject.
+assert_field() {
+  local file="$1" path="$2" expected="$3" label="$4"
+  local actual
+  actual=$(jq -r "$path // \"<absent>\"" "$file")
+  if [ "$actual" = "$expected" ]; then
+    echo "  ok   $label = $actual"
+  else
+    fail "$label is '$actual', expected '$expected'"
+  fi
+}
+
+# An endpoint republished to clients must be an absolute https URI with no fragment. Mirrors
+# UpstreamOidcMetadata.RequireEndpoint (#109): a fragment silently swallows any query appended after
+# it, and these values are handed to every client as fact.
+assert_upstream_endpoint() {
+  local file="$1" path="$2" label="$3"
+  local actual
+  actual=$(jq -r "$path // \"<absent>\"" "$file")
+  case "$actual" in
+    "<absent>")
+      fail "$label is absent"
+      return
+      ;;
+    https://*)
+      ;;
+    *)
+      fail "$label is '$actual', which is not an absolute https URI"
+      return
+      ;;
+  esac
+  case "$actual" in
+    *"#"*)
+      fail "$label is '$actual', which contains a URI fragment (RFC 6749 3.1 forbids one)"
+      return
+      ;;
+  esac
+  echo "  ok   $label = $actual"
+}
+
+echo "Verifying OAuth metadata at $ORIGIN"
+
+AS_DOC="$WORK_DIR/as.json"
+expected_as_issuer=""
+if fetch_json "$ORIGIN/.well-known/oauth-authorization-server" "$AS_DOC"; then
+  # RFC 8414 section 3.3 -- an anti-mix-up control. The document may only speak for the issuer it was
+  # fetched from, and we front authorize/token/register ourselves, so our own origin is the honest
+  # answer. Declaring the upstream provider's issuer here is the exact regression #90/#100 fixed, and
+  # it made strict clients (the TypeScript MCP SDK, hence MCP Inspector) abort before reaching DCR.
+  assert_field "$AS_DOC" '.issuer' "$ORIGIN" "issuer"
+
+  # The facade's own endpoints must keep naming us. If any of these ever pointed upstream, DCR and
+  # the iss contract would both break while /health and the 401 stayed perfectly green.
+  assert_field "$AS_DOC" '.authorization_endpoint' "$ORIGIN/oauth/authorize" "authorization_endpoint"
+  assert_field "$AS_DOC" '.token_endpoint' "$ORIGIN/oauth/token" "token_endpoint"
+  assert_field "$AS_DOC" '.registration_endpoint' "$ORIGIN/oauth/register" "registration_endpoint"
+
+  # RFC 9207. Honest only because /oauth/callback injects `iss` unconditionally -- advertising
+  # support and then omitting the parameter reads to a client as a stripped-parameter attack, so the
+  # flag and the injection ship together, and this pins the half observable from outside.
+  iss_flag=$(jq -r '.authorization_response_iss_parameter_supported // "<absent>"' "$AS_DOC")
+  if [ "$iss_flag" = "true" ]; then
+    echo "  ok   authorization_response_iss_parameter_supported = true"
+  else
+    fail "authorization_response_iss_parameter_supported is '$iss_flag', expected true"
+  fi
+
+  # These two point at the upstream provider and are read from its discovery document (#109), so a
+  # misconfigured OAuth:Authority surfaces here as a wrong value advertised to clients as fact.
+  assert_upstream_endpoint "$AS_DOC" '.jwks_uri' "jwks_uri"
+  assert_upstream_endpoint "$AS_DOC" '.userinfo_endpoint' "userinfo_endpoint"
+
+  expected_as_issuer=$(jq -r '.issuer // ""' "$AS_DOC")
+fi
+
+# RFC 9728, served from the canonical path and the resource-path-suffixed variant. Clients probe
+# either, so both must serve -- and both must agree with the authorization-server document.
+pr_index=0
+for path in "/.well-known/oauth-protected-resource" "/.well-known/oauth-protected-resource/mcp"; do
+  pr_index=$((pr_index + 1))
+  PR_DOC="$WORK_DIR/pr-$pr_index.json"
+  if ! fetch_json "$ORIGIN$path" "$PR_DOC"; then
+    continue
+  fi
+
+  # The pairing a strict client actually checks: it reads authorization_servers out of this document,
+  # uses that string verbatim to build the well-known URL, and requires the returned issuer to equal
+  # it. Asserting each document alone would let the two drift while both still looked correct.
+  advertised=$(jq -r '.authorization_servers[0] // "<absent>"' "$PR_DOC")
+  if [ -z "$expected_as_issuer" ]; then
+    fail "$path: cannot check authorization_servers -- the authorization-server document was unusable"
+  elif [ "$advertised" = "$expected_as_issuer" ]; then
+    echo "  ok   $path authorization_servers[0] = $advertised (matches issuer)"
+  else
+    fail "$path: authorization_servers[0] is '$advertised' but the authorization-server document declares issuer '$expected_as_issuer' -- clients compare these two literally"
+  fi
+
+  # RFC 9728 section 3.2 requires an unused metadata parameter to be *omitted*, not null. The
+  # ASP.NET Core default serialiser writes every unset optional as an explicit null, and the
+  # published @modelcontextprotocol/client types jwks_uri as a string and rejects the whole document
+  # on a null -- before any part of the OAuth flow is reached. Regression guard for the fix in #100,
+  # and invisible to any check that only reads the properties it expects to find.
+  null_paths=$(jq -c '[paths(. == null)]' "$PR_DOC")
+  if [ "$null_paths" = "[]" ]; then
+    echo "  ok   $path has no null-valued properties"
+  else
+    fail "$path serialises null at $null_paths -- RFC 9728 section 3.2 requires an unused parameter to be omitted, and strict clients reject the document over the difference"
+  fi
+done
+
+if [ "$failures" -ne 0 ]; then
+  echo "::error::OAuth metadata verification failed with $failures problem(s) at $ORIGIN"
+  exit 1
+fi
+
+echo "OAuth metadata verification passed at $ORIGIN"

--- a/.github/scripts/verify-oauth-metadata.sh
+++ b/.github/scripts/verify-oauth-metadata.sh
@@ -37,8 +37,13 @@ fail() {
 # Fetch a document, retrying because a freshly-swapped revision can take a moment to serve on the
 # public FQDN. curl emits "000" as the http_code on a connection failure; `|| true` stops `set -e`
 # aborting the loop so the retry can happen. No sleep after the final attempt.
+#
+# A 200 carrying a non-JSON body is retried too, not failed on the spot. An ingress or edge can answer
+# 200 with an HTML error or a truncated body while a revision is still swapping in, and this script can
+# revert a deploy — so a momentary bad body must not be mistaken for a metadata regression. Retrying
+# costs seconds; a spurious rollback of a good deploy costs a lot more.
 fetch_json() {
-  local url="$1" out="$2" code=""
+  local url="$1" out="$2" code="" reason=""
   local i
   for i in $(seq 1 "$ATTEMPTS"); do
     code=$(curl -s -o "$out" -w "%{http_code}" --max-time 20 "$url" || true)
@@ -46,13 +51,14 @@ fetch_json() {
       if jq -e . "$out" >/dev/null 2>&1; then
         return 0
       fi
-      fail "$url returned 200 but the body is not valid JSON"
-      return 1
+      reason="200 but the body is not valid JSON"
+    else
+      reason="HTTP ${code:-000}"
     fi
-    echo "  GET $url -> ${code:-000} (attempt $i/$ATTEMPTS)"
+    echo "  GET $url -> $reason (attempt $i/$ATTEMPTS)"
     if [ "$i" -lt "$ATTEMPTS" ]; then sleep "$SLEEP_SECONDS"; fi
   done
-  fail "$url did not return 200 after $ATTEMPTS attempts (last: ${code:-000})"
+  fail "$url did not return a usable JSON document after $ATTEMPTS attempts (last: $reason)"
   return 1
 }
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,7 @@ jobs:
       RESOURCE_GROUP: ${{ vars.RESOURCE_GROUP }}
       CONTAINER_APP: ${{ vars.CONTAINER_APP }}
       IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+      PUBLIC_ORIGIN: https://vitally.fiscaltec.com
       HEALTH_URL: https://vitally.fiscaltec.com/health
       MCP_URL: https://vitally.fiscaltec.com/mcp
     steps:
@@ -181,6 +182,20 @@ jobs:
             [ "$i" -lt 6 ] && sleep 10
           done
           [ "$mcp_code" = "401" ] || { echo "::error::/mcp unauthenticated not 401 after retries (last: ${mcp_code:-000}, expected 401)"; exit 1; }
+
+      # The step above proves the app is live and the Auth0 gate is enforced. It cannot tell whether
+      # the OAuth metadata documents are correct: a wrong `issuer`, a broken
+      # `issuer` <-> `authorization_servers` pairing, a bad `jwks_uri`, an `/oauth/authorize` pointed
+      # at the wrong upstream, a dropped `iss` flag or a null-serialised optional all leave /health at
+      # 200 and the 401 challenge intact while breaking every MCP client at its next
+      # re-authentication. That gap made the rollback below read as assurance it did not provide
+      # (#110). A separate step, not an extension of the one above, so the health/401 assertions stay
+      # untouched — `failure()` on the rollback step is job-scoped, so this still triggers it.
+      - name: Verify OAuth metadata documents (RFC 8414 / RFC 9728)
+        # Invoked through `bash` rather than relying on the executable bit. The repo is authored on
+        # Windows with core.filemode=false, so a future edit can silently drop the mode and this step
+        # would fail with "Permission denied" on a deploy rather than in review.
+        run: bash .github/scripts/verify-oauth-metadata.sh "$PUBLIC_ORIGIN"
 
       - name: Roll back on failure
         if: ${{ failure() && env.PREV_IMAGE != '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ The server uses ASP.NET Core 10 with `WebApplication.CreateBuilder` + `Microsoft
   - `POST /oauth/token` — proxies code/refresh exchanges to the **discovered** upstream `token_endpoint`, server-side-injecting `SharedClientSecret`.
   - `POST /oauth/register` — RFC 7591 DCR shim returning `SharedClientId` plus filtered `redirect_uris`.
 - `MapMcp("/mcp").RequireAuthorization()` — auth requirement is dropped when `NoAuth=true`.
-- The 401 challenge on `/mcp` carries a single `WWW-Authenticate` value pointing at the protected-resource metadata document (`resource_metadata="{PublicBaseUrl}/.well-known/oauth-protected-resource/mcp"`), adding `error="invalid_token"` when a token was presented and failed validation. The metadata document is served from both `/.well-known/oauth-protected-resource` and the `/mcp`-suffixed path (`ProtectedResourceMetadataBuilder.MetadataPath`). The status stays exactly 401 — `.github/workflows/deploy.yml` smoke-tests that and rolls back if it changes, so don't alter it.
+- The 401 challenge on `/mcp` carries a single `WWW-Authenticate` value pointing at the protected-resource metadata document (`resource_metadata="{PublicBaseUrl}/.well-known/oauth-protected-resource/mcp"`), adding `error="invalid_token"` when a token was presented and failed validation. The metadata document is served from both `/.well-known/oauth-protected-resource` and the `/mcp`-suffixed path (`ProtectedResourceMetadataBuilder.MetadataPath`). The status stays exactly 401 — `.github/workflows/deploy.yml` smoke-tests that and rolls back if it changes, so don't alter it. That smoke **also** pins the RFC 8414/9728 documents (`.github/scripts/verify-oauth-metadata.sh`): the `issuer`, its byte-for-byte equality with `authorization_servers`, the advertised `iss` flag, the façade endpoints naming our origin, `jwks_uri`/`userinfo_endpoint` being absolute https without a fragment, and no null-serialised optionals. Those are deploy-gating contracts now, not only test-suite ones.
 
 
 ### The OAuth proxy is a complete authorisation-server façade
@@ -619,8 +619,40 @@ The deployment shape is **Azure Container Apps + Azure Key Vault + Auth0** (with
 | Image registry | Azure Container Registry (Premium SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
 | Logs | Log Analytics (attached to the CAE) | + Application Insights for traces |
 | Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Resource Server identifier `https://vitally.fiscaltec.com/` (trailing slash — identifiers are exact-match and immutable); post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation |
-| CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it **only when the repo variable `AUTO_DEPLOY` is set to `true`** — see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
+| CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback — the smoke covers `/health`, the exact-401 challenge **and** the OAuth metadata documents); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it **only when the repo variable `AUTO_DEPLOY` is set to `true`** — see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
 | IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
+
+### The deploy smoke covers the OAuth metadata, not just liveness
+
+`.github/scripts/verify-oauth-metadata.sh <origin>` is run by `deploy.yml` after the revision is live
+and before the rollback step, so a failure reverts the revision.
+
+It exists because `/health` == 200 and unauthenticated `/mcp` == 401 — the original smoke — both stay
+green while the metadata documents are wrong. A wrong `issuer`, a broken
+`issuer` ↔ `authorization_servers` pairing, a bad `jwks_uri`, an `/oauth/authorize` pointed at the
+wrong upstream, a dropped `iss` flag, or a null-serialised optional each break every MCP client at its
+next re-authentication *and deploy green*. The rollback therefore used to read as assurance it did not
+provide (#110).
+
+**Run it by hand against any origin** — that is the point of it being a script rather than inline YAML:
+
+```bash
+bash .github/scripts/verify-oauth-metadata.sh https://vitally.fiscaltec.com
+bash .github/scripts/verify-oauth-metadata.sh http://localhost:5099   # a local run, for testing it
+```
+
+Two things about it that are deliberate and shouldn't be "tidied":
+
+- **No normalisation anywhere.** Trailing slashes and case are compared literally, because that is
+  what clients do — a check that tolerated a difference would pass configurations clients reject.
+- **It is invoked through `bash`**, not by its executable bit. The repo is authored on Windows with
+  `core.filemode=false`, so an edit can silently drop the mode; relying on it would surface as
+  "Permission denied" during a deploy rather than in review.
+
+Verified when written by running it both ways round: it **passes** against a local server built from
+`main`, and **fails with 6 problems** against the then-current production revision (which predated
+#100) — including `jwks_uri: null` in the RFC 9728 document, the exact defect that makes the published
+`@modelcontextprotocol/client` reject the whole document.
 
 ### Freezing deploys without freezing releases
 


### PR DESCRIPTION
Closes #110.

`deploy.yml`'s smoke asserted `/health` == 200 and unauthenticated `/mcp` == 401, then rolled the
Container App back on failure. Both stay green while the OAuth metadata documents are wrong — which is
the failure class that actually breaks MCP clients, and the one this repo has been actively changing.

## The gap, concretely

Each of these deploys **green** and stays deployed:

| Regression | `/health` | `/mcp` | Client impact |
|---|---|---|---|
| RFC 8414 `issuer` names the wrong origin | 200 | 401 | Strict clients abort before DCR — the #90/#100 bug |
| `issuer` ≠ `authorization_servers` in the RFC 9728 doc | 200 | 401 | The §3.3 pairing is what clients check |
| `jwks_uri` / `userinfo_endpoint` wrong, absent, or `null` | 200 | 401 | Advertised to every client as fact |
| `/oauth/authorize` points at the wrong upstream | 200 | 401 | Sign-in fails after the user has been sent away |
| `iss` flag dropped while `/oauth/callback` still injects it | 200 | 401 | Client reads the mismatch as an attack and aborts |

So the rollback read as assurance it did not provide: a deploy that breaks every client reported
success.

## What this adds

`.github/scripts/verify-oauth-metadata.sh <origin>`, run after the revision is live and **before** the
rollback step — `failure()` there is job-scoped, so a failed assertion still reverts the revision.

A script rather than inline YAML on purpose: **a check exercisable only by deploying to production is a
check nobody validates before relying on it.** Run it by hand against anything:

```bash
bash .github/scripts/verify-oauth-metadata.sh https://vitally.fiscaltec.com
bash .github/scripts/verify-oauth-metadata.sh http://localhost:5099
```

It asserts the `issuer`, its byte-for-byte equality with `authorization_servers` (on **both** RFC 9728
paths), the advertised `iss` flag, the three façade endpoints naming our own origin, `jwks_uri` /
`userinfo_endpoint` being absolute https with no fragment, and no null-serialised properties.

The health and 401 assertions are **untouched** — `CLAUDE.md` marks that 401 as a contract, so the new
work is a separate step rather than an extension of the existing one.

## Verified both ways round

Not reasoned about. Against a local server built from `main` — **passes**, 11 assertions. Against the
**current production revision** — **fails with 6 problems**:

```
::error::issuer is 'https://fiscal-it.uk.auth0.com/', expected 'https://vitally.fiscaltec.com'
::error::authorization_response_iss_parameter_supported is '<absent>', expected true
::error::/.well-known/oauth-protected-resource: authorization_servers[0] is
         'https://vitally.fiscaltec.com' but the authorization-server document declares issuer
         'https://fiscal-it.uk.auth0.com/' -- clients compare these two literally
::error::/.well-known/oauth-protected-resource serialises null at [["jwks_uri"], …8 more]
… same two for the /mcp-suffixed path
```

**That is not a false positive — production is genuinely in that state**, because it is still on
`v4.2.1` and predates #100. Note the fourth line especially: production is serving `jwks_uri: null`,
the exact defect that makes the published `@modelcontextprotocol/client` reject the whole document
before any part of the OAuth flow is reached. Worth knowing independently of this PR.

## Two deliberate choices

- **No normalisation anywhere.** Trailing slashes and case compare literally, because that is what
  clients do. A check that tolerated a difference would pass configurations clients reject.
- **Invoked through `bash`, not the executable bit.** The repo is authored on Windows with
  `core.filemode=false`; I recorded `100755` via `git update-index --chmod=+x`, but relying on it would
  mean a future edit silently dropping the mode and surfacing as "Permission denied" during a deploy
  rather than in review.

## Limitation

CI here cannot exercise the new step — it only runs inside `deploy.yml` against production. The
evidence above is the local + production runs, and the first in-pipeline run will be the next attended
deploy. That deploy is also the one that will make production **pass** these assertions for the first
time.

## Docs

`CLAUDE.md` gains *The deploy smoke covers the OAuth metadata, not just liveness*, the 401 bullet now
says what else the smoke pins, and the CI/CD component row is updated. `PUBLIC_ORIGIN` is added to
`deploy.yml`'s env so the origin is named once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoVcPDWpriH46jsTUXrvTn