### PR TITLE
ci: recreate staging and make deploy.yml target a GitHub environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,12 +105,21 @@ jobs:
             echo "::error::Target '$TARGET' is missing variable(s):$missing -- set them on the '$TARGET' GitHub environment (or repo-level if shared by every target)."
             exit 1
           fi
-          # No normalisation: PUBLIC_ORIGIN is concatenated into the smoke URLs and handed to
-          # verify-oauth-metadata.sh, which compares the published `issuer` to it literally.
+          # Must be scheme + host ONLY. No normalisation is applied, deliberately: PUBLIC_ORIGIN is
+          # concatenated into the smoke URLs and handed to verify-oauth-metadata.sh, which compares
+          # the published `issuer` to it literally. A path is the realistic mistake rather than a
+          # theoretical one -- this repo's docs are full of `https://<host>/mcp` URLs, and pasting one
+          # here would build `.../mcp/health`, fail every assertion below and roll back a healthy
+          # deploy. Rejecting `/`, `?` and `#` in the authority also subsumes the trailing slash.
           case "$PUBLIC_ORIGIN" in
-            https://*/) echo "::error::PUBLIC_ORIGIN must not end in a slash (got '$PUBLIC_ORIGIN')"; exit 1 ;;
-            https://*) ;;
+            https://*) origin_host="${PUBLIC_ORIGIN#https://}" ;;
             *) echo "::error::PUBLIC_ORIGIN must be an absolute https origin (got '$PUBLIC_ORIGIN')"; exit 1 ;;
+          esac
+          case "$origin_host" in
+            "" | */* | *\?* | *"#"*)
+              echo "::error::PUBLIC_ORIGIN must be scheme and host only -- no path, query, fragment or trailing slash (got '$PUBLIC_ORIGIN')"
+              exit 1
+              ;;
           esac
           echo "Target '$TARGET': app=$CONTAINER_APP origin=$PUBLIC_ORIGIN"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,36 @@
 name: Deploy
 
-# Production deploy. The ACR has public network access disabled, so the image cannot be built/pushed
-# to it from a GitHub-hosted runner. Instead we build + push to a private GHCR package, then
-# `az acr import` (server-side, works with public access disabled) pulls it into the private ACR, and
-# `az containerapp update` rolls the app. OIDC auth as the user-assigned managed identity (federated
-# credential subject repo:fiscaltec/vitally-mcp:environment:production). Callable manually
+# Deploys the image to one of the Container Apps targets in `vitally-prod-rg-uksouth`: `production`
+# (the default, and what the release train ships to) or `staging`. The ACR has public network access
+# disabled, so the image cannot be built/pushed to it from a GitHub-hosted runner. Instead we build +
+# push to a private GHCR package, then `az acr import` (server-side, works with public access
+# disabled) pulls it into the private ACR, and `az containerapp update` rolls the app. OIDC auth as
+# the user-assigned managed identity (federated credential subject
+# repo:fiscaltec/vitally-mcp:environment:<target> -- one per target). Callable manually
 # (workflow_dispatch) or by the release train (workflow_call). On a failed health/smoke check it rolls
 # the Container App back to the previous image.
+#
+# THE TARGET IS A GITHUB ENVIRONMENT NAME, and everything that differs between targets is an
+# environment-scoped variable (CONTAINER_APP, PUBLIC_ORIGIN) rather than a literal in this file, so
+# the smoke test, the metadata verification and the rollback are shared by every target instead of
+# being duplicated per target and left to drift. Adding a target is a GitHub environment plus a
+# federated credential, with no change here.
+#
+# `staging` exists for the Entra migration (#102/#112): authentication has the largest blast radius in
+# this system, so IdP changes are validated on staging first. Its hostname is deliberately stable --
+# identity-provider identifiers are immutable and must equal the server origin, so an ephemeral one
+# orphans an app registration per run.
 on:
   workflow_dispatch:
     inputs:
+      target:
+        description: "Deployment target (GitHub environment)"
+        required: false
+        default: production
+        type: choice
+        options:
+          - production
+          - staging
       ref:
         description: "Git ref (branch/tag/SHA) to deploy"
         required: false
@@ -20,6 +41,13 @@ on:
         type: string
   workflow_call:
     inputs:
+      target:
+        # `type: choice` is workflow_dispatch-only, so callers get a plain string. The default keeps
+        # the release train's existing call site (which passes no target) shipping to production.
+        description: "Deployment target (GitHub environment)"
+        required: false
+        default: production
+        type: string
       ref:
         description: "Git ref (branch/tag/SHA) to deploy"
         required: false
@@ -37,7 +65,9 @@ on:
         required: true
 
 concurrency:
-  group: deploy-production
+  # Per target: a staging deploy must not queue behind a production one, and two deploys to the same
+  # target must still serialise -- they race on one Container App's revisions.
+  group: deploy-${{ inputs.target }}
   cancel-in-progress: false
 
 jobs:
@@ -48,16 +78,44 @@ jobs:
       contents: read
       packages: write # push to GHCR
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{ inputs.target }}
     env:
+      # ACR_NAME / RESOURCE_GROUP / IMAGE_NAME are shared by every target and stay repo-level.
+      # CONTAINER_APP and PUBLIC_ORIGIN are set per environment; both targets set them explicitly so
+      # neither silently inherits the other's. The URLs are built from PUBLIC_ORIGIN in the steps --
+      # one `env:` entry cannot reference a sibling.
       ACR_NAME: ${{ vars.ACR_NAME }}
       RESOURCE_GROUP: ${{ vars.RESOURCE_GROUP }}
       CONTAINER_APP: ${{ vars.CONTAINER_APP }}
       IMAGE_NAME: ${{ vars.IMAGE_NAME }}
-      PUBLIC_ORIGIN: https://vitally.fiscaltec.com
-      HEALTH_URL: https://vitally.fiscaltec.com/health
-      MCP_URL: https://vitally.fiscaltec.com/mcp
+      PUBLIC_ORIGIN: ${{ vars.PUBLIC_ORIGIN }}
     steps:
+      # Runs before anything is built, imported or rolled, so a misconfigured target cannot leave a
+      # half-deployed app or a rollback to reason about. PUBLIC_ORIGIN earns the check on its own:
+      # it used to be a hardcoded production URL, and unset it would make every smoke assertion below
+      # run against a relative path, fail, and roll back a deploy that was in fact fine.
+      - name: Check the target's configuration is complete
+        run: |
+          set -euo pipefail
+          missing=""
+          for v in ACR_NAME RESOURCE_GROUP CONTAINER_APP IMAGE_NAME PUBLIC_ORIGIN; do
+            [ -n "${!v:-}" ] || missing="$missing $v"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Target '$TARGET' is missing variable(s):$missing -- set them on the '$TARGET' GitHub environment (or repo-level if shared by every target)."
+            exit 1
+          fi
+          # No normalisation: PUBLIC_ORIGIN is concatenated into the smoke URLs and handed to
+          # verify-oauth-metadata.sh, which compares the published `issuer` to it literally.
+          case "$PUBLIC_ORIGIN" in
+            https://*/) echo "::error::PUBLIC_ORIGIN must not end in a slash (got '$PUBLIC_ORIGIN')"; exit 1 ;;
+            https://*) ;;
+            *) echo "::error::PUBLIC_ORIGIN must be an absolute https origin (got '$PUBLIC_ORIGIN')"; exit 1 ;;
+          esac
+          echo "Target '$TARGET': app=$CONTAINER_APP origin=$PUBLIC_ORIGIN"
+        env:
+          TARGET: ${{ inputs.target }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
@@ -162,12 +220,12 @@ jobs:
           fi
           # Smoke (with retries): a freshly-swapped single-revision app may take a short while to
           # start serving on the public FQDN, so retry before failing (and triggering a rollback).
-          # /health must be 200; unauthenticated /mcp must be 401 (app live + Auth0 gate enforced).
+          # /health must be 200; unauthenticated /mcp must be 401 (app live + OAuth gate enforced).
           # curl already emits "000" as the http_code on a connection failure; `|| true` just stops
           # set -e aborting the loop so we can retry. No sleep after the final attempt.
           health_code=""
           for i in $(seq 1 6); do
-            health_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$HEALTH_URL" || true)
+            health_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 "$PUBLIC_ORIGIN/health" || true)
             echo "/health -> ${health_code:-000} (attempt $i)"
             [ "$health_code" = "200" ] && break
             [ "$i" -lt 6 ] && sleep 10
@@ -175,7 +233,7 @@ jobs:
           [ "$health_code" = "200" ] || { echo "::error::/health not 200 after retries (last: ${health_code:-000})"; exit 1; }
           mcp_code=""
           for i in $(seq 1 6); do
-            mcp_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -X POST "$MCP_URL" \
+            mcp_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 -X POST "$PUBLIC_ORIGIN/mcp" \
               -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}' || true)
             echo "/mcp (unauthenticated) -> ${mcp_code:-000} (attempt $i)"
             [ "$mcp_code" = "401" ] && break

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,8 +262,11 @@ against a local container is now a working end-to-end client, which is the pract
   `Authorization:Enabled=false` to confirm the rest of the path, or accept the empty list as evidence
   the RBAC discovery filter fails closed.
 - **Auth0 API identifiers are immutable and must equal the server origin** (the client throws if the
-  RFC 9728 `resource` does not match), so an ephemeral tunnel URL orphans one API per run. Use a
-  stable hostname, or budget for the cleanup.
+  RFC 9728 `resource` does not match), so an ephemeral tunnel URL orphans one API per run. This is
+  what the staging environment now exists to avoid — validate identity-provider changes against
+  `https://vitally-staging.fiscaltec.com`, whose hostname is stable and whose Resource Server already
+  matches it. Reach for a tunnel only for something staging genuinely cannot cover, and budget for the
+  cleanup if you do.
 
 ### Upstream endpoints come from OIDC discovery, not from `Authority`
 
@@ -609,18 +612,90 @@ dotnet test VitallyMcp.sln -c Debug --filter-class "*MeetingsToolsTests"
 
 ## Deployment
 
-The deployment shape is **Azure Container Apps + Azure Key Vault + Auth0** (with Auth0 federating to Microsoft Entra for FISCAL employee sign-in), and the container image hosted in Azure Container Registry. `.github/workflows/deploy.yml` builds the image in ACR (via GitHub OIDC, no long-lived credentials) and rolls the Container App to the new revision. It is currently **manual-trigger only** (`workflow_dispatch`) until the target infrastructure is provisioned in the separate Terraform repo, at which point the `push` trigger can be enabled. It expects repo variables `ACR_NAME` / `RESOURCE_GROUP` / `CONTAINER_APP` / `IMAGE_NAME` and secrets `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`.
+The deployment shape is **Azure Container Apps + Azure Key Vault + Auth0** (with Auth0 federating to Microsoft Entra for FISCAL employee sign-in), and the container image hosted in Azure Container Registry. `.github/workflows/deploy.yml` builds the image, imports it into the private ACR (via GitHub OIDC, no long-lived credentials) and rolls a Container App to the new revision.
+
+**It deploys to one of two targets, and the target is a GitHub *environment* name:** `production`
+(the default, and what the nightly release train ships to) or `staging` — see the staging section
+below. Everything that differs between targets is an environment-scoped GitHub variable
+(`CONTAINER_APP`, `PUBLIC_ORIGIN`), so the workflow contains no per-target literals and the smoke
+test, metadata verification and rollback are shared rather than duplicated per target and left to
+drift. Shared values (`ACR_NAME` / `RESOURCE_GROUP` / `IMAGE_NAME`) stay repo-level, as do the secrets
+`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID`. A first step fails the run *before*
+anything is built if any of those is missing, or if `PUBLIC_ORIGIN` is not a slash-free absolute https
+origin — unset, every smoke assertion below would be made against a relative path, fail, and roll back
+a deploy that was in fact fine.
+
+Each target needs its **own federated credential** on the managed identity, subject
+`repo:fiscaltec/vitally-mcp:environment:<target>`, plus `Contributor` on that target's Container App.
+The subject is an exact string match, so a target with no credential fails at `azure/login` rather
+than deploying somewhere unintended.
 
 | Component | Resource | Notes |
 |---|---|---|
-| Hosting | Azure Container Apps (consumption plan) | Scale-to-zero; HTTPS-native ingress; managed cert on `vitally.fiscaltec.com` |
+| Hosting (production) | Azure Container Apps `vitally-prod-ca-uksouth` (consumption plan) | `minReplicas: 1` (one warm replica); HTTPS-native ingress; managed cert on `vitally.fiscaltec.com` |
+| Hosting (staging) | Azure Container Apps `vitally-staging-ca-uksouth`, **same** RG and CAE | Scale-to-zero (`minReplicas: 0`); managed cert on `vitally-staging.fiscaltec.com`; the pre-production target for identity changes — see below |
 | Secrets | Azure Key Vault | `vitally-shared` is the default secret name; managed identity has `Key Vault Secrets User` |
 | Identity | User-assigned managed identity | `AcrPull` on the registry + `Key Vault Secrets User` on the vault |
 | Image registry | Azure Container Registry (Premium SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
 | Logs | Log Analytics (attached to the CAE) | + Application Insights for traces |
-| Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Resource Server identifier `https://vitally.fiscaltec.com/` (trailing slash — identifiers are exact-match and immutable); post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation |
+| Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Two Resource Servers, one per origin: `https://vitally.fiscaltec.com/` and `https://vitally-staging.fiscaltec.com/` (trailing slash — identifiers are exact-match and immutable). **One** shared client (`Vitally MCP`) carrying both origins' `/oauth/callback`, so both targets use the same `SharedClientId` / `SharedClientSecret`. Post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation |
 | CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback — the smoke covers `/health`, the exact-401 challenge **and** the OAuth metadata documents); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it — freeze by disabling the workflow, see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
 | IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
+
+### Staging (`vitally-staging-ca-uksouth`) — the pre-production target for identity changes
+
+**Deploy to it:**
+
+```powershell
+gh workflow run deploy.yml -f target=staging -f ref=<branch-tag-or-sha>
+```
+
+`https://vitally-staging.fiscaltec.com` — a second Container App in the *same* resource group and the
+*same* Container Apps Environment as production, not a second environment. That is what makes it
+cheap: the CAE is VNet-injected, so a new app inside it reaches Key Vault and ACR over the existing
+private endpoints with no additional networking, and it reuses the same user-assigned managed
+identity, so `AcrPull`, `Key Vault Secrets User` and the Graph `GroupMember.Read.All` grant already
+cover it.
+
+**Why it exists.** Authentication has the largest blast radius in this system, so the Entra migration
+(#102 / #108) is validated here before production. The alternatives were rejected: a local server
+behind an ephemeral HTTPS tunnel orphans one identity-provider app registration per run — identifier
+URIs are immutable and must equal the server origin — which cost two sessions during #90; and
+validating straight against production is the failure mode a staging-first design exists to prevent.
+**The hostname being stable is the load-bearing property, not a convenience:** it is what lets one app
+registration be reused across a multi-run validation.
+
+**What it shares with production, deliberately:** the CAE, the managed identity, the ACR, the Key
+Vault *and its `vitally-shared` secret*, the `sg-vitally-*` tier group ids, and the single Auth0
+client. Sharing is the point — a staging environment that differs in more than the thing under test
+cannot tell you whether a failure is the change or the environment.
+
+**What diverges:** `OAuth__Audience` / `OAuth__Resource` (`https://vitally-staging.fiscaltec.com/`,
+its own Auth0 Resource Server), `OAuth__PublicBaseUrl`, `minReplicas: 0`, and — at #108 —
+`OAuth__Authority`, which staging flips to Entra first while production stays on Auth0.
+
+**Two divergences that will cost you time if you meet them cold:**
+
+- **A staging token carries no `permissions` claim.** The post-login Action's guard is
+  `if (event.resource_server?.identifier !== 'https://vitally.fiscaltec.com/') return;`, so it mints
+  nothing for the staging audience. That is harmless today because `Authorization:LiveGroupCheck` is
+  `true` on both targets and entitlement comes from Graph `transitiveMembers` — but it does mean
+  staging has **no claim-based fallback tier**: a Graph failure denies on staging where production
+  would still degrade to the claim. Do **not** "fix" this by widening the Action's guard. The Action
+  and its claim disappear at cutover, so the work would be thrown away, and the divergence is in the
+  safe direction.
+- **There is one Vitally tenant and its API keys are global.** Staging reads the *production*
+  `vitally-shared` secret, so its write and delete tools mutate real customer data — there is no
+  sandbox to point it at. `Authorization:ReadOnly=true` is deliberately **not** set, because #108's
+  acceptance test needs the write tools visible to prove a reader is denied one. So staging is
+  read-only by convention, not by configuration.
+
+**The custom domain is bound out of band**, as production's is. `fiscaltec.com` is on Cloudflare, so
+DNS is not in `infra/terraform/`: the zone needs an **un-proxied** (DNS-only) `CNAME` from
+`vitally-staging` to the app's default FQDN, plus an `asuid.vitally-staging` `TXT` carrying the CAE's
+`customDomainVerificationId`. Proxying the CNAME breaks managed-certificate issuance. Then
+`az containerapp hostname add`, followed by
+`az containerapp hostname bind --validation-method CNAME`.
 
 ### The deploy smoke covers the OAuth metadata, not just liveness
 
@@ -634,10 +709,12 @@ wrong upstream, a dropped `iss` flag, or a null-serialised optional each break e
 next re-authentication *and deploy green*. The rollback therefore used to read as assurance it did not
 provide (#110).
 
-**Run it by hand against any origin** — that is the point of it being a script rather than inline YAML:
+**Run it by hand against any origin** — that is the point of it being a script rather than inline
+YAML, and it is also how the same assertions cover staging with no second copy to keep in step:
 
 ```bash
 bash .github/scripts/verify-oauth-metadata.sh https://vitally.fiscaltec.com
+bash .github/scripts/verify-oauth-metadata.sh https://vitally-staging.fiscaltec.com
 bash .github/scripts/verify-oauth-metadata.sh http://localhost:5099   # a local run, for testing it
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,7 +642,12 @@ than deploying somewhere unintended.
 | CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback — the smoke covers `/health`, the exact-401 challenge **and** the OAuth metadata documents); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it — freeze by disabling the workflow, see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
 | IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
 
-### Staging (`vitally-staging-ca-uksouth`) — the pre-production target for identity changes
+### Staging (`vitally-staging-ca-uksouth`) — an on-demand pre-production target
+
+**Staging is created when it is needed and torn down when the work is done.** It is not a standing
+environment, and `az containerapp list` showing only `vitally-prod-ca-uksouth` is a normal state, not
+a fault — that is exactly what #112 was raised for. Decided 2026-08-28, after evaluating and rejecting
+a separate dev environment (see the topology note at the end of this section).
 
 **Deploy to it:**
 
@@ -696,6 +701,50 @@ DNS is not in `infra/terraform/`: the zone needs an **un-proxied** (DNS-only) `C
 `customDomainVerificationId`. Proxying the CNAME breaks managed-certificate issuance. Then
 `az containerapp hostname add`, followed by
 `az containerapp hostname bind --validation-method CNAME`.
+
+#### What must survive a teardown
+
+Tearing down the **Container App** is the whole teardown. Everything below is persistent scaffolding
+that makes the next spin-up cheap, and deleting any of it is what turns a recreate back into the
+multi-session exercise #112 was raised to end:
+
+| Keep | Why |
+|---|---|
+| The Cloudflare `CNAME` + `asuid.vitally-staging` `TXT` | Costs nothing while the app is gone. The `CNAME` target is deterministic (`<app-name>.<CAE default domain>`), so it keeps pointing at the right place after a recreate under the same name |
+| The Auth0 Resource Server `https://vitally-staging.fiscaltec.com/` | **Identifiers are immutable.** Deleting and recreating it per run is precisely the orphaning cost the stable hostname exists to avoid |
+| The staging `/oauth/callback` on the shared Auth0 client | Same reason, and it is inert while no app answers there |
+| The Entra staging redirect URI (#107) | Same reason |
+| The `staging` GitHub environment + its `CONTAINER_APP` / `PUBLIC_ORIGIN` variables | The workflow reads them; recreating them by hand invites a typo into the origin, which the preflight check would catch but only after a wasted run |
+| The federated credential and role assignments | See the identity note below |
+| `containerapps-staging.tf` | The recreate recipe. Keep it in step with the live app rather than deleting it when the app goes |
+
+The managed TLS certificate and the hostname binding go with the app and are re-created by the two
+`az containerapp hostname` commands above — that plus the app itself is the entire spin-up, because
+the CAE, identity, ACR and Key Vault are all shared and never leave.
+
+#### The shared managed identity is a known weakness
+
+`vitally-prod-id-uksouth` serves both targets and holds `Contributor` on the production Container App,
+so a federated credential for `environment:staging` mints a token that **can roll production**. The
+per-app role assignments give no protection, because one identity holds both. Recorded rather than
+fixed; the fix is a `vitally-staging-id-uksouth` with its own `AcrPull`, `Key Vault Secrets User`,
+Graph `GroupMember.Read.All` and an app-scoped `Contributor` — the Graph grant needs admin consent,
+which is the only friction. This matters more under the on-demand model, not less: the identity is
+persistent scaffolding, so getting it right once pays on every spin-up.
+
+#### Why there is no separate dev environment
+
+Evaluated on 2026-08-28 and deliberately not done. A `global` / `prod` / `dev` split is the right end
+state and the `global` tier already exists implicitly — the Premium ACR with CMK, the CMK vault, the
+Auth0 tenant and DNS are all genuinely shared but carry `prod` names. The cheap version, if it is ever
+picked up, is **not** full duplication: the VNet is `10.80.0.0/23` with only `10.80.0.0-.127`
+allocated, so a second `/27` app subnet and its own CAE drop in with no re-addressing, one NAT gateway
+serves multiple subnets in the same VNet, and both CAEs resolve the same private endpoints through the
+shared DNS zone links. That closes the one gap the shared model cannot: **CAE-level and platform
+changes cannot be rehearsed before production sees them.**
+
+What no topology fixes: there is one Vitally tenant and its API keys are global, so any staging or dev
+environment reads real customer data.
 
 ### The deploy smoke covers the OAuth metadata, not just liveness
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -722,15 +722,25 @@ The managed TLS certificate and the hostname binding go with the app and are re-
 `az containerapp hostname` commands above — that plus the app itself is the entire spin-up, because
 the CAE, identity, ACR and Key Vault are all shared and never leave.
 
-#### The shared managed identity is a known weakness
+#### One managed identity serves both targets — an accepted risk, not an open defect
 
 `vitally-prod-id-uksouth` serves both targets and holds `Contributor` on the production Container App,
 so a federated credential for `environment:staging` mints a token that **can roll production**. The
-per-app role assignments give no protection, because one identity holds both. Recorded rather than
-fixed; the fix is a `vitally-staging-id-uksouth` with its own `AcrPull`, `Key Vault Secrets User`,
-Graph `GroupMember.Read.All` and an app-scoped `Contributor` — the Graph grant needs admin consent,
-which is the only friction. This matters more under the on-demand model, not less: the identity is
-persistent scaffolding, so getting it right once pays on every spin-up.
+per-app role assignments give no protection, because one identity holds both — do not read them as a
+boundary.
+
+**Accepted deliberately on 2026-08-28**, on this basis: neither the `production` nor the `staging`
+GitHub environment has protection rules or a deployment branch policy (verified, not assumed), and
+`deploy.yml` is `workflow_dispatch`-able against production directly. So anyone who can trigger a
+staging deploy can already trigger a production one, and the shared identity grants no privilege they
+did not already hold. Don't "fix" this on sight — it was priced and taken.
+
+**What would change the answer:** the moment `production` gains a protection rule that `staging` does
+not — required reviewers, or a deployment branch policy — the shared identity becomes a way around
+that gate, and it stops being an accepted risk. Revisit it then, and also if staging starts routinely
+deploying unreviewed refs. The remedy is a `vitally-staging-id-uksouth` with its own `AcrPull`,
+`Key Vault Secrets User`, Graph `GroupMember.Read.All` and an app-scoped `Contributor`; the Graph
+grant needs admin consent, which is the only real friction.
 
 #### Why there is no separate dev environment
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -17,7 +17,8 @@ and DR-able.
 | `keyvault.tf` | secret vault (private), CMK vault (firewalled) + RSA key, KV private endpoint, diag |
 | `acr.tf` | ACR (Premium, CMK, private) + private endpoint + diag |
 | `monitoring.tf` | Log Analytics + Application Insights |
-| `containerapps.tf` | Container Apps env, app, and the secret-expiry scanner Job (`scan/run.py`) |
+| `containerapps.tf` | Container Apps env, production app, and the secret-expiry scanner Job (`scan/run.py`) |
+| `containerapps-staging.tf` | Staging app (#112) — second app in the *same* env; pre-production target for IdP changes |
 | `imports.tf` | import blocks for adoption (comment out after import) |
 
 ## Prerequisites
@@ -48,10 +49,15 @@ role assignments (`az role assignment list --scope <id> --query "[].id"`), diagn
 DNS vnet-links / NAT associations (composite IDs).
 
 ## Known limitations (reconcile manually / accept drift)
-- **Managed TLS certificate** — the `vitally.fiscaltec.com` custom domain uses a *free managed* cert,
-  which azurerm cannot create. It's bound out-of-band (`az containerapp hostname bind --validation-method TXT`).
-  The `custom_domain` block in `containerapps.tf` is commented; either keep binding it manually and
-  `ignore_changes`, or switch to a BYO cert via `azurerm_container_app_environment_certificate`.
+- **Managed TLS certificates** — both the `vitally.fiscaltec.com` and `vitally-staging.fiscaltec.com`
+  custom domains use *free managed* certs, which azurerm cannot create. They're bound out-of-band
+  (`az containerapp hostname add` then `az containerapp hostname bind`). The `custom_domain` blocks in
+  `containerapps.tf` / `containerapps-staging.tf` are commented; either keep binding them manually and
+  `ignore_changes`, or switch to BYO certs via `azurerm_container_app_environment_certificate`.
+- **DNS** — `fiscaltec.com` is on Cloudflare, not Azure DNS, so no zone is managed here. Each custom
+  domain needs an **un-proxied** (DNS-only) `CNAME` to the app's default FQDN plus an
+  `asuid.<subdomain>` `TXT` carrying the environment's `customDomainVerificationId`. Proxying the
+  CNAME breaks managed-certificate issuance.
 - **`vitally-shared` secret value** — the Vitally API key is *not* managed here (would land in state).
   Manage it with `az keyvault secret set` and keep its 180-day expiry; the scanner Job alerts before expiry.
 - **CMK key management** — the dedicated CMK vault is firewalled; managing the key via Terraform needs the
@@ -59,11 +65,20 @@ DNS vnet-links / NAT associations (composite IDs).
 - **Diagnostic-setting block syntax** and **container `cpu`/`memory`** may need minor tweaks to match the
   exact azurerm version / live values — `terraform plan` will surface these.
 
-## Not yet done (#10 part b — CI/CD)
-The OIDC deploy pipeline (`.github/workflows/deploy.yml`) is scaffolded but unwired: it needs a GitHub
-federated credential, repo variables/secrets, and a `production` environment. The registry keeps
-`network_rule_bypass_option = "AzureServices"`, so ACR Tasks (`az acr build`) still work with public
-access off. Wiring this is the natural next step.
+## CI/CD (wired)
+`.github/workflows/deploy.yml` deploys to one of two targets, named by GitHub **environment**:
+`production` (default, and where the nightly release train ships) or `staging`. Each target needs
+three things, all captured here: a federated credential on the managed identity whose subject is
+`repo:fiscaltec/vitally-mcp:environment:<target>` (`identity.tf`), `Contributor` on that target's
+Container App (`identity.tf`), and `CONTAINER_APP` + `PUBLIC_ORIGIN` as **environment-scoped** GitHub
+variables. `ACR_NAME` / `RESOURCE_GROUP` / `IMAGE_NAME` are shared and stay repo-level.
+
+The workflow itself holds no per-target literals, so adding a target means an environment plus a
+federated credential and no YAML change. It fails before building if any of those variables is
+missing, rather than mid-deploy.
+
+The registry keeps `network_rule_bypass_option = "AzureServices"`, so ACR Tasks (`az acr build`) still
+work with public access off.
 
 ## Related
 - `docs/runbooks/vitally-private-networking.md` — the VNet/private-endpoint migration

--- a/infra/terraform/containerapps-staging.tf
+++ b/infra/terraform/containerapps-staging.tf
@@ -1,0 +1,152 @@
+# Staging Container App — the pre-production target for identity-provider changes (#112).
+#
+# WHY IT EXISTS. Authentication has the largest blast radius in this system, so the Entra migration
+# (#102) is validated here before production. The alternatives were both rejected: a local server
+# behind an ephemeral HTTPS tunnel orphans one identity-provider app registration per run (identifier
+# URIs are immutable and must equal the server origin), and validating straight against production is
+# the failure mode the staging-first design exists to avoid.
+#
+# WHY IT IS CHEAP. It shares the VNet-injected Container Apps Environment, so it reaches Key Vault and
+# ACR over the existing private endpoints with no additional networking, and it shares the
+# user-assigned managed identity, so the AcrPull / Key Vault Secrets User / Graph GroupMember.Read.All
+# grants all apply to it already. What is actually staging-specific is this app, a stable hostname, an
+# ingress certificate and one federated credential.
+#
+# WHY THIS IS DUPLICATED RATHER THAN for_each'd over a map with the production app. Refactoring the
+# two into one resource would change `azurerm_container_app.app`'s address, invalidating the import
+# block that adopts the live production app — and this configuration is documentation of the as-built
+# estate that is never applied blind (see README.md). Explicit duplication is the readable, low-risk
+# form here; keep the two in step by hand.
+resource "azurerm_container_app" "staging" {
+  name                         = var.staging_app_name
+  resource_group_name          = data.azurerm_resource_group.rg.name
+  container_app_environment_id = azurerm_container_app_environment.env.id
+  revision_mode                = "Single"
+  workload_profile_name        = "Consumption"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.app.id]
+  }
+
+  registry {
+    server   = azurerm_container_registry.acr.login_server
+    identity = azurerm_user_assigned_identity.app.id
+  }
+
+  # The same Auth0 client as production, so this is the same secret value. The client's Allowed
+  # Callback URLs carry both origins' /oauth/callback; the proxy's callback is fixed per origin.
+  secret {
+    name  = "oauth-shared-client-secret"
+    value = var.oauth_shared_client_secret
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+    transport        = "auto"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+
+    # Custom domain bound to a FREE MANAGED certificate, as production is. azurerm cannot create
+    # managed certs, so the binding is done out-of-band:
+    #   az containerapp hostname add  -n <app> -g <rg> --hostname vitally-staging.fiscaltec.com
+    #   az containerapp hostname bind -n <app> -g <rg> --hostname vitally-staging.fiscaltec.com \
+    #     --environment vitally-prod-cae-uksouth --validation-method CNAME
+    # Cloudflare (fiscaltec.com) carries the un-proxied CNAME to the app FQDN plus the
+    # asuid.vitally-staging TXT ownership proof. The CNAME must stay DNS-only — proxying it breaks
+    # both the managed-certificate issuance and the TLS chain clients see.
+    # custom_domain {
+    #   name                     = "vitally-staging.fiscaltec.com"
+    #   certificate_binding_type = "SniEnabled"
+    #   certificate_id           = "<managed cert id>"
+    # }
+  }
+
+  template {
+    # Unlike production, staging scales to zero. The warm replica production keeps exists to avoid a
+    # server-side cold start on real user traffic; staging has no users to protect, and a cold start
+    # is absorbed by the retries in deploy.yml's smoke and verify-oauth-metadata.sh.
+    min_replicas = 0
+    max_replicas = 2
+
+    container {
+      name   = "vitally-mcp"
+      image  = "${azurerm_container_registry.acr.login_server}/vitally-mcp:${var.staging_image_tag}"
+      cpu    = 0.5
+      memory = "1Gi"
+
+      env {
+        name  = "Vitally__Region"
+        value = "EU"
+      }
+      # Deliberately the production vault and the production `vitally-shared` secret: there is only
+      # one Vitally tenant and its API keys are global, so there is no staging key to point at. That
+      # means staging writes reach real Vitally data — see the note in CLAUDE.md.
+      env {
+        name  = "Vitally__KeyVaultUri"
+        value = "https://${azurerm_key_vault.secret.name}.vault.azure.net/"
+      }
+      env {
+        name  = "AZURE_CLIENT_ID"
+        value = var.managed_identity_client_id
+      }
+      # The one value that intentionally diverges from production during the migration: staging is
+      # pointed at Entra first (#108), production stays on Auth0 until staging has passed.
+      env {
+        name  = "OAuth__Authority"
+        value = var.staging_oauth_authority
+      }
+      env {
+        name  = "OAuth__Audience"
+        value = var.staging_oauth_audience
+      }
+      env {
+        name  = "OAuth__Resource"
+        value = var.staging_oauth_audience
+      }
+      env {
+        name  = "OAuth__NoAuth"
+        value = "false"
+      }
+      env {
+        name  = "OAuth__SharedClientId"
+        value = var.oauth_shared_client_id
+      }
+      env {
+        name        = "OAuth__SharedClientSecret"
+        secret_name = "oauth-shared-client-secret"
+      }
+      env {
+        name  = "OAuth__AllowedClientRedirectUris__0"
+        value = var.allowed_client_redirect_uri
+      }
+      env {
+        name  = "OAuth__PublicBaseUrl"
+        value = var.staging_public_base_url
+      }
+      # Same tier groups as production. Entitlement is resolved live from Graph transitiveMembers
+      # using only the `oid` claim, so it is identity-provider-independent and needs no staging
+      # variant — which is also why staging can be moved to Entra without touching these.
+      env {
+        name  = "Authorization__LiveGroupCheck"
+        value = "true"
+      }
+      env {
+        name  = "Authorization__ReaderGroupId"
+        value = var.entra_group_reader
+      }
+      env {
+        name  = "Authorization__EditorGroupId"
+        value = var.entra_group_editor
+      }
+      env {
+        name  = "Authorization__AdminGroupId"
+        value = var.entra_group_admin
+      }
+    }
+  }
+}

--- a/infra/terraform/containerapps-staging.tf
+++ b/infra/terraform/containerapps-staging.tf
@@ -1,4 +1,12 @@
-# Staging Container App — the pre-production target for identity-provider changes (#112).
+# Staging Container App — the on-demand pre-production target for identity-provider changes (#112).
+#
+# LIFECYCLE. Staging is spun up when it is needed and torn down when the work is done (decided
+# 2026-08-28), so this resource frequently describes something that does not currently exist — that
+# is the intended state, not drift to reconcile. Its import block in imports.tf therefore only
+# applies while the app is live; comment it out otherwise. Everything else staging needs (the CAE,
+# managed identity, ACR, Key Vault, DNS records, Auth0 Resource Server, GitHub environment and the
+# federated credential) is persistent scaffolding that deliberately survives a teardown — see the
+# teardown table in CLAUDE.md before deleting any of it.
 #
 # WHY IT EXISTS. Authentication has the largest blast radius in this system, so the Entra migration
 # (#102) is validated here before production. The alternatives were both rejected: a local server

--- a/infra/terraform/identity.tf
+++ b/infra/terraform/identity.tf
@@ -32,8 +32,12 @@ resource "azurerm_role_assignment" "mi_cmk_crypto" {
 # separate Entra-scoped config.
 
 # CI/CD (GitHub Actions OIDC): GitHub authenticates as this identity to deploy. The federated
-# credential subject matches the deploy workflow's `environment: production` job, so only that
-# environment can mint a token. Audience is the value azure/login requests by default.
+# credential subject matches the deploy workflow's `environment:` job, so only that environment can
+# mint a token. Audience is the value azure/login requests by default.
+#
+# ONE CREDENTIAL PER TARGET, and that is the whole reason deploy.yml keys off a GitHub environment
+# name: the subject is an exact string match, so a deploy to a target with no credential here fails
+# at azure/login rather than deploying somewhere unintended.
 resource "azurerm_federated_identity_credential" "github_actions_prod" {
   name                = "github-actions-prod-env"
   resource_group_name = data.azurerm_resource_group.rg.name
@@ -41,6 +45,15 @@ resource "azurerm_federated_identity_credential" "github_actions_prod" {
   audience            = ["api://AzureADTokenExchange"]
   issuer              = "https://token.actions.githubusercontent.com"
   subject             = "repo:fiscaltec/vitally-mcp:environment:production"
+}
+
+resource "azurerm_federated_identity_credential" "github_actions_staging" {
+  name                = "github-actions-staging-env"
+  resource_group_name = data.azurerm_resource_group.rg.name
+  parent_id           = azurerm_user_assigned_identity.app.id
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = "https://token.actions.githubusercontent.com"
+  subject             = "repo:fiscaltec/vitally-mcp:environment:staging"
 }
 
 # Deploy: `az acr import` the built image into the private ACR. AcrPush does NOT include the
@@ -54,6 +67,14 @@ resource "azurerm_role_assignment" "mi_acr_contributor" {
 # Deploy: roll the Container App to the new revision (`az containerapp update`).
 resource "azurerm_role_assignment" "mi_ca_contributor" {
   scope                = azurerm_container_app.app.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_user_assigned_identity.app.principal_id
+}
+
+# Deploy: the same, for staging. Scoped to the app rather than the resource group so a deploy to one
+# target cannot roll the other.
+resource "azurerm_role_assignment" "mi_ca_staging_contributor" {
+  scope                = azurerm_container_app.staging.id
   role_definition_name = "Contributor"
   principal_id         = azurerm_user_assigned_identity.app.principal_id
 }

--- a/infra/terraform/imports.tf
+++ b/infra/terraform/imports.tf
@@ -71,6 +71,7 @@ import {
   to = azurerm_container_app.app
   id = "${local.rg_id}/providers/Microsoft.App/containerApps/vitally-prod-ca-uksouth"
 }
+# Only valid while staging is spun up — it is an on-demand app (see containerapps-staging.tf).
 import {
   to = azurerm_container_app.staging
   id = "${local.rg_id}/providers/Microsoft.App/containerApps/vitally-staging-ca-uksouth"

--- a/infra/terraform/imports.tf
+++ b/infra/terraform/imports.tf
@@ -72,6 +72,10 @@ import {
   id = "${local.rg_id}/providers/Microsoft.App/containerApps/vitally-prod-ca-uksouth"
 }
 import {
+  to = azurerm_container_app.staging
+  id = "${local.rg_id}/providers/Microsoft.App/containerApps/vitally-staging-ca-uksouth"
+}
+import {
   to = azurerm_container_app_job.scanner
   id = "${local.rg_id}/providers/Microsoft.App/jobs/vitally-prod-secscan-uksouth"
 }

--- a/infra/terraform/imports.tf
+++ b/infra/terraform/imports.tf
@@ -72,9 +72,13 @@ import {
   id = "${local.rg_id}/providers/Microsoft.App/containerApps/vitally-prod-ca-uksouth"
 }
 # Only valid while staging is spun up — it is an on-demand app (see containerapps-staging.tf).
+# Unlike the blocks above, this one interpolates its name rather than hardcoding it. Those adopt
+# fixed production resources, whereas staging's name is a variable precisely because it is recreated
+# on demand — so a parallel spin-up under another name would otherwise adopt the wrong app into
+# `azurerm_container_app.staging` and show up as a rename.
 import {
   to = azurerm_container_app.staging
-  id = "${local.rg_id}/providers/Microsoft.App/containerApps/vitally-staging-ca-uksouth"
+  id = "${local.rg_id}/providers/Microsoft.App/containerApps/${var.staging_app_name}"
 }
 import {
   to = azurerm_container_app_job.scanner

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -72,6 +72,40 @@ variable "entra_group_admin" {
   default = "70b48a20-d4b1-47dc-a132-21bc99272a86"
 }
 
+# ---- Staging target (#112) ----
+# Everything the staging Container App does NOT share with production. The rest — region, vault,
+# managed identity, shared Auth0 client, tier group ids — is deliberately the same, so a staging
+# failure points at what changed rather than at the environment.
+variable "staging_app_name" {
+  type        = string
+  description = "Staging Container App name. Deliberately outside the name_prefix convention: it is a second app inside the production RG and Container Apps Environment, not a second environment."
+  default     = "vitally-staging-ca-uksouth"
+}
+
+variable "staging_image_tag" {
+  type        = string
+  description = "Container image tag deployed to the staging Container App. Moves independently of production's."
+  default     = "sha-3c40e0e"
+}
+
+variable "staging_oauth_authority" {
+  type        = string
+  description = "Upstream OIDC issuer for staging. Auth0 today (a like-for-like baseline against production); becomes the Entra issuer first at #108, while production stays on Auth0."
+  default     = "https://fiscal-it.uk.auth0.com/"
+}
+
+variable "staging_oauth_audience" {
+  type        = string
+  description = "Auth0 Resource Server identifier for staging, WITH the trailing slash. Must equal the staging origin: it is published as the RFC 9728 `resource`, and MCP clients reject the whole metadata document when that does not match the server they fetched it from."
+  default     = "https://vitally-staging.fiscaltec.com/"
+}
+
+variable "staging_public_base_url" {
+  type        = string
+  description = "Canonical public origin for staging — no trailing slash (it is an origin, and Validate() trims one anyway)."
+  default     = "https://vitally-staging.fiscaltec.com"
+}
+
 # ---- Secrets (DO NOT hardcode/commit — supply via TF_VAR_* or an untracked tfvars) ----
 variable "oauth_shared_client_secret" {
   type        = string


### PR DESCRIPTION
Closes #112

`vitally-staging-ca-uksouth` was torn down w/c 2026-08-18, so #108's staging-first Entra validation
had nowhere to run. This recreates it and makes `deploy.yml` able to deploy to it.

Production stays on Auth0 and is untouched by this PR — consistent with the standing constraint that
every #102 prerequisite leaves production working on Auth0, and #108 is the only issue that switches
anything.

## What was provisioned (already live, outside this diff)

| Thing | Value |
|---|---|
| Container App | `vitally-staging-ca-uksouth` — same RG and **same CAE** as production |
| Origin | `https://vitally-staging.fiscaltec.com` (hostname agreed before #107 provisions the Entra app) |
| Default FQDN | `vitally-staging-ca-uksouth.greenpond-74909a01.uksouth.azurecontainerapps.io` |
| Scale | `minReplicas: 0`, `maxReplicas: 2`, 0.5 vCPU / 1 GiB |
| Identity | the existing `vitally-prod-id-uksouth` user-assigned MI |
| Auth0 Resource Server | `https://vitally-staging.fiscaltec.com/` — mirrors production's `token_lifetime`, `allow_offline_access`, consent-skip, RBAC and the four scopes |
| Auth0 client | **unchanged and shared.** `https://vitally-staging.fiscaltec.com/oauth/callback` added alongside production's; a client grant was added for the new audience |
| GitHub | `staging` environment created; `CONTAINER_APP` + `PUBLIC_ORIGIN` set as environment variables on **both** environments |

Reusing the VNet-injected CAE is what makes this cheap — the new app reaches Key Vault and ACR over
the existing private endpoints, and the shared MI already holds `AcrPull`, `Key Vault Secrets User`
and the Graph `GroupMember.Read.All` grant. What was actually needed was the app, a hostname, a cert
and one federated credential.

## Why the workflow changed shape rather than gaining a sibling

`deploy.yml` now takes a `target` input which **is a GitHub environment name** (`production` by
default). Everything per-target is an environment-scoped variable, so the file holds no per-target
literals and the `/health`, exact-401 and OAuth-metadata assertions plus the rollback are shared. A
`deploy-staging.yml` would have duplicated ~200 lines including the metadata verifier, and those two
copies would drift — which matters here specifically, because that verifier is what stops an auth
regression deploying green.

The `/health` and exact-401 assertions are unchanged; only the URLs they are built from moved from
three hardcoded production literals to `$PUBLIC_ORIGIN`.

A **preflight step** now fails the run before anything is built if a variable is missing, or if
`PUBLIC_ORIGIN` is not a slash-free absolute https origin. That is not decoration: unset, every smoke
assertion would run against a relative path, fail, and roll back a deploy that was fine — the same
false-rollback class as the revision-swap race fixed in #116.

`release.yml`'s call site is unchanged; the input default keeps it shipping to production.

## Verification

Against the running app on its **default FQDN, before DNS exists** — so this is the environment
proving itself, not an assumption:

- `/health` → `200`
- unauthenticated `POST /mcp` → exactly `401`, with
  `WWW-Authenticate: Bearer resource_metadata="https://vitally-staging.fiscaltec.com/.well-known/oauth-protected-resource/mcp"`
- RFC 8414: `issuer` = `https://vitally-staging.fiscaltec.com`; `authorization_endpoint` /
  `token_endpoint` / `registration_endpoint` all name that origin; `jwks_uri` and `userinfo_endpoint`
  resolve to the real Auth0 values via OIDC discovery (#104 working on a second app);
  `authorization_response_iss_parameter_supported: true`
- RFC 9728: `resource` = `https://vitally-staging.fiscaltec.com/` (trailing slash),
  `authorization_servers[0]` equal to `issuer` byte for byte, **no null-valued properties**

Also: `449/449` tests pass, `terraform validate` succeeds and `terraform fmt -check` is clean.

`verify-oauth-metadata.sh https://vitally-staging.fiscaltec.com` cannot pass until the custom domain
is bound (it compares `issuer` to the origin it is given, literally, by design) — that is the last
step below, and it is the acceptance check for this issue.

## Remaining steps that need the repo owner (blocked by the sandbox classifier)

Batched so they can run in one go. Items 2–3 are ordinary `az`; item 1 is Cloudflare (the connected
MCP token is read-only for DNS).

**1. Cloudflare DNS — zone `fiscaltec.com`.** Mirror the two production records exactly:

| Type | Name | Content | Proxy |
|---|---|---|---|
| `CNAME` | `vitally-staging` | `vitally-staging-ca-uksouth.greenpond-74909a01.uksouth.azurecontainerapps.io` | **DNS only (grey cloud)** |
| `TXT` | `asuid.vitally-staging` | `8FA40178B1A5C32D8C92683DCFA541BC443AA1090AA3C735339BF29C0B08D91E` | n/a |

Proxying the CNAME breaks managed-certificate issuance and changes the TLS chain clients see.

**2. Copy the Auth0 client secret across, bind the hostname, and grant the deploy role.** The
container-app secret is currently the literal `placeholder-operator-must-replace`, so `/oauth/token`
will fail until this runs. Reading a secret value is blocked in-session, so the copy is yours — the
value never needs to be printed:

```bash
RG=vitally-prod-rg-uksouth

# a) real Auth0 client secret (same client as production)
val=$(az containerapp secret show -n vitally-prod-ca-uksouth -g $RG \
        --secret-name oauth-shared-client-secret --query value -o tsv)
az containerapp secret set -n vitally-staging-ca-uksouth -g $RG \
  --secrets "oauth-shared-client-secret=$val" -o none
unset val

# b) custom domain + free managed cert (run AFTER the DNS records above have propagated)
az containerapp hostname add  -n vitally-staging-ca-uksouth -g $RG \
  --hostname vitally-staging.fiscaltec.com
az containerapp hostname bind -n vitally-staging-ca-uksouth -g $RG \
  --hostname vitally-staging.fiscaltec.com \
  --environment vitally-prod-cae-uksouth --validation-method CNAME

# c) let CI roll the staging app (scoped to the app, not the RG)
az role assignment create \
  --assignee-object-id c57b35e7-19b8-4d25-b762-321de5f4f0cb \
  --assignee-principal-type ServicePrincipal --role Contributor \
  --scope "/subscriptions/282207c6-4107-47fa-9d4e-b2fa9b3066cb/resourceGroups/$RG/providers/Microsoft.App/containerapps/vitally-staging-ca-uksouth"
```

**3. Federated credential for the `staging` environment** — without it `azure/login` fails on a
staging deploy (the subject is an exact string match, which is the safety property):

```bash
az identity federated-credential create \
  --name github-actions-staging-env \
  --identity-name vitally-prod-id-uksouth \
  -g vitally-prod-rg-uksouth \
  --issuer https://token.actions.githubusercontent.com \
  --subject repo:fiscaltec/vitally-mcp:environment:staging \
  --audiences api://AzureADTokenExchange
```

**4. Then the acceptance check:**

```bash
bash .github/scripts/verify-oauth-metadata.sh https://vitally-staging.fiscaltec.com
gh workflow run deploy.yml -f target=staging -f ref=main
```

## Two staging divergences recorded in CLAUDE.md, both deliberate

- **A staging token carries no `permissions` claim.** The post-login Action returns early for any
  audience other than production's, so entitlement on staging comes purely from
  `LiveGroupCheck` → Graph `transitiveMembers`. Harmless today (production works the same way), but
  staging has **no claim-based fallback tier** — a Graph failure denies there where production would
  degrade. Not worth widening the Action's guard: it disappears at cutover, and the divergence fails
  in the safe direction.
- **One Vitally tenant, global API keys.** Staging reads the *production* `vitally-shared` secret, so
  its write tools mutate real customer data. `Authorization:ReadOnly=true` is deliberately **not**
  set, because #108's step 5 needs the write tools visible to prove a reader is denied one. Staging is
  read-only by convention, not configuration.

## Merging this deploys

`release.yml` is enabled, so the nightly train will ship this at 02:00 UTC. That is fine here — no
application code changed, so production rolls to an identically-built image — and the metadata smoke
now gates it either way. No freeze needed.

## Follow-ups

- Unblocks #108. #107 can now be provisioned against an agreed hostname
  (`https://vitally-staging.fiscaltec.com/oauth/callback` is the staging redirect URI it needs).
- #105 and #106 remain independent and can run in parallel next — note the corrections in their issue
  *comments*, not their bodies.
