### PR TITLE
chore: enforce the Copilot review round before merge

### DIFF
--- a/.claude/hooks/pre-merge-copilot-gate.sh
+++ b/.claude/hooks/pre-merge-copilot-gate.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) hook — block `gh pr merge` on a human PR until Copilot's
+# review cycle for the current HEAD commit is complete and clean.
+#
+# Registered in .claude/settings.json with `if: "Bash(gh pr merge*)"`, so it
+# only fires on merge commands. Blocks via the PreToolUse permissionDecision
+# JSON. Fail-closed: if any check cannot be verified, deny rather than risk a
+# premature merge. Dependabot PRs are exempt (CI-gated auto-merge by design).
+set -uo pipefail
+
+# Deny the tool call with a reason (PreToolUse JSON mechanism; exit 0).
+deny() {
+	printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' \
+		"$(printf 'Copilot merge gate — %s' "$1" | jq -Rs .)"
+	exit 0
+}
+# Allow: emit nothing and exit 0 → defer to Claude Code's normal permission flow.
+allow() { exit 0; }
+
+# deny() builds its JSON with jq, so the gate would fail *open* if jq were
+# missing OR present-but-broken. Prove jq actually runs (not just that it's on
+# PATH) with a static denial fallback (printf is a shell builtin — no external
+# tool needed) so a broken toolchain can never wave a merge through.
+if ! printf '{}' | jq -e . >/dev/null 2>&1 \
+	|| ! printf 'x' | sed 's/x/y/' >/dev/null 2>&1 \
+	|| ! awk 'BEGIN { exit 0 }' >/dev/null 2>&1; then
+	printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Copilot merge gate — a required tool (jq/sed/awk) is missing or not runnable; cannot verify the gate (failing closed)"}}\n'
+	exit 0
+fi
+
+input=$(cat)
+# Fail closed if the payload can't be parsed or carries no command — we can't
+# confirm the call is safe, and the `if` filter means we only get here for merges.
+cmd=$(printf '%s' "$input" | jq -er '.tool_input.command' 2>/dev/null) \
+	|| deny "could not read the command from hook input (failing closed)"
+
+# Only gate `gh pr merge` (secondary guard; the `if` filter already scopes this).
+# Bash regex — no external grep, so a broken grep can't make this fail open.
+[[ "$cmd" =~ gh[[:space:]]+pr[[:space:]]+merge ]] || allow
+
+# The gate only reasons about the *current* repo; a cross-repo merge can't be
+# verified here, so fail closed if -R/--repo is present.
+[[ "$cmd" =~ (^|[[:space:]])(-R|--repo) ]] && deny "cross-repo merge (-R/--repo) is not supported by the gate (failing closed)"
+
+# Current repo — every check below is scoped to it.
+nwo=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) \
+	|| deny "could not resolve the current repo (failing closed)"
+owner=${nwo%%/*}; name=${nwo#*/}
+
+# Resolve the PR: first non-flag token after `merge` (number, URL, or branch —
+# all accepted by `gh pr view`), else the current branch's PR.
+# Collect positional candidates, skipping flags AND the values consumed by
+# value-taking flags (so `--subject Foo` doesn't get mistaken for the PR). One
+# candidate → that PR; none → current branch; more than one → ambiguous, deny.
+arg=$(printf '%s' "$cmd" | sed -nE 's/.*gh[[:space:]]+pr[[:space:]]+merge[[:space:]]+//p' | awk '
+	BEGIN { split("-t --subject -b --body -F --body-file --author-email --match-head-commit", f, " "); for (k in f) vf[f[k]] = 1 }
+	{
+		n = 0
+		for (i = 1; i <= NF; i++) {
+			t = $i
+			if (t ~ /^-/) { if (t !~ /=/ && (t in vf)) i++; continue }  # skip flag (and its value if it takes one)
+			cand[++n] = t
+		}
+		if (n == 1) print cand[1]
+		else if (n > 1) print "__AMBIGUOUS__"
+	}')
+if [ "$arg" = "__AMBIGUOUS__" ]; then
+	deny "ambiguous PR argument in the merge command (failing closed)"
+elif [ -n "$arg" ]; then
+	# A PR URL must point at the current repo — the checks below assume it.
+	case "$arg" in
+	*://*) [[ "$arg" == *"/$owner/$name/"* ]] || deny "PR URL targets a different repo than $nwo (failing closed)" ;;
+	esac
+	pr=$(gh pr view "$arg" --json number --jq '.number' 2>/dev/null || true)
+	[ -n "$pr" ] || deny "could not resolve a PR from '$arg' (failing closed)"
+else
+	pr=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
+	[ -n "$pr" ] || deny "no PR resolvable for the current branch to gate (failing closed)"
+fi
+
+facts=$(gh pr view "$pr" --json headRefOid,author,reviewRequests 2>/dev/null) \
+	|| deny "could not query PR #$pr (failing closed)"
+author=$(printf '%s' "$facts" | jq -r '.author.login // empty')
+head=$(printf '%s' "$facts" | jq -r '.headRefOid // empty')
+pending=$(printf '%s' "$facts" | jq -r '[.reviewRequests[].login] | index("copilot-pull-request-reviewer") != null')
+
+# Dependabot carve-out. Mind the two forms of the bot's login — the suffix tracks
+# which API answered, not which field was read. `$author` comes from `gh pr view
+# --json author`, which is GraphQL underneath and reports `app/dependabot`; REST
+# (`gh api repos/{owner}/{repo}/pulls/N`) reports `dependabot[bot]`. Matching only
+# the REST form meant this carve-out never fired, so every Dependabot PR was gated
+# as a human PR — a gate it can never pass, because Copilot doesn't review them.
+# Accept both rather than picking one, so the carve-out survives either API's
+# spelling.
+case "$author" in
+dependabot\[bot\] | app/dependabot) allow ;;
+esac
+
+# (1) Copilot must not be mid-review.
+[ "$pending" = "false" ] || deny "Copilot is still a requested reviewer on PR #$pr (review pending)"
+
+# (2) Copilot's latest review must target the current head commit.
+#     sort_by(.submitted_at) first — the REST reviews response order isn't guaranteed.
+#     `// empty` coerces the no-reviews case (null) to an empty string.
+# Exact login match — REST reports Copilot as `…[bot]` (gh pr view omits the
+# suffix; see the pending check above). `contains` would match unrelated logins.
+last=$(gh api "repos/{owner}/{repo}/pulls/$pr/reviews" \
+	--jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | sort_by(.submitted_at) | last | .commit_id // empty' 2>/dev/null) \
+	|| deny "could not read reviews for PR #$pr (failing closed)"
+[ -n "$last" ] || deny "Copilot has not reviewed PR #$pr yet"
+[ "$last" = "$head" ] || deny "Copilot's latest review ($last) is not on the current head ($head) — re-review pending on PR #$pr"
+
+# (3) Zero unresolved review threads. Fetch hasNextPage too and fail closed if a
+#     PR ever exceeds one page (100) — we can't verify the tail otherwise.
+#     owner/name were resolved up front (current repo).
+threads=$(gh api graphql -f owner="$owner" -f name="$name" -F number="$pr" \
+	-f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved} pageInfo{hasNextPage}}}}}' \
+	--jq '.data.repository.pullRequest.reviewThreads | "\([.nodes[] | select(.isResolved == false)] | length) \(.pageInfo.hasNextPage)"' 2>/dev/null) \
+	|| deny "could not read review threads for PR #$pr (failing closed)"
+unresolved=${threads% *}
+morepages=${threads#* }
+[ "$morepages" = "false" ] || deny "PR #$pr has more than 100 review threads — cannot verify the tail (failing closed)"
+[ "$unresolved" = "0" ] || deny "$unresolved unresolved review thread(s) on PR #$pr"
+
+allow

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,14 @@
           {
             "type": "command",
             "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'git push[^|;]*--force\\b[^|;]*\\b(origin\\s+)?(main|master)\\b'; then echo 'BLOCKED: Force-push to main is never allowed.'; exit 1; fi"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-merge-copilot-gate.sh\"",
+            "if": "Bash(gh pr merge*)",
+            "shell": "bash",
+            "timeout": 30,
+            "statusMessage": "Checking Copilot merge gate…"
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,88 @@ and these checks green: `Analyze (csharp)`, `Validate PR title`, `Build and test
 net10.0)`, `nuget-vuln`, `image-cve`. Read the ruleset rather than inferring from
 `mergeStateStatus`, which reports `BLOCKED` for unresolved threads and pending checks too.
 
+**That ruleset is not the whole gate.** It says nothing about Copilot, and reading "0 approvals
+required" as "nothing else to wait for" is exactly what merged #117 with three unreviewed commits —
+see the next section before merging anything.
+
+### Copilot review & merge gate
+
+Copilot reviews every PR automatically, **asynchronously**, and its reviews are always `COMMENTED` —
+never `APPROVED`. So it can never satisfy an approval-count rule, and the ruleset above is blind to
+it. Two consequences, both of which have cost real time in this repo and its siblings:
+
+- **`mergeStateStatus: CLEAN` does NOT mean Copilot has finished.** It reflects the ruleset only.
+  `searledan/rosetechnologies.co.uk` records its own version of this: PR #24 merged 15 seconds before
+  Copilot's second review posted two valid comments. Here, **#117 merged with Copilot having reviewed
+  only the first pushed commit** — the two fixes Copilot itself asked for went in unseen, while
+  `CLEAN` held the whole time because the threads had been resolved.
+- **A push does not reliably start a re-review.** The automatic request fires when the PR is
+  *opened*. After pushing review fixes you must **re-request explicitly**, or you will wait for a
+  review that is never coming and read the silence as approval.
+
+**The merge sequence — a loop, not a one-shot:**
+
+1. Open the PR; let the checks and the first Copilot pass run.
+2. Each round:
+   1. **Wait for Copilot to finish reviewing the _current head_.** Done only when it is **not** in
+      requested reviewers **AND** its latest review's `commit_id` **equals the head SHA**. A stale
+      review of an earlier commit does not count, and timestamps cannot be lined up against the head
+      commit — compare the SHA.
+      ```bash
+      n=<PR>; head=$(gh pr view "$n" --json headRefOid --jq .headRefOid)
+      gh pr view "$n" --json reviewRequests \
+        --jq '[.reviewRequests[].login] | index("copilot-pull-request-reviewer") != null'   # false = not pending
+      gh api "repos/fiscaltec/vitally-mcp/pulls/$n/reviews" \
+        --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | sort_by(.submitted_at) | last | .commit_id'
+      ```
+      ⚠️ **"Not pending" alone is meaningless.** Copilot dequeues itself the moment it accepts a
+      request, so `reviewRequests` is empty within seconds of asking — long before it has reviewed
+      anything. Both conditions, always.
+   2. A clean pass says *"reviewed N of N files … generated no new comments"* and adds no threads.
+   3. Work every open thread: fix and reply, or reply with the reasoning — then **resolve** it.
+   4. **If you pushed code in (3), re-request and go back to (1):**
+      ```bash
+      gh api repos/fiscaltec/vitally-mcp/pulls/$n/requested_reviewers \
+        -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+      ```
+      **`gh pr edit --add-reviewer` silently no-ops on the Copilot bot** — use the REST endpoint.
+      `requested_reviewers` reading empty seconds later is **not** failure (see the warning above);
+      check the timeline (`.event == "review_requested"`) if in doubt. Reply-only rounds need no
+      re-request.
+3. Only then merge (squash), re-checking all three immediately beforehand: required checks green and
+   branch current, Copilot's latest review on the current head, zero unresolved threads.
+
+**Mind the two spellings of the bot's login — both are correct, don't "align" them.** The suffix
+tracks *which API answered*, not which field you read. **REST** (`gh api …/pulls/N/reviews`,
+`…/requested_reviewers`) uses `copilot-pull-request-reviewer[bot]`; **GraphQL** — and
+`gh pr view --json`, which is GraphQL underneath — reports `copilot-pull-request-reviewer` without it.
+
+⚠️ **Never `--auto` merge a human PR.** It fires the instant CI passes and beats a pending review.
+`--auto` is for Dependabot only, which carries no human review.
+
+**This is enforced mechanically, not just documented.** `.claude/hooks/pre-merge-copilot-gate.sh` is a
+`PreToolUse` hook (registered in `.claude/settings.json` under the `Bash` matcher with
+`if: "Bash(gh pr merge*)"`) that **denies** `gh pr merge` unless Copilot is not a requested reviewer,
+its latest review's `commit_id` equals the head, and unresolved threads are zero. It exempts
+Dependabot and **fails closed** — including if `jq`/`sed`/`awk` are missing or broken, so a damaged
+toolchain cannot wave a merge through. Ported from `searledan/dansearle.co.uk`; it needs no
+adaptation, resolving owner/repo at runtime.
+
+Caveats worth knowing before trusting it:
+
+- It guards **only Claude Code's own tool calls** — a merge from the GitHub UI is unaffected.
+- A newly added hook needs `/hooks` opened once (or a restart) to activate.
+- **Run `gh pr merge` as a standalone command — no pipes, no `;`, no `&&`.** The hook resolves the PR
+  by counting non-flag positional tokens after the subcommand, so a chained form turns every
+  following word into a candidate and the gate denies as ambiguous.
+- The `if` filter matches the command text, so *any* Bash call containing `gh pr merge` is gated —
+  including a test harness. Testing the hook means invoking it from a script file rather than inline.
+  Over-matching is the safe direction; don't loosen it.
+
+Verified on porting (2026-08-28) by running the hook against real PRs: it allows #118, whose Copilot
+review was on the merged head, and **denies #117** — *"Copilot's latest review (6808805…) is not on
+the current head (58afb2b…)"* — which is the mistake that prompted the port.
+
 **Forms** — `.github/ISSUE_TEMPLATE/` provides seven, one per type label except `ux`: `bug.yml`,
 `feature.yml`, `tech-debt.yml`, `security.yml`, `ops.yml`, `documentation.yml`, `content.yml`.
 Filenames match the label they preset, and the shared four match the sibling repos. Each form


### PR DESCRIPTION
Closes #119

Nothing in this repo stopped a PR merging while a Copilot review round was outstanding — and earlier
today that happened. **#117 merged with three commits Copilot had never seen**, two of them the fixes
Copilot itself had asked for. `mergeStateStatus` read `CLEAN` the whole time, correctly: it reflects
the ruleset, and the ruleset says nothing about Copilot.

The sibling repos already solved this after the same mistake. This ports it.

## What's here

| Change | Detail |
|---|---|
| `.claude/hooks/pre-merge-copilot-gate.sh` | Copied **verbatim** from `searledan/dansearle.co.uk` — no adaptation needed, it resolves owner/repo at runtime. Denies `gh pr merge` unless Copilot is not a requested reviewer, its latest review's `commit_id` equals the head, and unresolved threads are zero. Exempts Dependabot; **fails closed**, including if `jq`/`sed`/`awk` are missing or broken |
| `.claude/settings.json` | Registered in the existing `Bash` matcher with `if: "Bash(gh pr merge*)"`, so it fires only on merges |
| `CLAUDE.md` | New *Copilot review & merge gate* section, plus a pointer on the existing gate paragraph saying the ruleset is not the whole gate |

Dansearle's version was taken over rose's: rose still says Copilot re-reviews "after every push", which
dansearle explicitly walks back as never tested.

## The two traps the docs now carry

- **`CLEAN` ≠ Copilot done.** Rose records its own instance — PR #24 merged 15 seconds before
  Copilot's second review posted two valid comments.
- **A push does not reliably start a re-review.** The automatic request fires on *open*. After pushing
  review fixes you must re-request explicitly, via REST — `gh pr edit --add-reviewer` **silently
  no-ops** on the Copilot bot.

And the one that nearly caught me again on #118: **"not a requested reviewer" alone means nothing.**
Copilot dequeues itself the instant it accepts, so `reviewRequests` is empty within seconds of asking,
long before it has reviewed anything. The done-condition needs both that *and* the review's
`commit_id` matching the head.

## Verified, not assumed

Ran the hook against real PRs in this repo:

```
ok   ALLOW  a non-merge command is not gated
ok   ALLOW  #118: Copilot reviewed the merged head
ok   DENY   #117: Copilot only reviewed an earlier commit
            Copilot's latest review (6808805…) is not on the current head (58afb2b…) — re-review pending on PR #117
ok   DENY   cross-repo merge is refused
ok   DENY   unresolvable PR argument
```

**It denies #117** — the exact mistake that prompted this — and allows #118, whose review was on the
merged head. That's the whole case for the change.

It also demonstrated itself unprompted: my first attempt to test it inline was denied, because the `if`
filter matches command *text*, so any Bash call containing `gh pr merge` is gated — a test harness
included. Over-matching is the safe direction; testing goes through a script file instead. Documented.

## Rejected alternative

Making Copilot a required reviewer in the ruleset. Its reviews are always `COMMENTED`, never
`APPROVED` (2/2 observed here), so an approval-count gate can never be satisfied by it and would block
every PR until a human approved. `required_reviewers` is the only ruleset-level option and still
wouldn't enforce *re*-review of a new head — which is the actual failure mode. The hook compares the
head commit, so it does.

## Caveats, all documented

- Guards **only Claude Code's own tool calls** — a merge from the GitHub UI is unaffected.
- A newly added hook needs `/hooks` opened once (or a restart) to activate. It was already live in this
  session, which is how it denied my test.
- `gh pr merge` must be run as a standalone command — the hook resolves the PR by counting non-flag
  positional tokens, so chaining makes it deny as ambiguous.
