### PR TITLE
ci: revert the AUTO_DEPLOY switch and stop the metadata check racing revision swaps

### DIFF
--- a/.github/scripts/verify-oauth-metadata.sh
+++ b/.github/scripts/verify-oauth-metadata.sh
@@ -9,43 +9,55 @@
 # their next re-authentication while the deploy reports success, so the auto-rollback used to read as
 # assurance it did not provide. See issue #110.
 #
+# WHY THE WHOLE ASSERTION SET RETRIES, not just the fetches. In single-revision mode Container Apps
+# reports the new revision Provisioned/Healthy *before* ingress finishes shifting traffic, so a check
+# that runs immediately can be answered by the OLD revision -- with a perfectly valid 200 and a
+# perfectly valid document, just the previous configuration. Asserting once turned that race into a
+# rollback of a healthy deploy on 2026-08-28: revision 21 (v4.2.2) came up Healthy and was reverted
+# 23 seconds later. Neither /health nor the 401 can catch the race, because both pass on whichever
+# revision answers -- this is the first check able to tell them apart, so it has to wait for the swap.
+#
 # Usage:  verify-oauth-metadata.sh <public-origin>
 #   e.g.  verify-oauth-metadata.sh https://vitally.fiscaltec.com
 #         verify-oauth-metadata.sh http://localhost:5099      # local run, for testing this script
 #
-# Exits non-zero with a ::error:: annotation listing every failed assertion. Deliberately runnable
-# outside CI against any origin: a check that can only be exercised by deploying to production is a
-# check nobody validates before relying on it.
+# Exits non-zero with a ::error:: annotation per failed assertion, emitted only after the final
+# attempt so a transient mismatch does not spam the log with errors that then resolve themselves.
+# Deliberately runnable outside CI against any origin: a check that can only be exercised by
+# deploying to production is a check nobody validates before relying on it.
 set -euo pipefail
 
 ORIGIN="${1:?usage: verify-oauth-metadata.sh <public-origin>}"
 ORIGIN="${ORIGIN%/}"          # tolerate a trailing slash on the argument only
 
-ATTEMPTS="${ATTEMPTS:-6}"
+ATTEMPTS="${ATTEMPTS:-6}"             # retries of the whole assertion set
 SLEEP_SECONDS="${SLEEP_SECONDS:-10}"
+# Fetch retries stay low because the outer loop already retries everything; otherwise the two nest
+# and an unreachable host burns ATTEMPTS x FETCH_ATTEMPTS x SLEEP before reporting anything.
+FETCH_ATTEMPTS="${FETCH_ATTEMPTS:-2}"
 
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 failures=0
+failure_log=""
 
+# Collects rather than printing: an assertion that fails on attempt 1 and passes on attempt 2 must
+# not leave an ::error:: annotation behind. The log is replayed once, after the final attempt.
 fail() {
-  echo "::error::$*"
   failures=$((failures + 1))
+  failure_log="${failure_log}${*}"$'\n'
 }
 
-# Fetch a document, retrying because a freshly-swapped revision can take a moment to serve on the
-# public FQDN. curl emits "000" as the http_code on a connection failure; `|| true` stops `set -e`
-# aborting the loop so the retry can happen. No sleep after the final attempt.
+# Fetch a document. curl emits "000" as the http_code on a connection failure; `|| true` stops
+# `set -e` aborting the loop so the retry can happen. No sleep after the final attempt.
 #
-# A 200 carrying a non-JSON body is retried too, not failed on the spot. An ingress or edge can answer
-# 200 with an HTML error or a truncated body while a revision is still swapping in, and this script can
-# revert a deploy — so a momentary bad body must not be mistaken for a metadata regression. Retrying
-# costs seconds; a spurious rollback of a good deploy costs a lot more.
+# A 200 carrying a non-JSON body is retried too, not failed on the spot: an ingress or edge can
+# answer 200 with an HTML error or a truncated body mid-swap, and this script can revert a deploy.
 fetch_json() {
   local url="$1" out="$2" code="" reason=""
   local i
-  for i in $(seq 1 "$ATTEMPTS"); do
+  for i in $(seq 1 "$FETCH_ATTEMPTS"); do
     code=$(curl -s -o "$out" -w "%{http_code}" --max-time 20 "$url" || true)
     if [ "$code" = "200" ]; then
       if jq -e . "$out" >/dev/null 2>&1; then
@@ -55,10 +67,10 @@ fetch_json() {
     else
       reason="HTTP ${code:-000}"
     fi
-    echo "  GET $url -> $reason (attempt $i/$ATTEMPTS)"
-    if [ "$i" -lt "$ATTEMPTS" ]; then sleep "$SLEEP_SECONDS"; fi
+    echo "  GET $url -> $reason (fetch attempt $i/$FETCH_ATTEMPTS)"
+    if [ "$i" -lt "$FETCH_ATTEMPTS" ]; then sleep "$SLEEP_SECONDS"; fi
   done
-  fail "$url did not return a usable JSON document after $ATTEMPTS attempts (last: $reason)"
+  fail "$url did not return a usable JSON document after $FETCH_ATTEMPTS fetch attempts (last: $reason)"
   return 1
 }
 
@@ -104,79 +116,101 @@ assert_upstream_endpoint() {
   echo "  ok   $label = $actual"
 }
 
+# One full pass. Resets the counters so a retry starts clean rather than accumulating.
+verify_once() {
+  failures=0
+  failure_log=""
+
+  local as_doc="$WORK_DIR/as.json"
+  local expected_as_issuer=""
+
+  if fetch_json "$ORIGIN/.well-known/oauth-authorization-server" "$as_doc"; then
+    # RFC 8414 section 3.3 -- an anti-mix-up control. The document may only speak for the issuer it
+    # was fetched from, and we front authorize/token/register ourselves, so our own origin is the
+    # honest answer. Declaring the upstream provider's issuer here is the regression #90/#100 fixed,
+    # and it made strict clients (the TypeScript MCP SDK, hence MCP Inspector) abort before DCR.
+    assert_field "$as_doc" '.issuer' "$ORIGIN" "issuer"
+
+    # The facade's own endpoints must keep naming us. If any of these ever pointed upstream, DCR and
+    # the iss contract would both break while /health and the 401 stayed perfectly green.
+    assert_field "$as_doc" '.authorization_endpoint' "$ORIGIN/oauth/authorize" "authorization_endpoint"
+    assert_field "$as_doc" '.token_endpoint' "$ORIGIN/oauth/token" "token_endpoint"
+    assert_field "$as_doc" '.registration_endpoint' "$ORIGIN/oauth/register" "registration_endpoint"
+
+    # RFC 9207. Honest only because /oauth/callback injects `iss` unconditionally -- advertising
+    # support and then omitting the parameter reads to a client as a stripped-parameter attack, so
+    # the flag and the injection ship together, and this pins the half observable from outside.
+    local iss_flag
+    iss_flag=$(jq -r '.authorization_response_iss_parameter_supported // "<absent>"' "$as_doc")
+    if [ "$iss_flag" = "true" ]; then
+      echo "  ok   authorization_response_iss_parameter_supported = true"
+    else
+      fail "authorization_response_iss_parameter_supported is '$iss_flag', expected true"
+    fi
+
+    # These two point at the upstream provider and are read from its discovery document (#109), so a
+    # misconfigured OAuth:Authority surfaces here as a wrong value advertised to clients as fact.
+    assert_upstream_endpoint "$as_doc" '.jwks_uri' "jwks_uri"
+    assert_upstream_endpoint "$as_doc" '.userinfo_endpoint' "userinfo_endpoint"
+
+    expected_as_issuer=$(jq -r '.issuer // ""' "$as_doc")
+  fi
+
+  # RFC 9728, served from the canonical path and the resource-path-suffixed variant. Clients probe
+  # either, so both must serve -- and both must agree with the authorization-server document.
+  local pr_index=0
+  local path pr_doc advertised null_paths
+  for path in "/.well-known/oauth-protected-resource" "/.well-known/oauth-protected-resource/mcp"; do
+    pr_index=$((pr_index + 1))
+    pr_doc="$WORK_DIR/pr-$pr_index.json"
+    if ! fetch_json "$ORIGIN$path" "$pr_doc"; then
+      continue
+    fi
+
+    # The pairing a strict client actually checks: it reads authorization_servers out of this
+    # document, uses that string verbatim to build the well-known URL, and requires the returned
+    # issuer to equal it. Asserting each document alone would let the two drift while both still
+    # looked correct.
+    advertised=$(jq -r '.authorization_servers[0] // "<absent>"' "$pr_doc")
+    if [ -z "$expected_as_issuer" ]; then
+      fail "$path: cannot check authorization_servers -- the authorization-server document was unusable"
+    elif [ "$advertised" = "$expected_as_issuer" ]; then
+      echo "  ok   $path authorization_servers[0] = $advertised (matches issuer)"
+    else
+      fail "$path: authorization_servers[0] is '$advertised' but the authorization-server document declares issuer '$expected_as_issuer' -- clients compare these two literally"
+    fi
+
+    # RFC 9728 section 3.2 requires an unused metadata parameter to be *omitted*, not null. The
+    # ASP.NET Core default serialiser writes every unset optional as an explicit null, and the
+    # published @modelcontextprotocol/client types jwks_uri as a string and rejects the whole
+    # document on a null -- before any part of the OAuth flow is reached. Regression guard for the
+    # fix in #100, and invisible to any check that only reads the properties it expects to find.
+    null_paths=$(jq -c '[paths(. == null)]' "$pr_doc")
+    if [ "$null_paths" = "[]" ]; then
+      echo "  ok   $path has no null-valued properties"
+    else
+      fail "$path serialises null at $null_paths -- RFC 9728 section 3.2 requires an unused parameter to be omitted, and strict clients reject the document over the difference"
+    fi
+  done
+}
+
 echo "Verifying OAuth metadata at $ORIGIN"
 
-AS_DOC="$WORK_DIR/as.json"
-expected_as_issuer=""
-if fetch_json "$ORIGIN/.well-known/oauth-authorization-server" "$AS_DOC"; then
-  # RFC 8414 section 3.3 -- an anti-mix-up control. The document may only speak for the issuer it was
-  # fetched from, and we front authorize/token/register ourselves, so our own origin is the honest
-  # answer. Declaring the upstream provider's issuer here is the exact regression #90/#100 fixed, and
-  # it made strict clients (the TypeScript MCP SDK, hence MCP Inspector) abort before reaching DCR.
-  assert_field "$AS_DOC" '.issuer' "$ORIGIN" "issuer"
-
-  # The facade's own endpoints must keep naming us. If any of these ever pointed upstream, DCR and
-  # the iss contract would both break while /health and the 401 stayed perfectly green.
-  assert_field "$AS_DOC" '.authorization_endpoint' "$ORIGIN/oauth/authorize" "authorization_endpoint"
-  assert_field "$AS_DOC" '.token_endpoint' "$ORIGIN/oauth/token" "token_endpoint"
-  assert_field "$AS_DOC" '.registration_endpoint' "$ORIGIN/oauth/register" "registration_endpoint"
-
-  # RFC 9207. Honest only because /oauth/callback injects `iss` unconditionally -- advertising
-  # support and then omitting the parameter reads to a client as a stripped-parameter attack, so the
-  # flag and the injection ship together, and this pins the half observable from outside.
-  iss_flag=$(jq -r '.authorization_response_iss_parameter_supported // "<absent>"' "$AS_DOC")
-  if [ "$iss_flag" = "true" ]; then
-    echo "  ok   authorization_response_iss_parameter_supported = true"
-  else
-    fail "authorization_response_iss_parameter_supported is '$iss_flag', expected true"
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  # `|| true` because verify_once ends on an arbitrary assertion and set -e would abort the loop.
+  verify_once || true
+  if [ "$failures" -eq 0 ]; then
+    echo "OAuth metadata verification passed at $ORIGIN"
+    exit 0
   fi
-
-  # These two point at the upstream provider and are read from its discovery document (#109), so a
-  # misconfigured OAuth:Authority surfaces here as a wrong value advertised to clients as fact.
-  assert_upstream_endpoint "$AS_DOC" '.jwks_uri' "jwks_uri"
-  assert_upstream_endpoint "$AS_DOC" '.userinfo_endpoint' "userinfo_endpoint"
-
-  expected_as_issuer=$(jq -r '.issuer // ""' "$AS_DOC")
-fi
-
-# RFC 9728, served from the canonical path and the resource-path-suffixed variant. Clients probe
-# either, so both must serve -- and both must agree with the authorization-server document.
-pr_index=0
-for path in "/.well-known/oauth-protected-resource" "/.well-known/oauth-protected-resource/mcp"; do
-  pr_index=$((pr_index + 1))
-  PR_DOC="$WORK_DIR/pr-$pr_index.json"
-  if ! fetch_json "$ORIGIN$path" "$PR_DOC"; then
-    continue
-  fi
-
-  # The pairing a strict client actually checks: it reads authorization_servers out of this document,
-  # uses that string verbatim to build the well-known URL, and requires the returned issuer to equal
-  # it. Asserting each document alone would let the two drift while both still looked correct.
-  advertised=$(jq -r '.authorization_servers[0] // "<absent>"' "$PR_DOC")
-  if [ -z "$expected_as_issuer" ]; then
-    fail "$path: cannot check authorization_servers -- the authorization-server document was unusable"
-  elif [ "$advertised" = "$expected_as_issuer" ]; then
-    echo "  ok   $path authorization_servers[0] = $advertised (matches issuer)"
-  else
-    fail "$path: authorization_servers[0] is '$advertised' but the authorization-server document declares issuer '$expected_as_issuer' -- clients compare these two literally"
-  fi
-
-  # RFC 9728 section 3.2 requires an unused metadata parameter to be *omitted*, not null. The
-  # ASP.NET Core default serialiser writes every unset optional as an explicit null, and the
-  # published @modelcontextprotocol/client types jwks_uri as a string and rejects the whole document
-  # on a null -- before any part of the OAuth flow is reached. Regression guard for the fix in #100,
-  # and invisible to any check that only reads the properties it expects to find.
-  null_paths=$(jq -c '[paths(. == null)]' "$PR_DOC")
-  if [ "$null_paths" = "[]" ]; then
-    echo "  ok   $path has no null-valued properties"
-  else
-    fail "$path serialises null at $null_paths -- RFC 9728 section 3.2 requires an unused parameter to be omitted, and strict clients reject the document over the difference"
+  if [ "$attempt" -lt "$ATTEMPTS" ]; then
+    echo "  $failures problem(s) on attempt $attempt/$ATTEMPTS -- a revision swap can leave the previous one still serving; retrying in ${SLEEP_SECONDS}s"
+    sleep "$SLEEP_SECONDS"
   fi
 done
 
-if [ "$failures" -ne 0 ]; then
-  echo "::error::OAuth metadata verification failed with $failures problem(s) at $ORIGIN"
-  exit 1
-fi
-
-echo "OAuth metadata verification passed at $ORIGIN"
+printf '%s' "$failure_log" | while IFS= read -r line; do
+  if [ -n "$line" ]; then echo "::error::$line"; fi
+done
+echo "::error::OAuth metadata verification failed with $failures problem(s) at $ORIGIN after $ATTEMPTS attempts"
+exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ name: Release
 # conventional commits, create the tag + a GitHub Release (the changelog), and deploy it via the
 # reusable deploy workflow. Fully automatic; the deploy self-rolls-back on a failed smoke test.
 #
-# TO FREEZE DEPLOYS: `gh workflow disable release.yml` (re-enable with `gh workflow enable`). That
-# stops tagging, releasing and deploying together, which is the coherent unit — a freeze must not be
-# able to leave a Release behind for something that never shipped.
+# TO FREEZE DEPLOYS: `gh workflow disable release.yml`; to lift it, `gh workflow enable release.yml`.
+# That stops tagging, releasing and deploying together, which is the coherent unit — a freeze must not
+# be able to leave a Release behind for something that never shipped.
 #
 # Nothing is lost by pausing: the commits stay on main, and whenever the train next runs it tags once
 # and `--generate-notes` builds the changelog from everything since the previous tag. #111 briefly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,18 @@
 name: Release
 
 # Nightly release train: if main changed since the last tag, compute the next semver from
-# conventional commits, create the tag + a GitHub Release (the changelog), and — only when the
-# repository variable AUTO_DEPLOY has the value true (lowercase, no quotes) — deploy it via the
-# reusable deploy workflow, which self-rolls-back on a failed smoke test.
+# conventional commits, create the tag + a GitHub Release (the changelog), and deploy it via the
+# reusable deploy workflow. Fully automatic; the deploy self-rolls-back on a failed smoke test.
 #
-# Versioning and deploying are deliberately on separate switches. Freezing deploys by disabling this
-# whole workflow (`gh workflow disable release.yml`) also stops tagging and Releases, so the changelog
-# record silently pauses too — that happened on 2026-08-26 and is what #111 fixed. To freeze deploys,
-# set AUTO_DEPLOY=false and leave the workflow enabled.
+# TO FREEZE DEPLOYS: `gh workflow disable release.yml` (re-enable with `gh workflow enable`). That
+# stops tagging, releasing and deploying together, which is the coherent unit — a freeze must not be
+# able to leave a Release behind for something that never shipped.
 #
-# AUTO_DEPLOY defaults to off: an unset variable does NOT deploy. Production deploys should require an
-# explicit opt-in rather than inheriting one from a missing value. The deploy-skipped job below emits a
-# run annotation whenever a tag was cut but not shipped, so an unintentionally long freeze is visible
-# in the run log rather than looking like nothing happened.
+# Nothing is lost by pausing: the commits stay on main, and whenever the train next runs it tags once
+# and `--generate-notes` builds the changelog from everything since the previous tag. #111 briefly
+# added an AUTO_DEPLOY variable to keep tagging during a freeze, on the mistaken premise that a freeze
+# discarded changelog history. It does not — and the one night that ran produced v4.2.2: a Release
+# marked "Latest" that had been deployed nowhere. Reverted in #115; don't reintroduce it.
 on:
   schedule:
     - cron: "0 2 * * *" # 02:00 UTC nightly
@@ -58,9 +57,7 @@ jobs:
 
   deploy:
     needs: release
-    # `vars` is available in a job-level `if`, so the gate costs nothing at runtime. Compared against
-    # the literal string 'true' — an unset variable is the empty string and therefore does not deploy.
-    if: ${{ needs.release.outputs.new_tag != '' && vars.AUTO_DEPLOY == 'true' }}
+    if: ${{ needs.release.outputs.new_tag != '' }}
     permissions:
       id-token: write # OIDC for azure/login in the called deploy
       contents: read
@@ -73,24 +70,3 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-  # A reusable-workflow job (`uses:`) cannot carry extra steps, so the "why didn't it deploy?" notice
-  # has to be its own job. Without it a frozen train looks identical to a train with nothing to ship:
-  # the deploy job is simply absent from the run, which is exactly how a freeze outlives its purpose.
-  deploy-skipped:
-    name: Deploy skipped (AUTO_DEPLOY not enabled)
-    needs: release
-    if: ${{ needs.release.outputs.new_tag != '' && vars.AUTO_DEPLOY != 'true' }}
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      - name: Explain why nothing was deployed
-        # Both values go through env rather than being interpolated into the script. Repository
-        # variables are maintainer-set so the risk is slight, but `${{ }}` inside `run:` is a script
-        # injection shape and there is no reason to write one.
-        env:
-          NEW_TAG: ${{ needs.release.outputs.new_tag }}
-          AUTO_DEPLOY: ${{ vars.AUTO_DEPLOY }}
-        run: |
-          set -euo pipefail
-          echo "::notice title=Deploy skipped::Tagged ${NEW_TAG} and published the Release, but did not deploy - repository variable AUTO_DEPLOY is '${AUTO_DEPLOY:-<unset>}' and must be exactly 'true'. To ship this tag now: gh workflow run deploy.yml -f ref=${NEW_TAG}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,7 +619,7 @@ The deployment shape is **Azure Container Apps + Azure Key Vault + Auth0** (with
 | Image registry | Azure Container Registry (Premium SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
 | Logs | Log Analytics (attached to the CAE) | + Application Insights for traces |
 | Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Resource Server identifier `https://vitally.fiscaltec.com/` (trailing slash — identifiers are exact-match and immutable); post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation |
-| CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback — the smoke covers `/health`, the exact-401 challenge **and** the OAuth metadata documents); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it **only when the repo variable `AUTO_DEPLOY` is set to `true`** — see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
+| CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback — the smoke covers `/health`, the exact-401 challenge **and** the OAuth metadata documents); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it — freeze by disabling the workflow, see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
 | IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
 
 ### The deploy smoke covers the OAuth metadata, not just liveness
@@ -641,7 +641,16 @@ bash .github/scripts/verify-oauth-metadata.sh https://vitally.fiscaltec.com
 bash .github/scripts/verify-oauth-metadata.sh http://localhost:5099   # a local run, for testing it
 ```
 
-Two things about it that are deliberate and shouldn't be "tidied":
+**The whole assertion set retries, not just the fetches.** Container Apps reports a new revision
+`Provisioned`/`Healthy` *before* ingress finishes shifting traffic, so a check that runs immediately
+can be answered by the **old** revision — a valid 200, a valid document, the previous configuration.
+Asserting once turned that race into a rollback of a healthy deploy on 2026-08-28 (revision 21 came up
+Healthy and was reverted 23 seconds later). `/health` and the 401 cannot catch the race in either
+direction, because both pass on whichever revision answers; this is the first check able to tell them
+apart, so it is the one that has to wait for the swap. Failures are collected and emitted as
+annotations only after the final attempt.
+
+Three things about it that are deliberate and shouldn't be "tidied":
 
 - **No normalisation anywhere.** Trailing slashes and case are compared literally, because that is
   what clients do — a check that tolerated a difference would pass configurations clients reject.
@@ -654,28 +663,43 @@ Verified when written by running it both ways round: it **passes** against a loc
 #100) — including `jwks_uri: null` in the RFC 9728 document, the exact defect that makes the published
 `@modelcontextprotocol/client` reject the whole document.
 
-### Freezing deploys without freezing releases
+### Freezing deploys
 
-`release.yml` cuts the tag and Release, then calls `deploy.yml` — but the deploy job is gated on the
-repository variable `AUTO_DEPLOY`, whose value must be exactly `true` — lowercase, with no quotes
-around it (`gh variable set AUTO_DEPLOY --body true`; a value of `"true"` that includes the quote
-characters does not match). **An unset variable does not deploy**: a production deploy should require
-an explicit opt-in rather than inherit one from a missing value.
+**`gh workflow disable release.yml`** (re-enable with `gh workflow enable release.yml`). That is the
+whole mechanism. It stops tagging, releasing and deploying together, which is the coherent unit: a
+freeze must not be able to leave a GitHub Release behind for something that never shipped.
 
-**To freeze deploys, set `AUTO_DEPLOY=false` and leave the workflow enabled.** Do *not* reach for
-`gh workflow disable release.yml` — that is the whole train, so it silently stops semver tagging and
-GitHub Releases too, and the changelog record pauses along with the deploys. That is exactly what
-happened on 2026-08-26 (to hold the queued OAuth work back from an unattended 02:00 UTC deploy) and it
-is the reason this switch exists (#111).
+An **attended** deploy stays available throughout via `deploy.yml`'s own `workflow_dispatch`, which is
+a separate workflow and unaffected by the freeze:
 
-When a tag is cut but not shipped, the `deploy-skipped` job emits a run annotation naming the tag and
-the `gh workflow run deploy.yml -f ref=<tag>` command to ship it manually. That annotation is the only
-thing distinguishing a deliberate freeze from a train with nothing to release, so don't remove it — a
-frozen train otherwise looks identical to an idle one, which is how a freeze outlives its purpose.
+```powershell
+gh workflow run deploy.yml --ref <tag-or-sha> -f ref=<tag-or-sha> -f image_tag=<tag>
+```
 
-An **attended** deploy is always available via `deploy.yml`'s own `workflow_dispatch`, regardless of
-`AUTO_DEPLOY`. That is the intended route while a freeze is in place, and it is what the #102 migration
-needs: #108 is gated on its predecessors being *deployed*, not merely merged, so a blanket freeze would
-deadlock it.
+That is the intended route during a freeze, and #108 needs it — the Entra cutover is gated on its
+predecessors being *deployed*, not merely merged, so a freeze that blocked every deploy would deadlock
+it.
+
+**Nothing is lost by pausing.** The commits stay on `main`; whenever the train next runs it cuts one
+tag and `--generate-notes` builds the changelog from everything since the previous tag. The only thing
+forgone is intermediate version numbers for versions that never existed anywhere.
+
+**Do not reintroduce an `AUTO_DEPLOY`-style variable.** #111 added one so tagging could continue during
+a freeze, on the premise that freezing discarded changelog history. That premise was wrong, and the one
+night it ran produced `v4.2.2` — a Release marked "Latest", deployed nowhere. Reverted in #115. If a
+future change makes "release without deploying" look useful again, re-read this paragraph first: the
+requirement it was serving did not exist.
+
+**A `deploy` job showing as `skipped` in a release run is normal** and is not a freeze. The job is
+gated on `new_tag != ''`, so a night with no new conventional commits produces no tag and nothing to
+ship. Most historical runs look like this; the deploys that did fire (18, 19 and 22 August 2026)
+appear as `deploy / Build, import to ACR, roll Container App`.
+
+**Automatic deploys do not appear in `deploy.yml`'s run list.** When `release.yml` calls it via
+`uses:`, the job runs *inside the caller's run* — `gh run list --workflow=deploy.yml` shows only
+manual `workflow_dispatch` runs, which makes the automation look untested when it is not. A second
+tell: the release train passes `image_tag: <semver>`, whereas a manual dispatch defaults to
+`sha-<short-sha>`, so the deployed image name says which path shipped it
+(`az containerapp show ... --query properties.template.containers[0].image`).
 
 Infrastructure-as-code is in this repo at `infra/terraform/` — the table above documents the runtime contract for what `deploy.yml` expects. Anyone replicating can swap Container Apps for App Service, ACR for GHCR, Auth0 for Keycloak, etc., without touching the application code.


### PR DESCRIPTION
Closes #115.

Two corrections to the release/deploy pipeline: one undoing yesterday's mistake, one fixing a defect
that #110's first real run exposed.

## 1. Revert #111

#111 was raised on the premise that disabling `release.yml` to freeze deploys "silently pauses the
changelog record". **That was wrong.** The commits stay on `main`, and the next run cuts one tag with
`--generate-notes` covering everything since the previous one. Only intermediate version numbers are
forgone — for versions that never existed anywhere.

The one night the variable was live, it produced precisely the artefact it should have prevented:
**`v4.2.2`, marked "Latest", deployed nowhere.**

Freezing is now `gh workflow disable release.yml` again, which stops tagging, releasing and deploying
together. That is the coherent unit — a freeze cannot leave a Release behind for something that never
shipped. Restores `if: new_tag != ''`, removes `deploy-skipped`, and the docs now say so with an
explicit note not to reintroduce the variable.

## 2. The metadata check raced the revision swap

#110's verifier **rolled back a healthy deploy** on its first real run:

```
0000021  09:17:51  vitally-mcp:v4.2.2   Healthy   <- new revision, started fine
0000022  09:18:14  vitally-mcp:v4.2.1   Healthy   <- rollback, 23 seconds later
```

Container Apps reports a new revision `Provisioned`/`Healthy` *before* ingress finishes shifting
traffic. The verifier ran ~23s in, was answered by the **old** revision — valid 200, valid document,
previous configuration — and failed immediately, because it retried only fetch failures, not failed
assertions.

Worth noting why nothing else caught it: `/health` 200 and `/mcp` 401 pass on *either* revision, so
they give no signal about which is answering. The metadata check is the first assertion able to tell
them apart, which is exactly why it has to tolerate the swap.

Now the whole assertion set retries; failures are collected and annotated only after the final
attempt; fetch retries are separated (`FETCH_ATTEMPTS`) so the loops don't multiply.

## Verification

Ran, not just syntax-checked — an earlier iteration passed `bash -n` while being structurally broken,
so both cases were executed:

- **Stub serving the stale document for one full pass, then the correct one** — attempt 1 reports 6
  problems *silently*, attempt 2 passes, exit 0. That is the failed deploy, recovering.
- **Genuinely wrong target (production today)** — retries, then reports all 6 problems once, exit 1.

## Also documented

Two things that cost time today and were nowhere in the docs:

- A `deploy` job showing `skipped` in a release run is **normal** — no new tag, nothing to ship.
- Automatic deploys do **not** appear in `deploy.yml`'s run list, because a `workflow_call` job runs
  inside the caller's run. That makes the automation look untested when it isn't. The image tag is the
  tell: the train passes `v<semver>`, a manual dispatch defaults to `sha-<short>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoVcPDWpriH46jsTUXrvTn