### PR TITLE
refactor: validate the RFC 8707 resource parameter in the OAuth proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,6 +374,13 @@ trailing-slash form, so the two forms have to name one resource. Nothing else is
 neither `Resource` nor `Audience` configured — only possible under `NoAuth` — there is nothing to
 compare against and every value is accepted.
 
+**A malformed identifier fails at boot**, not at the first sign-in. `OAuth:Resource` (or `Audience`
+standing in for it) must be an absolute URI with no fragment or `OAuthOptions.Validate()` throws —
+because it is no longer only *published*: an unparseable value would refuse every request carrying
+`resource`, an authentication outage discovered at sign-in time. An Entra-style client-ID GUID is a
+perfectly good `aud` but not a resource identifier, and lands here whenever `Resource` is left unset;
+set `Resource` to the server origin in that case.
+
 **It is still forwarded, deliberately.** Dropping or substituting it is the Auth0-breaking half of
 #105 and moved to the cutover (#108): with Auth0 live, removing the parameter removes the audience
 binding and `aud` stops matching `OAuth:Audience` for **every** user. So the tenant still needs the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This is a Model Context Protocol (MCP) server implementation in C# that provides
 - Full CRUD API access to Vitally resources (accounts, organisations, users, conversations, notes, projects, tasks, admins, NPS responses, project templates, project categories, messages, custom objects, meetings — including participants and transcripts — custom traits, custom surveys)
 - Permission management via `ReadOnly` and `Destructive` flags on every tool, for MCP clients to enforce per-category permissions
 - **Streamable HTTP transport** (MCP 2026-07-28) on the `ModelContextProtocol.AspNetCore` package, stateless mode
-- **Auth0 OAuth 2.1 protection** via JwtBearer on `/mcp`; publishes RFC 9728 protected-resource metadata at `/.well-known/oauth-protected-resource`. An in-process OAuth proxy fronts the upstream Auth0 tenant when `OAuth:SharedClientId` is set — it implements an RFC 7591 DCR shim so every MCP client converges on one pre-registered first-party app (skipping the per-session consent screen and accepting any RFC 8252 loopback port). Non-loopback `redirect_uri` values must be in `OAuth:AllowedClientRedirectUris`. **Auth0 tenant must have "Resource Parameter Compatibility Profile" enabled** (Settings → Advanced) so the `resource` parameter from MCP clients is consumed locally and not forwarded to upstream IdPs (avoids AADSTS9010010 with the Entra federation hop).
+- **Auth0 OAuth 2.1 protection** via JwtBearer on `/mcp`; publishes RFC 9728 protected-resource metadata at `/.well-known/oauth-protected-resource`. An in-process OAuth proxy fronts the upstream Auth0 tenant when `OAuth:SharedClientId` is set — it implements an RFC 7591 DCR shim so every MCP client converges on one pre-registered first-party app (skipping the per-session consent screen and accepting any RFC 8252 loopback port). Non-loopback `redirect_uri` values must be in `OAuth:AllowedClientRedirectUris`. **Auth0 tenant must have "Resource Parameter Compatibility Profile" enabled** (Settings → Advanced) so the `resource` parameter from MCP clients is consumed locally and not forwarded to upstream IdPs (avoids AADSTS9010010 with the Entra federation hop). Still required: the proxy *validates* `resource` (#105) but deliberately keeps forwarding it, because on Auth0 it is the only thing binding the token audience — see the `resource` section under Architecture.
 - **On-demand Vitally API key fetch**: the server fetches the `vitally-shared` secret from Azure Key Vault via its user-assigned managed identity (with a short in-memory cache) and uses it to call Vitally on behalf of all authenticated users. Future per-user keys can be added by reintroducing claim-based secret resolution.
 - .NET 10 ASP.NET Core, framework-dependent — runs in any .NET 10 container
 - Built on the official `ModelContextProtocol` C# SDK 2.2.0 + `ModelContextProtocol.AspNetCore` 2.2.0
@@ -282,9 +282,9 @@ The server uses ASP.NET Core 10 with `WebApplication.CreateBuilder` + `Microsoft
 - OAuth proxy endpoints (only active when `OAuth:SharedClientId` is set):
   - `GET /.well-known/oauth-protected-resource` — RFC 9728 metadata, serialised with `McpJsonUtilities.DefaultOptions`. That is load-bearing, not incidental: the ASP.NET Core defaults write every unset optional as an explicit `null`, and RFC 9728 §3.2 requires an unused parameter to be *omitted* — strict clients reject the whole document over the difference.
   - `GET /.well-known/oauth-authorization-server` — RFC 8414 metadata declaring **our own origin** as `issuer` (see the façade section below), pointing `authorization_endpoint` / `token_endpoint` / `registration_endpoint` at our own proxy endpoints, and advertising `authorization_response_iss_parameter_supported: true`. `userinfo_endpoint` and `jwks_uri` still point upstream — **read from the provider's discovery document**, not concatenated onto `Authority`.
-  - `GET /oauth/authorize` — validates the client `redirect_uri` against `OAuth:AllowedClientRedirectUris` (plus implicit loopback exemption), stashes it keyed by `state`, and proxies to the **discovered** upstream `authorization_endpoint` with our own fixed callback.
+  - `GET /oauth/authorize` — validates the client `redirect_uri` against `OAuth:AllowedClientRedirectUris` (plus implicit loopback exemption), validates any RFC 8707 `resource` against the identifier we publish (rejecting a mismatch with `invalid_target`; see the `resource` section below), stashes it keyed by `state`, and proxies to the **discovered** upstream `authorization_endpoint` with our own fixed callback.
   - `GET /oauth/callback` — reverses the stash, **replaces any upstream `iss` with our own origin**, and redirects to the original client URI.
-  - `POST /oauth/token` — proxies code/refresh exchanges to the **discovered** upstream `token_endpoint`, server-side-injecting `SharedClientSecret`.
+  - `POST /oauth/token` — proxies code/refresh exchanges to the **discovered** upstream `token_endpoint`, server-side-injecting `SharedClientSecret`. Applies the same `resource` validation to the form body.
   - `POST /oauth/register` — RFC 7591 DCR shim returning `SharedClientId` plus filtered `redirect_uris`.
 - `MapMcp("/mcp").RequireAuthorization()` — auth requirement is dropped when `NoAuth=true`.
 - The 401 challenge on `/mcp` carries a single `WWW-Authenticate` value pointing at the protected-resource metadata document (`resource_metadata="{PublicBaseUrl}/.well-known/oauth-protected-resource/mcp"`), adding `error="invalid_token"` when a token was presented and failed validation. The metadata document is served from both `/.well-known/oauth-protected-resource` and the `/mcp`-suffixed path (`ProtectedResourceMetadataBuilder.MetadataPath`). The status stays exactly 401 — `.github/workflows/deploy.yml` smoke-tests that and rolls back if it changes, so don't alter it. That smoke **also** pins the RFC 8414/9728 documents (`.github/scripts/verify-oauth-metadata.sh`): the `issuer`, its byte-for-byte equality with `authorization_servers`, the advertised `iss` flag, the façade endpoints naming our origin, `jwks_uri`/`userinfo_endpoint` being absolute https without a fragment, and no null-serialised optionals. Those are deploy-gating contracts now, not only test-suite ones.
@@ -349,6 +349,37 @@ against a local container is now a working end-to-end client, which is the pract
   `https://vitally-staging.fiscaltec.com`, whose hostname is stable and whose Resource Server already
   matches it. Reach for a tunnel only for something staging genuinely cannot cover, and budget for the
   cleanup if you do.
+
+### The RFC 8707 `resource` parameter is validated here — and still relayed upstream
+
+`OAuthOptions.IsResourceIndicatorAllowed(value)` is the single check, reading
+`PublishedResourceIdentifier` (`OAuth:Resource`, falling back to `OAuth:Audience`) — the same
+property `ProtectedResourceMetadataBuilder` publishes, so the value validated against is by
+construction the value clients were told to send. `/oauth/authorize` (query) and `/oauth/token`
+(form body) both apply it and reject a mismatch with `invalid_target`; every value is checked when
+the parameter repeats, and a present-but-empty one is a mismatch rather than an absence. An absent
+`resource` is untouched — RFC 8707 is optional for clients.
+
+**Why it is a real control and not paperwork.** `resource` is what binds the audience of the token
+that comes back: `Program.cs` sends **no `audience` parameter anywhere**, and the Auth0 tenant's
+*Resource Parameter Compatibility Profile* consumes `resource` locally to that end. Until #105 it
+was relayed unvalidated, so a client could ask to be bound to an audience this server never
+published and the proxy would pass the request on.
+
+**Comparison rules** — component-wise per RFC 3986 §6.2.2, not one string compare. Scheme and host
+case-insensitive; port, path and query exact; a fragment rejected outright (RFC 8707 §2); a single
+trailing slash tolerated on either side. That last one is load-bearing: Entra refuses to register an
+`identifierUris` value ending in a slash, while Claude Code normalises a bare-host resource *to* the
+trailing-slash form, so the two forms have to name one resource. Nothing else is normalised. With
+neither `Resource` nor `Audience` configured — only possible under `NoAuth` — there is nothing to
+compare against and every value is accepted.
+
+**It is still forwarded, deliberately.** Dropping or substituting it is the Auth0-breaking half of
+#105 and moved to the cutover (#108): with Auth0 live, removing the parameter removes the audience
+binding and `aud` stops matching `OAuth:Audience` for **every** user. So the tenant still needs the
+compatibility profile enabled, and terminating `resource` at the façade — where Entra's exact-match
+rule against a non-slashed `identifierUris` starts to matter — happens only once `OAuth:Authority`
+points at Entra.
 
 ### Upstream endpoints come from OIDC discovery, not from `Authority`
 
@@ -426,7 +457,7 @@ Two details of that fallback are easy to get wrong and are pinned by tests:
 `OAuthOptions` (singleton, bound from `OAuth:` section):
 - `Authority` — the provider's OIDC **issuer** identifier, e.g. `https://fiscal-it.uk.auth0.com/` (Auth0) or `https://login.microsoftonline.com/{tenant-id}/v2.0` (Entra). It is *not* a prefix the endpoint URLs are built from: `{Authority}/.well-known/openid-configuration` is fetched and the endpoints come from that document. The trailing slash is whatever the provider's own issuer carries — Auth0's has one, Entra's does not.
 - `Audience` — the Auth0 Resource Server / API identifier, e.g. `https://vitally.fiscaltec.com/` — **with the trailing slash**, because Auth0 identifiers are exact-match and production's carries one (verified against the live tenant, 2026-08-22). Validated against the JWT `aud` claim.
-- `Resource` — canonical resource identifier published in `/.well-known/oauth-protected-resource` (falls back to `Audience` if empty). Set explicitly when MCP clients validate metadata `resource` against the server URL/origin (RFC 8707 + RFC 9728 compliance) — the published client rejects the whole document on a mismatch, so this tracks `Audience` and carries the same trailing slash. `PublicBaseUrl` is the odd one out: it is an origin, so no trailing slash (and `Validate()` trims one anyway).
+- `Resource` — canonical resource identifier published in `/.well-known/oauth-protected-resource` (falls back to `Audience` if empty). Set explicitly when MCP clients validate metadata `resource` against the server URL/origin (RFC 8707 + RFC 9728 compliance) — the published client rejects the whole document on a mismatch, so this tracks `Audience` and carries the same trailing slash. Second role: `PublishedResourceIdentifier` (this value, falling back to `Audience`) is what an incoming RFC 8707 `resource` parameter is validated *against* on `/oauth/authorize` and `/oauth/token` — so it is now a control on what audience a caller may ask to be bound to, not only a value published. `PublicBaseUrl` is the odd one out: it is an origin, so no trailing slash (and `Validate()` trims one anyway).
 - `SharedClientId` — pre-registered Auth0 native-app client_id that every MCP client converges on via the DCR shim. When set, the OAuth proxy endpoints become active.
 - `SharedClientSecret` — confidential-client secret for `SharedClientId`, injected server-side at `/oauth/token`.
 - `AllowedClientRedirectUris` — non-loopback `redirect_uri` allowlist for the OAuth proxy. Loopback URIs (`localhost`, `127.0.0.1`, `[::1]`) on any port are always allowed per RFC 8252 §7.3; this list covers hosted MCP clients like `https://claude.ai/api/mcp/auth_callback`. `OAuthOptions.IsRedirectUriAllowed(uri)` is the single check; `/oauth/authorize` and `/oauth/register` both use it. **This is the only thing standing between the proxy and an open redirector with authorisation-code theft — never bypass it.**
@@ -725,7 +756,7 @@ than deploying somewhere unintended.
 | Identity | User-assigned managed identity | `AcrPull` on the registry + `Key Vault Secrets User` on the vault |
 | Image registry | Azure Container Registry (Premium SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
 | Logs | Log Analytics (attached to the CAE) | + Application Insights for traces |
-| Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Two Resource Servers, one per origin: `https://vitally.fiscaltec.com/` and `https://vitally-staging.fiscaltec.com/` (trailing slash — identifiers are exact-match and immutable). **One** shared client (`Vitally MCP`) carrying both origins' `/oauth/callback`, so both targets use the same `SharedClientId` / `SharedClientSecret`. Post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation |
+| Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Two Resource Servers, one per origin: `https://vitally.fiscaltec.com/` and `https://vitally-staging.fiscaltec.com/` (trailing slash — identifiers are exact-match and immutable). **One** shared client (`Vitally MCP`) carrying both origins' `/oauth/callback`, so both targets use the same `SharedClientId` / `SharedClientSecret`. Post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation — and still needs it, since the proxy validates but does not terminate `resource` until the cutover |
 | CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback — the smoke covers `/health`, the exact-401 challenge **and** the OAuth metadata documents); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it — freeze by disabling the workflow, see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
 | IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,15 @@ it. Two consequences, both of which have cost real time in this repo and its sib
       gh api "repos/fiscaltec/vitally-mcp/pulls/$n/reviews" \
         --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | sort_by(.submitted_at) | last | .commit_id'
       ```
+
+      ⚠️ **Take the head SHA from `git rev-parse HEAD`, not from `gh pr view --json headRefOid`,
+      in the seconds after a push.** The GraphQL field lags: on #122 it still reported the previous
+      commit right after a push, so the comparison matched Copilot's *old* review and the gate read
+      as passing. Two consequences, and the second is the expensive one: re-requesting in that
+      window gets a review of the previous commit (that happened on #122 too — a review arrived four
+      minutes after the request, on the superseded SHA), so **wait until the API reports the new head
+      before re-requesting**, then compare against `git rev-parse`.
+
       ⚠️ **"Not pending" alone is meaningless.** Copilot dequeues itself the moment it accepts a
       request, so `reviewRequests` is empty within seconds of asking — long before it has reviewed
       anything. Both conditions, always.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,11 +375,17 @@ neither `Resource` nor `Audience` configured — only possible under `NoAuth` �
 compare against and every value is accepted.
 
 **A malformed identifier fails at boot**, not at the first sign-in. `OAuth:Resource` (or `Audience`
-standing in for it) must be an absolute URI with no fragment or `OAuthOptions.Validate()` throws —
-because it is no longer only *published*: an unparseable value would refuse every request carrying
+standing in for it) must be an absolute **http(s)** URI with no fragment or `OAuthOptions.Validate()`
+throws — because it is no longer only *published*: an unparseable value would refuse every request carrying
 `resource`, an authentication outage discovered at sign-in time. An Entra-style client-ID GUID is a
 perfectly good `aud` but not a resource identifier, and lands here whenever `Resource` is left unset;
 set `Resource` to the server origin in that case.
+
+The **scheme** is checked, not merely absoluteness, and that is not fussiness:
+`Uri.TryCreate("/mcp", UriKind.Absolute)` *succeeds* on Unix — as `file:///mcp` — and fails on
+Windows. An absoluteness-only check therefore passes locally and is inert on the Linux containers
+this runs on; CI on `ubuntu-latest` caught exactly that in #122. `http` is allowed alongside `https`
+so loopback development still works.
 
 **It is still forwarded, deliberately.** Dropping or substituting it is the Auth0-breaking half of
 #105 and moved to the cutover (#108): with Auth0 live, removing the parameter removes the audience

--- a/VitallyMcp.Tests/OAuthOptionsTests.cs
+++ b/VitallyMcp.Tests/OAuthOptionsTests.cs
@@ -229,6 +229,7 @@ public class OAuthOptionsTests
     [InlineData("https://vitally.fiscaltec.com/", "https://vitally.fiscaltec.com")]   // client dropped the slash
     [InlineData("https://vitally.fiscaltec.com", "https://vitally.fiscaltec.com/")]   // client added one
     [InlineData("https://vitally.fiscaltec.com/mcp", "https://vitally.fiscaltec.com/mcp")]
+    [InlineData("https://vitally.fiscaltec.com/mcp", "https://vitally.fiscaltec.com/mcp/")]  // exactly one slash
     [InlineData("https://VITALLY.fiscaltec.com/", "https://vitally.fiscaltec.com/")]  // host is case-insensitive
     [InlineData("https://vitally.fiscaltec.com/", "HTTPS://vitally.fiscaltec.com/")]  // so is scheme
     public void IsResourceIndicatorAllowed_MatchesThePublishedIdentifier(string published, string requested)
@@ -246,6 +247,7 @@ public class OAuthOptionsTests
     [InlineData("https://evil.example.com/")]
     [InlineData("https://vitally.fiscaltec.com.evil.com/")]     // suffix spoof
     [InlineData("https://vitally.fiscaltec.com/mcp/other")]
+    [InlineData("https://vitally.fiscaltec.com/mcp//")]        // two slashes is a different path, not the same name
     [InlineData("https://vitally.fiscaltec.com:8443/mcp")]      // different port
     [InlineData("http://vitally.fiscaltec.com/mcp")]            // different scheme
     [InlineData("https://vitally.fiscaltec.com/MCP")]           // path is case-sensitive (RFC 3986 6.2.2.1)

--- a/VitallyMcp.Tests/OAuthOptionsTests.cs
+++ b/VitallyMcp.Tests/OAuthOptionsTests.cs
@@ -223,6 +223,80 @@ public class OAuthOptionsTests
             .Which.Should().Be("https://claude.ai/api/mcp/auth_callback");
     }
 
+
+    [Theory]
+    [InlineData("https://vitally.fiscaltec.com/", "https://vitally.fiscaltec.com/")]  // exact
+    [InlineData("https://vitally.fiscaltec.com/", "https://vitally.fiscaltec.com")]   // client dropped the slash
+    [InlineData("https://vitally.fiscaltec.com", "https://vitally.fiscaltec.com/")]   // client added one
+    [InlineData("https://vitally.fiscaltec.com/mcp", "https://vitally.fiscaltec.com/mcp")]
+    [InlineData("https://VITALLY.fiscaltec.com/", "https://vitally.fiscaltec.com/")]  // host is case-insensitive
+    [InlineData("https://vitally.fiscaltec.com/", "HTTPS://vitally.fiscaltec.com/")]  // so is scheme
+    public void IsResourceIndicatorAllowed_MatchesThePublishedIdentifier(string published, string requested)
+    {
+        // Trailing-slash tolerance is not cosmetic: Entra refuses to register an identifierUri
+        // that ends in a slash, while Claude Code normalises a bare-host resource to the
+        // trailing-slash form. Both forms name the same resource and both must be accepted.
+        var options = ValidOptions([]);
+        options.Resource = published;
+
+        options.IsResourceIndicatorAllowed(requested).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("https://evil.example.com/")]
+    [InlineData("https://vitally.fiscaltec.com.evil.com/")]     // suffix spoof
+    [InlineData("https://vitally.fiscaltec.com/mcp/other")]
+    [InlineData("https://vitally.fiscaltec.com:8443/mcp")]      // different port
+    [InlineData("http://vitally.fiscaltec.com/mcp")]            // different scheme
+    [InlineData("https://vitally.fiscaltec.com/MCP")]           // path is case-sensitive (RFC 3986 6.2.2.1)
+    [InlineData("not-a-uri")]
+    [InlineData("")]                                            // present but empty binds nothing
+    [InlineData("   ")]
+    public void IsResourceIndicatorAllowed_RejectsAnythingElse(string requested)
+    {
+        // `resource` is an audience-binding control (RFC 8707). Accepting a value we do not
+        // publish would hand the caller a token bound to an audience we never vouched for.
+        var options = ValidOptions([]);
+        options.Resource = "https://vitally.fiscaltec.com/mcp";
+
+        options.IsResourceIndicatorAllowed(requested).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsResourceIndicatorAllowed_RejectsAFragment()
+    {
+        // RFC 8707 section 2 forbids a fragment on a resource indicator outright.
+        var options = ValidOptions([]);
+        options.Resource = "https://vitally.fiscaltec.com/";
+
+        options.IsResourceIndicatorAllowed("https://vitally.fiscaltec.com/#frag").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsResourceIndicatorAllowed_FallsBackToAudienceWhenResourceIsUnset()
+    {
+        // The same fallback ProtectedResourceMetadataBuilder publishes, so the value validated
+        // against is always the value clients were told to send.
+        var options = ValidOptions([]);
+        options.Resource = string.Empty;
+        options.Audience = "https://api.example.com/";
+
+        options.IsResourceIndicatorAllowed("https://api.example.com").Should().BeTrue();
+        options.IsResourceIndicatorAllowed("https://elsewhere.example.com").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsResourceIndicatorAllowed_AcceptsAnythingWhenNoIdentifierIsConfigured()
+    {
+        // Reachable only in a NoAuth dev configuration: Validate() requires Audience whenever
+        // NoAuth is false, so production always has something to compare against. With nothing
+        // published there is no audience binding to protect, and rejecting every value would
+        // break the local proxy for no gain.
+        var options = new OAuthOptions();
+
+        options.IsResourceIndicatorAllowed("https://anything.example.com/").Should().BeTrue();
+    }
+
     private static OAuthOptions ValidOptions(string[] allowedRedirectUris)
     {
         var options = new OAuthOptions

--- a/VitallyMcp.Tests/OAuthOptionsTests.cs
+++ b/VitallyMcp.Tests/OAuthOptionsTests.cs
@@ -214,6 +214,44 @@ public class OAuthOptionsTests
             .WithMessage("*https*");
     }
 
+    [Theory]
+    [InlineData("vitally.fiscaltec.com")]                 // no scheme
+    [InlineData("/mcp")]                                  // relative
+    [InlineData("https://vitally.fiscaltec.com/#frag")]    // fragment — RFC 8707 §2 forbids it
+    public void Validate_MalformedResource_Throws(string resource)
+    {
+        // PublishedResourceIdentifier is no longer only published: it is what an incoming RFC 8707
+        // `resource` is validated against, so a value that cannot be parsed rejects *every* request
+        // carrying the parameter. That has to surface at boot, not at the first sign-in.
+        var options = new OAuthOptions
+        {
+            Authority = "https://example.auth0.com/",
+            Audience = "https://api.example.com",
+            Resource = resource
+        };
+
+        var act = () => options.Validate();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*OAuth:Resource*");
+    }
+
+    [Fact]
+    public void Validate_MalformedAudienceStandingInForTheResource_Throws()
+    {
+        // With Resource unset, Audience is what gets published and validated against — so the same
+        // check has to reach it. An Entra-style client-ID GUID would land here: it is a fine
+        // `aud` value but not a resource identifier, and it must not be published as one.
+        var options = new OAuthOptions
+        {
+            Authority = "https://example.auth0.com/",
+            Audience = "11111111-2222-3333-4444-555555555555"
+        };
+
+        var act = () => options.Validate();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*OAuth:Resource*");
+    }
+
     [Fact]
     public void Validate_NormalisesTrailingSlashes()
     {

--- a/VitallyMcp.Tests/OAuthOptionsTests.cs
+++ b/VitallyMcp.Tests/OAuthOptionsTests.cs
@@ -216,13 +216,20 @@ public class OAuthOptionsTests
 
     [Theory]
     [InlineData("vitally.fiscaltec.com")]                 // no scheme
-    [InlineData("/mcp")]                                  // relative
+    [InlineData("/mcp")]                                  // relative — and `file:///mcp` on Linux, see below
+    [InlineData("file:///etc/passwd")]                    // absolute, wrong scheme
+    [InlineData("urn:example:vitally")]                   // absolute, but not an http resource
     [InlineData("https://vitally.fiscaltec.com/#frag")]    // fragment — RFC 8707 §2 forbids it
     public void Validate_MalformedResource_Throws(string resource)
     {
         // PublishedResourceIdentifier is no longer only published: it is what an incoming RFC 8707
         // `resource` is validated against, so a value that cannot be parsed rejects *every* request
         // carrying the parameter. That has to surface at boot, not at the first sign-in.
+        //
+        // The scheme is checked, not merely absoluteness, because `Uri.TryCreate("/mcp", Absolute)`
+        // *succeeds* on Unix — as `file:///mcp` — and fails on Windows. CI on ubuntu caught exactly
+        // that after this passed locally, and production runs Linux containers, so an absoluteness
+        // check alone would have been inert where it matters most.
         var options = new OAuthOptions
         {
             Authority = "https://example.auth0.com/",

--- a/VitallyMcp.Tests/OAuthProxyEndpointsTests.cs
+++ b/VitallyMcp.Tests/OAuthProxyEndpointsTests.cs
@@ -118,6 +118,75 @@ public class OAuthProxyEndpointsTests : IClassFixture<OAuthProxyEndpointsTests.F
         doc.RootElement.GetProperty("registration_endpoint").GetString().Should().Be("http://localhost/oauth/register");
     }
 
+    [Theory]
+    [InlineData("https://vitally.example.com")]
+    [InlineData("https://vitally.example.com/")]
+    public async Task Authorize_ForwardsAMatchingResourceUnchanged(string resource)
+    {
+        // `resource` still goes upstream: while Auth0 is the authority, the tenant's Resource
+        // Parameter Compatibility Profile consumes it locally and it is the only thing binding
+        // the issued token's audience (Program.cs sends no `audience` parameter anywhere).
+        // Terminating it here is #108's job, once Authority points at Entra.
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=res-ok"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback")
+            + "&resource=" + Uri.EscapeDataString(resource));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        var forwarded = QueryHelpers.ParseQuery(response.Headers.Location!.Query);
+        forwarded["resource"].ToString().Should().Be(resource,
+            "the value must reach the upstream provider exactly as the client sent it");
+    }
+
+    [Theory]
+    [InlineData("https://evil.example.com/")]
+    [InlineData("https://vitally.example.com.evil.com/")]
+    [InlineData("https://vitally.example.com/other")]
+    [InlineData("")]
+    public async Task Authorize_RejectsAResourceWeDoNotPublish(string resource)
+    {
+        // RFC 8707 `resource` is an audience-binding control, and it arrived unvalidated: the
+        // proxy forwarded the client's query string verbatim. Accepting a value we never
+        // published in our RFC 9728 document would let a client obtain a token bound to an
+        // audience this server does not vouch for.
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=res-bad"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback")
+            + "&resource=" + Uri.EscapeDataString(resource));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("invalid_target");
+    }
+
+    [Fact]
+    public async Task Authorize_WithoutAResourceIsUnaffected()
+    {
+        // RFC 8707 is optional for clients. Validation must not turn an absent parameter into
+        // a failure, and must not invent one on the way upstream.
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=res-absent"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        QueryHelpers.ParseQuery(response.Headers.Location!.Query)
+            .Should().NotContainKey("resource");
+    }
+
     [Fact]
     public async Task Register_RejectsWhenAllRedirectUrisDisallowed()
     {

--- a/VitallyMcp.Tests/OAuthProxyEndpointsTests.cs
+++ b/VitallyMcp.Tests/OAuthProxyEndpointsTests.cs
@@ -188,6 +188,27 @@ public class OAuthProxyEndpointsTests : IClassFixture<OAuthProxyEndpointsTests.F
     }
 
     [Fact]
+    public async Task Authorize_RejectsWhenOnlyOneOfSeveralResourcesMatches()
+    {
+        // RFC 8707 lets `resource` repeat. Checking only the first value would let a caller pair a
+        // matching indicator with one we never published and have both relayed, which is the very
+        // thing this validation exists to stop.
+        using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=res-repeated"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback")
+            + "&resource=" + Uri.EscapeDataString("https://vitally.example.com/")
+            + "&resource=" + Uri.EscapeDataString("https://evil.example.com/"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("invalid_target");
+    }
+
+    [Fact]
     public async Task Register_RejectsWhenAllRedirectUrisDisallowed()
     {
         using var client = _factory.CreateClient();

--- a/VitallyMcp.Tests/OAuthTokenProxyForwardTests.cs
+++ b/VitallyMcp.Tests/OAuthTokenProxyForwardTests.cs
@@ -73,6 +73,52 @@ public class OAuthTokenProxyForwardTests : IClassFixture<OAuthTokenProxyForwardT
         body.Should().NotContain(Uri.EscapeDataString("http://localhost:54321/callback"));
     }
 
+    [Fact]
+    public async Task Token_ForwardsAMatchingResourceUnchanged()
+    {
+        // Same reasoning as /oauth/authorize: validated here, still relayed, because Auth0's
+        // compatibility profile consumes it and nothing else binds the token's audience.
+        using var client = _factory.CreateClient();
+
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = "test-code",
+            ["redirect_uri"] = "http://localhost:54321/callback",
+            ["resource"] = "https://vitally.example.com/"
+        });
+        var response = await client.PostAsync("/oauth/token", form);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        _factory.Upstream.RequestBodies.Last()
+            .Should().Contain("resource=" + Uri.EscapeDataString("https://vitally.example.com/"));
+    }
+
+    [Theory]
+    [InlineData("authorization_code")]
+    [InlineData("refresh_token")]
+    public async Task Token_RejectsAResourceWeDoNotPublish(string grantType)
+    {
+        // The token endpoint forwarded `resource` unvalidated too, and a refresh exchange can
+        // carry one just as a code exchange can — so both grants need the same check.
+        using var client = _factory.CreateClient();
+
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = grantType,
+            ["code"] = "test-code",
+            ["refresh_token"] = "test-refresh",
+            ["resource"] = "https://evil.example.com/"
+        });
+        var response = await client.PostAsync("/oauth/token", form);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("invalid_target");
+        // Order-independent because the fixture is shared: no request the proxy has ever made
+        // may carry the rejected value. The guard has to return before the upstream call.
+        _factory.Upstream.RequestBodies.Should().NotContain(b => b.Contains("evil.example.com"));
+    }
+
     public class Factory : WebApplicationFactory<Program>
     {
         /// <summary>Stands in for the upstream token endpoint; records what the proxy sent it.</summary>

--- a/VitallyMcp.Tests/OAuthTokenProxyForwardTests.cs
+++ b/VitallyMcp.Tests/OAuthTokenProxyForwardTests.cs
@@ -119,6 +119,27 @@ public class OAuthTokenProxyForwardTests : IClassFixture<OAuthTokenProxyForwardT
         _factory.Upstream.RequestBodies.Should().NotContain(b => b.Contains("evil.example.com"));
     }
 
+    [Fact]
+    public async Task Token_RejectsWhenOnlyOneOfSeveralResourcesMatches()
+    {
+        // Same repeated-parameter case on the form body. Built from a list rather than a dictionary
+        // precisely so the key can repeat — a dictionary cannot express this request.
+        using var client = _factory.CreateClient();
+
+        using var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string, string>("grant_type", "authorization_code"),
+            new KeyValuePair<string, string>("code", "test-code"),
+            new KeyValuePair<string, string>("resource", "https://vitally.example.com/"),
+            new KeyValuePair<string, string>("resource", "https://evil.example.com/")
+        });
+        var response = await client.PostAsync("/oauth/token", form);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("invalid_target");
+        _factory.Upstream.RequestBodies.Should().NotContain(b => b.Contains("evil.example.com"));
+    }
+
     public class Factory : WebApplicationFactory<Program>
     {
         /// <summary>Stands in for the upstream token endpoint; records what the proxy sent it.</summary>

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -305,9 +305,17 @@ public class OAuthOptions
         return string.Equals(requested.Scheme, expected.Scheme, StringComparison.OrdinalIgnoreCase)
             && string.Equals(requested.Host, expected.Host, StringComparison.OrdinalIgnoreCase)
             && requested.Port == expected.Port
-            && string.Equals(requested.AbsolutePath.TrimEnd('/'), expected.AbsolutePath.TrimEnd('/'), StringComparison.Ordinal)
+            && string.Equals(WithoutOneTrailingSlash(requested.AbsolutePath), WithoutOneTrailingSlash(expected.AbsolutePath), StringComparison.Ordinal)
             && string.Equals(requested.Query, expected.Query, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Drops at most one trailing slash. Deliberately not <c>TrimEnd('/')</c>: the tolerance exists
+    /// because Entra and Claude Code disagree by exactly one slash, and <c>/mcp//</c> is a different
+    /// path per RFC 3986 rather than another spelling of the same resource.
+    /// </summary>
+    private static string WithoutOneTrailingSlash(string path) =>
+        path.EndsWith('/') ? path[..^1] : path;
     private static bool IsLoopbackHost(string host) =>
         host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
         // Covers the full IPv4 127.0.0.0/8 loopback range plus IPv6 ::1.

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -139,13 +139,19 @@ public class OAuthOptions
         // discovered at the first sign-in rather than at boot. An Entra-style client-ID GUID is
         // a perfectly good `aud` but not a resource identifier, and lands here when `Resource`
         // is left unset; set `Resource` to the server origin in that case.
+        //
+        // The scheme is checked, not just absoluteness: Uri.TryCreate("/mcp", Absolute) succeeds on
+        // Unix as file:///mcp and fails on Windows, so an absoluteness-only check would be inert on
+        // the Linux containers this actually runs on (CI caught it). http is allowed alongside https
+        // for loopback development; production carries an https origin.
         var publishedResource = PublishedResourceIdentifier;
         if (!string.IsNullOrWhiteSpace(publishedResource)
             && (!Uri.TryCreate(publishedResource, UriKind.Absolute, out var resourceUri)
+                || (resourceUri.Scheme != Uri.UriSchemeHttps && resourceUri.Scheme != Uri.UriSchemeHttp)
                 || !string.IsNullOrEmpty(resourceUri.Fragment)))
         {
             throw new InvalidOperationException(
-                $"OAuth:Resource (or OAuth:Audience, which stands in for it when Resource is empty) must be an absolute URI with no fragment (got '{publishedResource}').");
+                $"OAuth:Resource (or OAuth:Audience, which stands in for it when Resource is empty) must be an absolute http(s) URI with no fragment (got '{publishedResource}').");
         }
 
         if (!string.IsNullOrWhiteSpace(SharedClientSecret) && string.IsNullOrWhiteSpace(SharedClientId))

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -35,6 +35,15 @@ public class OAuthOptions
     public bool NoAuth { get; set; }
 
     /// <summary>
+    /// The canonical resource identifier this server actually publishes: <see cref="Resource"/>,
+    /// falling back to <see cref="Audience"/>. Both the RFC 9728 document and
+    /// <see cref="IsResourceIndicatorAllowed"/> read it, so the value clients are told to send is
+    /// by construction the value their <c>resource</c> parameter is validated against.
+    /// </summary>
+    public string PublishedResourceIdentifier =>
+        (string.IsNullOrWhiteSpace(Resource) ? Audience : Resource)?.Trim() ?? string.Empty;
+
+    /// <summary>
     /// Canonical public origin of this server (scheme + host, no trailing path), e.g.
     /// <c>https://vitally.fiscaltec.com</c>. When set, the <c>/.well-known/*</c> metadata documents
     /// and the OAuth proxy's own callback URL are built from this value instead of the request's
@@ -236,6 +245,69 @@ public class OAuthOptions
         });
     }
 
+
+    /// <summary>
+    /// Returns true if <paramref name="resource"/> names the resource this server publishes, so an
+    /// RFC 8707 <c>resource</c> parameter may be honoured. The parameter is an audience-binding
+    /// control: whatever the caller sends here is what the token's <c>aud</c> ends up naming, so a
+    /// value we never published must be refused rather than passed on or quietly dropped.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Compared component-wise rather than as one string, per RFC 3986 §6.2.2: scheme and host are
+    /// case-insensitive, path and query are not. A single trailing slash is tolerated on either
+    /// side — and that tolerance is load-bearing, not cosmetic. Entra refuses to register an
+    /// <c>identifierUris</c> value ending in a slash, while Claude Code normalises a bare-host
+    /// resource *to* the trailing-slash form, so the two forms have to be treated as one name.
+    /// Nothing else is normalised: a differing port, scheme or path is a different resource.
+    /// </para>
+    /// <para>
+    /// With no identifier configured at all — neither <see cref="Resource"/> nor
+    /// <see cref="Audience"/>, which <see cref="Validate"/> only permits when <see cref="NoAuth"/>
+    /// is true — there is nothing to compare against and no audience binding to protect, so every
+    /// value is accepted. Production always has <see cref="Audience"/>.
+    /// </para>
+    /// </remarks>
+    public bool IsResourceIndicatorAllowed(string resource)
+    {
+        var published = PublishedResourceIdentifier;
+        if (string.IsNullOrWhiteSpace(published))
+        {
+            return true;
+        }
+
+        // A present-but-empty `resource` binds nothing, so it is malformed rather than absent —
+        // callers must only reach here when the parameter was actually sent.
+        if (string.IsNullOrWhiteSpace(resource))
+        {
+            return false;
+        }
+
+        // As in IsRedirectUriAllowed: Uri.TryCreate tolerates padding, the comparisons below would
+        // not, so reject it outright rather than silently normalising a client's malformed input.
+        if (resource.Length != resource.Trim().Length)
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(resource, UriKind.Absolute, out var requested)
+            || !Uri.TryCreate(published, UriKind.Absolute, out var expected))
+        {
+            return false;
+        }
+
+        // RFC 8707 §2 — a resource indicator must not carry a fragment.
+        if (!string.IsNullOrEmpty(requested.Fragment))
+        {
+            return false;
+        }
+
+        return string.Equals(requested.Scheme, expected.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(requested.Host, expected.Host, StringComparison.OrdinalIgnoreCase)
+            && requested.Port == expected.Port
+            && string.Equals(requested.AbsolutePath.TrimEnd('/'), expected.AbsolutePath.TrimEnd('/'), StringComparison.Ordinal)
+            && string.Equals(requested.Query, expected.Query, StringComparison.Ordinal);
+    }
     private static bool IsLoopbackHost(string host) =>
         host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
         // Covers the full IPv4 127.0.0.0/8 loopback range plus IPv6 ::1.

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -133,6 +133,21 @@ public class OAuthOptions
             throw new InvalidOperationException("OAuth:Audience is required when OAuth:NoAuth is false.");
         }
 
+        // PublishedResourceIdentifier is published as the RFC 9728 `resource` *and* is what an
+        // incoming RFC 8707 `resource` parameter is validated against, so a value that cannot be
+        // parsed would reject every request carrying the parameter — an authentication outage
+        // discovered at the first sign-in rather than at boot. An Entra-style client-ID GUID is
+        // a perfectly good `aud` but not a resource identifier, and lands here when `Resource`
+        // is left unset; set `Resource` to the server origin in that case.
+        var publishedResource = PublishedResourceIdentifier;
+        if (!string.IsNullOrWhiteSpace(publishedResource)
+            && (!Uri.TryCreate(publishedResource, UriKind.Absolute, out var resourceUri)
+                || !string.IsNullOrEmpty(resourceUri.Fragment)))
+        {
+            throw new InvalidOperationException(
+                $"OAuth:Resource (or OAuth:Audience, which stands in for it when Resource is empty) must be an absolute URI with no fragment (got '{publishedResource}').");
+        }
+
         if (!string.IsNullOrWhiteSpace(SharedClientSecret) && string.IsNullOrWhiteSpace(SharedClientId))
         {
             throw new InvalidOperationException("OAuth:SharedClientSecret requires OAuth:SharedClientId to also be set.");

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -391,6 +391,26 @@ app.MapGet("/oauth/authorize", async (HttpContext ctx, IOptions<OAuthOptions> oa
         return Results.BadRequest(new { error = "invalid_request", error_description = "redirect_uri is not allowed" });
     }
 
+    // RFC 8707. `resource` is what binds the audience of the token that comes back: this proxy
+    // sends no `audience` parameter anywhere, and the Auth0 tenant's Resource Parameter
+    // Compatibility Profile consumes `resource` locally to that end. It arrived here
+    // unvalidated — so a client could ask to be bound to an audience this server never
+    // published, and we would relay the request. Refuse the mismatch instead; the value is
+    // still forwarded verbatim below, because dropping it is what would break Auth0 today.
+    // Terminating it at this façade belongs to the Entra cutover (#105 part B / #108), which is
+    // where Entra's exact-match rule against a non-slashed identifierUri starts to matter.
+    // Indexer lookups on IQueryCollection are case-insensitive, so a differently-cased spelling
+    // is checked here too even though only the exact `resource` reaches the provider as one.
+    if (query.ContainsKey("resource")
+        && query["resource"].Any(value => !o.IsResourceIndicatorAllowed(value ?? string.Empty)))
+    {
+        return Results.BadRequest(new
+        {
+            error = "invalid_target",
+            error_description = "The resource parameter does not match the resource identifier this server publishes."
+        });
+    }
+
     cache.Set($"oauth-proxy:state:{state}", clientRedirectUri, TimeSpan.FromMinutes(10));
 
     var ourCallback = $"{GetServerBaseUrl(ctx, o.PublicBaseUrl)}/oauth/callback";
@@ -461,6 +481,19 @@ app.MapPost("/oauth/token", async (HttpContext ctx, IOptions<OAuthOptions> oauth
     var ourCallback = $"{GetServerBaseUrl(ctx, o.PublicBaseUrl)}/oauth/callback";
 
     var form = await ctx.Request.ReadFormAsync();
+    // Same audience-binding control as /oauth/authorize, applied to the form body — a refresh
+    // exchange can carry `resource` just as a code exchange can, and this endpoint forwarded it
+    // unvalidated too. See the comment there for why it is validated but still relayed.
+    if (form.ContainsKey("resource")
+        && form["resource"].Any(value => !o.IsResourceIndicatorAllowed(value ?? string.Empty)))
+    {
+        return Results.BadRequest(new
+        {
+            error = "invalid_target",
+            error_description = "The resource parameter does not match the resource identifier this server publishes."
+        });
+    }
+
     var pairs = new List<KeyValuePair<string, string>>();
     var sawRedirect = false;
     foreach (var kv in form)

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -399,8 +399,11 @@ app.MapGet("/oauth/authorize", async (HttpContext ctx, IOptions<OAuthOptions> oa
     // still forwarded verbatim below, because dropping it is what would break Auth0 today.
     // Terminating it at this façade belongs to the Entra cutover (#105 part B / #108), which is
     // where Entra's exact-match rule against a non-slashed identifierUri starts to matter.
-    // Indexer lookups on IQueryCollection are case-insensitive, so a differently-cased spelling
-    // is checked here too even though only the exact `resource` reaches the provider as one.
+    // Indexer lookups on IQueryCollection are case-insensitive, so an oddly-cased `RESOURCE` is
+    // validated here too — and refused if it does not match. The forwarding loop below preserves
+    // the caller's key casing, so such a pair does travel upstream as-is; a conformant provider
+    // ignores it, because RFC 6749 defines parameter names as lowercase literals. #123 tracks
+    // stripping them rather than relying on that.
     if (query.ContainsKey("resource")
         && query["resource"].Any(value => !o.IsResourceIndicatorAllowed(value ?? string.Empty)))
     {

--- a/VitallyMcp/ProtectedResourceMetadataBuilder.cs
+++ b/VitallyMcp/ProtectedResourceMetadataBuilder.cs
@@ -25,7 +25,7 @@ public static class ProtectedResourceMetadataBuilder
 
         return new ProtectedResourceMetadata
         {
-            Resource = string.IsNullOrWhiteSpace(oauth.Resource) ? oauth.Audience : oauth.Resource,
+            Resource = oauth.PublishedResourceIdentifier,
             // Collection-expression assignment (not the nested `= { ... }` initialiser syntax) is
             // deliberate: BearerMethodsSupported already defaults to a pre-populated ["header"]
             // list on this SDK type, so `= { "header" }` would append and leave a duplicate entry.


### PR DESCRIPTION
Closes #105 — **Part A only**, per the correction in the issue comments. The `resource`
parameter is now *validated*; it is still forwarded upstream unchanged.

## Why the split

`resource` is what binds the audience of the token the proxy returns. `Program.cs` sends
**no `audience` parameter anywhere**, and the Auth0 tenant's *Resource Parameter
Compatibility Profile* consumes `resource` locally to that end. So dropping or substituting
it — steps 1, 3 and 4 of the issue body — would remove the audience binding while Auth0 is
live, `aud` would stop matching `OAuth:Audience`, and **every user** would fail token
validation. That half moves to the cutover (#108), where staging can prove it against Entra.

What is left is the security-relevant half and is provider-neutral: the parameter arrived
**unvalidated**, so a client could ask to be bound to an audience this server never published
and the proxy would relay the request.

## What changed

| | |
|---|---|
| `OAuthOptions.PublishedResourceIdentifier` | `OAuth:Resource` falling back to `OAuth:Audience`. `ProtectedResourceMetadataBuilder` now reads it too, so the value validated against *is* the value published — by construction, not by convention |
| `OAuthOptions.IsResourceIndicatorAllowed` | The single comparison, alongside `IsRedirectUriAllowed` |
| `/oauth/authorize` (query) and `/oauth/token` (form) | Reject a mismatch with `invalid_target`; every value checked when the parameter repeats; a present-but-empty value is a mismatch, not an absence; an absent parameter is untouched (RFC 8707 is optional for clients) |

**Comparison rules** — component-wise per RFC 3986 §6.2.2, not one string compare: scheme and
host case-insensitive, port/path/query exact, fragment rejected outright (RFC 8707 §2), and a
single trailing slash tolerated on either side. That tolerance is load-bearing rather than
cosmetic — Entra refuses to register an `identifierUris` value ending in a slash, while Claude
Code normalises a bare-host resource *to* the trailing-slash form, so the two forms have to
name one resource. Nothing else is normalised.

With neither `Resource` nor `Audience` configured — only reachable under `NoAuth`, since
`Validate()` requires `Audience` otherwise — there is nothing to compare against and every
value is accepted.

## Tests

488 pass (460 before; 28 new), TDD throughout — the reject cases were watched failing against
the un-wired code first.

- `OAuthOptionsTests` — match/mismatch, trailing-slash tolerance both ways, host and scheme
  case-insensitivity, path case-sensitivity, port/scheme/suffix-spoof rejection, fragment,
  empty and non-URI input, the `Audience` fallback, and the unconfigured dev case
- `OAuthProxyEndpointsTests` — a matching `resource` reaches the upstream redirect **byte for
  byte**, a mismatch is `400 invalid_target`, an absent one changes nothing
- `OAuthTokenProxyForwardTests` — the same three on the form body, both grants, asserting no
  request the proxy ever made carried the rejected value (the guard returns before the
  upstream call)

## Verification beyond the suite

Deployed to staging and driven the way a client does — reading the published `resource` out of
the live RFC 9728 document and sending that exact value to `/oauth/authorize`. Results in a
comment below.

## CLAUDE.md

New Architecture section on the parameter (the control, the comparison rules, and why it is
still relayed), the two proxy endpoint bullets, and the `OAuth:Resource` second role. The
Auth0 *Resource Parameter Compatibility Profile* note in the overview and the deployment table
is **not** obsolete — both now say why it is still required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrDwBJXV4pSAE6dfxhLEBD