### PR TITLE
feat: cut the OAuth proxy over from Auth0 to Entra-direct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Model Context Protocol (MCP) server implementation in C# that provides full CRUD access to the Vitally customer success platform. The server is a **remote HTTP MCP server** secured with Auth0 (which federates to Microsoft Entra for FISCAL identity); users connect to it by URL rather than installing a binary.
+This is a Model Context Protocol (MCP) server implementation in C# that provides full CRUD access to the Vitally customer success platform. The server is a **remote HTTP MCP server** secured by Microsoft Entra directly; users connect to it by URL rather than installing a binary. Auth0 was the identity provider until the #108 cutover on 2026-09-03 and is no longer in the path.
 
 **Key characteristics:**
 - Full CRUD API access to Vitally resources (accounts, organisations, users, conversations, notes, projects, tasks, admins, NPS responses, project templates, project categories, messages, custom objects, meetings — including participants and transcripts — custom traits, custom surveys)
 - Permission management via `ReadOnly` and `Destructive` flags on every tool, for MCP clients to enforce per-category permissions
 - **Streamable HTTP transport** (MCP 2026-07-28) on the `ModelContextProtocol.AspNetCore` package, stateless mode
-- **Auth0 OAuth 2.1 protection** via JwtBearer on `/mcp`; publishes RFC 9728 protected-resource metadata at `/.well-known/oauth-protected-resource`. An in-process OAuth proxy fronts the upstream Auth0 tenant when `OAuth:SharedClientId` is set — it implements an RFC 7591 DCR shim so every MCP client converges on one pre-registered first-party app (skipping the per-session consent screen and accepting any RFC 8252 loopback port). Non-loopback `redirect_uri` values must be in `OAuth:AllowedClientRedirectUris`. **Auth0 tenant must have "Resource Parameter Compatibility Profile" enabled** (Settings → Advanced) so the `resource` parameter from MCP clients is consumed locally and not forwarded to upstream IdPs (avoids AADSTS9010010 with the Entra federation hop). Still required: the proxy *validates* `resource` (#105) but deliberately keeps forwarding it, because on Auth0 it is the only thing binding the token audience — see the `resource` section under Architecture.
+- **Entra OAuth 2.1 protection** via JwtBearer on `/mcp`; publishes RFC 9728 protected-resource metadata at `/.well-known/oauth-protected-resource`. An in-process OAuth proxy fronts the upstream Entra tenant when `OAuth:SharedClientId` is set — it implements an RFC 7591 DCR shim so every MCP client converges on one pre-registered first-party app (skipping the per-session consent screen and accepting any RFC 8252 loopback port). Non-loopback `redirect_uri` values must be in `OAuth:AllowedClientRedirectUris`. The proxy *validates* the RFC 8707 `resource` parameter (#105) and then **terminates** it, naming the API upstream by scope instead — see the `resource` section under Architecture for why relaying it to Entra is a hard failure.
 - **On-demand Vitally API key fetch**: the server fetches the `vitally-shared` secret from Azure Key Vault via its user-assigned managed identity (with a short in-memory cache) and uses it to call Vitally on behalf of all authenticated users. Future per-user keys can be added by reintroducing claim-based secret resolution.
 - .NET 10 ASP.NET Core, framework-dependent — runs in any .NET 10 container
 - Built on the official `ModelContextProtocol` C# SDK 2.2.0 + `ModelContextProtocol.AspNetCore` 2.2.0
@@ -31,7 +31,7 @@ dotnet build VitallyMcp.sln
 # Run a single test class
 dotnet test VitallyMcp.sln -c Debug --filter-class "*MeetingsToolsTests"
 
-# Start the server in dev mode (no Auth0, no Key Vault)
+# Start the server in dev mode (no identity provider, no Key Vault)
 $env:OAuth__NoAuth = "true"
 $env:Vitally__Region = "EU"
 $env:Vitally__DevelopmentApiKey = "sk_live_your_key"
@@ -90,7 +90,7 @@ A successful response carries `ttlMs: 300000` and `cacheScope: "private"` alongs
 
 ## Installing for End Users
 
-FISCAL employees point their MCP client at `https://vitally.fiscaltec.com/mcp`. The client handles the Auth0 OAuth flow automatically on first use via the protected-resource metadata document (Auth0 federates to Entra for the actual sign-in).
+FISCAL employees point their MCP client at `https://vitally.fiscaltec.com/mcp`. The client handles the OAuth flow automatically on first use via the protected-resource metadata document, signing in against Entra.
 
 | Client | How to connect |
 |---|---|
@@ -273,7 +273,7 @@ defects rather than cosmetics; the form asks for the observed effect to keep tha
 The server uses ASP.NET Core 10 with `WebApplication.CreateBuilder` + `Microsoft.NET.Sdk.Web`. Key wiring:
 
 - Binds `VitallyServerOptions` from the `Vitally:` configuration section, calls `Validate()` at startup to fail-fast on bad config.
-- Binds `OAuthOptions` from `OAuth:` (provider-agnostic — works with Auth0, Entra direct, Keycloak, etc.).
+- Binds `OAuthOptions` from `OAuth:` (provider-agnostic — works with Entra, Auth0, Keycloak, etc.; only `OAuth:UpstreamResourceScope` differs between them, and it is a value rather than a branch).
 - Conditionally registers `SecretClient` (Azure Key Vault) as singleton when `Vitally:KeyVaultUri` is set; uses `DefaultAzureCredential` so it works with managed identity in production and `az login` locally.
 - `IMemoryCache` registered for the API key cache and OAuth proxy state cache.
 - Authorisation policy plumbing: `VitallyPermissionRequirement.cs` carries one `vitally:*` permission,
@@ -304,11 +304,11 @@ The server uses ASP.NET Core 10 with `WebApplication.CreateBuilder` + `Microsoft
 From a client's point of view this server *is* the authorisation server: `/oauth/authorize`,
 `/oauth/token` and `/oauth/register` are all ours. So the RFC 8414 document declares **our own
 origin** as `issuer` (`PublicBaseUrl`, falling back to the request origin) — the same string
-`ProtectedResourceMetadataBuilder` publishes as `authorization_servers`. Auth0 still issues the
+`ProtectedResourceMetadataBuilder` publishes as `authorization_servers`. Entra still issues the
 tokens and `jwks_uri` / `userinfo_endpoint` still point there; the façade covers identity and
 discovery, not issuance.
 
-It previously declared **Auth0's** issuer while being served from our origin, which violates RFC 8414
+It previously declared the **upstream provider's** issuer while being served from our origin, which violates RFC 8414
 §3.3 (an anti-mix-up control: a metadata document can only ever speak for itself) and made strict
 clients — including **MCP Inspector** — abort before reaching DCR. Fixed 2026-08-21 (#90).
 
@@ -317,21 +317,21 @@ clients — including **MCP Inspector** — abort before reaching DCR. Fixed 202
 | Piece | Why |
 |---|---|
 | `issuer` = our origin | RFC 8414 §3.3. Must equal `authorization_servers` in the RFC 9728 document byte for byte — the check is simple string equality, tolerating only a trailing slash *on the expected value*. |
-| `/oauth/callback` strips any upstream `iss` and appends our own | RFC 9207. **Mandatory, not defensive.** Clients compare a *present* `iss` against the metadata `issuer` even when support is not advertised — so an Auth0 `iss` forwarded through would now be a hard failure, and appending ours alongside would leave two values. |
+| `/oauth/callback` strips any upstream `iss` and appends our own | RFC 9207. **Mandatory, not defensive.** Clients compare a *present* `iss` against the metadata `issuer` even when support is not advertised — so an upstream `iss` forwarded through would now be a hard failure, and appending ours alongside would leave two values. |
 | `authorization_response_iss_parameter_supported: true` | Honest only because of the row above. Advertising it and then omitting `iss` reads as a stripped-parameter attack and the client aborts. |
 
 **Verified 2026-08-21** against `@modelcontextprotocol/client` 2.0.0 — the package MCP Inspector 2.3.0
 actually depends on — driving a local container: the RFC 9728 document parses, `discoverAuthorizationServerMetadata`
 passes §3.3, **DCR is reached and returns the shared `client_id`** (it was never called before), and
 `validateAuthorizationResponseIssuer` accepts the `iss` we emit. A control assertion confirms the same
-function still rejects Auth0's issuer, so the passes are not a skipped check.
+function still rejects the upstream issuer, so the passes are not a skipped check.
 
 Two things were verified rather than assumed, both of which the design had flagged as open:
 
 - **No client validates the access token's `iss` against the metadata `issuer`.** The SDK's client
   auth module never decodes a JWT or fetches JWKS — access tokens are opaque to it — so `jwks_uri`
-  pointing at Auth0 while we claim the issuer is safe. Our own `JwtBearer` validates against Auth0's
-  `Authority` internally and is unaffected either way.
+  pointing upstream while we claim the issuer is safe. Our own `JwtBearer` validates against the
+  provider's `Authority` internally and is unaffected either way.
 - **The published SDK 1.x does not enforce §3.3 at all**; the enforcement ships in the 2.x packages.
   So this was latent for Claude Desktop / Claude Code and immediately fatal for anything on 2.x.
 
@@ -344,22 +344,24 @@ That is the acceptance test in #90, and it is past the point where the flow prev
 **If you touch this,** re-run that validation rather than reasoning about it — `npx @modelcontextprotocol/inspector`
 against a local container is now a working end-to-end client, which is the practical payoff.
 
-**Two traps when validating against a throwaway Auth0 audience** (both cost time on 2026-08-22):
+**Validate identity-provider changes against staging, not against a tunnel.** An identifier URI is
+immutable and must equal the server origin (the client throws when the RFC 9728 `resource` does not
+match what it fetched), so an ephemeral tunnel URL orphans one registration per run — which cost two
+sessions during #90. `https://vitally-staging.fiscaltec.com` has a stable hostname and is already
+carried in the Entra app's `identifierUris`/redirect URIs, so it can be reused run after run. Reach
+for a tunnel only for something staging genuinely cannot cover, and budget for the cleanup if you do.
 
-- **`tools/list` will be empty, and that is expected.** The post-login Action `Vitally MCP claims`
-  opens with `if (event.resource_server?.identifier !== 'https://vitally.fiscaltec.com/') return;`,
-  so no `permissions` claim is minted for any other audience and every tool is filtered out. It looks
-  exactly like an authorisation failure at the moment you are least able to dismiss it. Set
-  `Authorization:Enabled=false` to confirm the rest of the path, or accept the empty list as evidence
-  the RBAC discovery filter fails closed.
-- **Auth0 API identifiers are immutable and must equal the server origin** (the client throws if the
-  RFC 9728 `resource` does not match), so an ephemeral tunnel URL orphans one API per run. This is
-  what the staging environment now exists to avoid — validate identity-provider changes against
-  `https://vitally-staging.fiscaltec.com`, whose hostname is stable and whose Resource Server already
-  matches it. Reach for a tunnel only for something staging genuinely cannot cover, and budget for the
-  cleanup if you do.
+**How far a validation can get without a browser** — worth knowing before assuming the whole flow
+needs a human. Everything up to the credential prompt is scriptable, and that covers most of what
+breaks: the metadata documents (`verify-oauth-metadata.sh`), the proxy's upstream redirect (read the
+`Location` and assert on its query), and **Entra's own acceptance of that redirect** — follow it and
+Entra answers with either its sign-in page or an `AADSTS` error, which is a real test of `client_id`,
+`redirect_uri`, `scope` and `resource` handling. What genuinely needs a person is a token: `az account
+get-access-token --scope https://vitally.fiscaltec.com/mcp.access` fails with `AADSTS65001`, because
+Azure CLI is not a pre-authorised client on this API, and adding it would grant a broad first-party
+client permanent silent access — not a change to make for a test.
 
-### The RFC 8707 `resource` parameter is validated here — and still relayed upstream
+### The RFC 8707 `resource` parameter is validated here — and terminated here
 
 `OAuthOptions.IsResourceIndicatorAllowed(value)` is the single check, reading
 `PublishedResourceIdentifier` (`OAuth:Resource`, falling back to `OAuth:Audience`) — the same
@@ -369,11 +371,11 @@ construction the value clients were told to send. `/oauth/authorize` (query) and
 the parameter repeats, and a present-but-empty one is a mismatch rather than an absence. An absent
 `resource` is untouched — RFC 8707 is optional for clients.
 
-**Why it is a real control and not paperwork.** `resource` is what binds the audience of the token
-that comes back: `Program.cs` sends **no `audience` parameter anywhere**, and the Auth0 tenant's
-*Resource Parameter Compatibility Profile* consumes `resource` locally to that end. Until #105 it
-was relayed unvalidated, so a client could ask to be bound to an audience this server never
-published and the proxy would pass the request on.
+**Why it is a real control and not paperwork.** It governs what audience a caller may ask to be
+bound to. Until #105 the parameter was relayed unvalidated, so a client could name an audience this
+server never published and the proxy would pass the request on. That check is unchanged by the
+cutover and is deliberately independent of what happens to the value afterwards — the two questions
+are separate, and conflating them is how the validation would quietly become "ignore it".
 
 **Comparison rules** — component-wise per RFC 3986 §6.2.2, not one string compare. Scheme and host
 case-insensitive; port, path and query exact; a fragment rejected outright (RFC 8707 §2); a single
@@ -396,12 +398,50 @@ Windows. An absoluteness-only check therefore passes locally and is inert on the
 this runs on; CI on `ubuntu-latest` caught exactly that in #122. `http` is allowed alongside `https`
 so loopback development still works.
 
-**It is still forwarded, deliberately.** Dropping or substituting it is the Auth0-breaking half of
-#105 and moved to the cutover (#108): with Auth0 live, removing the parameter removes the audience
-binding and `aud` stops matching `OAuth:Audience` for **every** user. So the tenant still needs the
-compatibility profile enabled, and terminating `resource` at the façade — where Entra's exact-match
-rule against a non-slashed `identifierUris` starts to matter — happens only once `OAuth:Authority`
-points at Entra.
+**What happens to a value that passes: `OAuth:UpstreamResourceScope` decides.** It is one setting
+because neither half is usable alone.
+
+| | unset | set (production and staging) |
+|---|---|---|
+| Provider it suits | Auth0 | Entra |
+| A matching `resource` is | relayed verbatim | **dropped at the façade** |
+| The API is named upstream by | that relayed `resource` | this scope, merged into `scope` |
+
+`Program.cs` sends **no `audience` parameter anywhere**, so something has to name the API. On Auth0
+that was the relayed `resource`, consumed locally by the tenant's *Resource Parameter Compatibility
+Profile*; under Entra it is the scope. Dropping `resource` without the scope leaves the token bound
+to nothing; adding the scope while still relaying `resource` is the failure below. Hence one switch,
+and hence it is **configuration rather than a check on `OAuth:Authority`** — which is what keeps a
+rollback a revert of environment variables.
+
+**Relaying `resource` to Entra is a hard failure, and the reason is not the one #105/#107 recorded.**
+Verified against the live tenant on 2026-09-02 by driving `/oauth2/v2.0/authorize` directly:
+
+```
+error=invalid_target&error_description=AADSTS9010010: The resource parameter provided in the
+request doesn't match with the requested scopes.
+```
+
+Two corrections to what was written before the cutover:
+
+- **Both spellings fail, not just the trailing-slash one.** `https://vitally.fiscaltec.com/` and
+  `https://vitally.fiscaltec.com` both return **400**, as does a resource naming nothing at all. The
+  v2 endpoint cross-checks `resource` against `scope`; it is not comparing against `identifierUris`,
+  so the slash is beside the point. Dropping the parameter is therefore *required*, not merely
+  tidier — a version that only normalised the slash would still be broken.
+- **A bare `mcp.access` scope does not fail at `/authorize`** — Entra returns its sign-in page. It
+  resolves an unqualified scope against Microsoft Graph, so the flow completes and hands back a token
+  for the wrong resource. That is why both metadata documents advertise the App ID URI-qualified form
+  in `scopes_supported`: the failure it prevents is a silent wrong audience, not a visible rejection.
+
+The scope is merged on `/oauth/token` as well as `/oauth/authorize`. On a code exchange that is
+redundant; on a **refresh** it is load-bearing, because Entra issues the new access token for
+whatever resource `scope` names — so a client refreshing with only the OIDC scopes would silently be
+handed a Graph-audience token, and the failure would surface at `/mcp` an hour after a sign-in that
+looked fine.
+
+The Auth0 tenant's compatibility profile is now irrelevant to this server. Leave it as it is; it is
+harmless, and the Auth0 client stays in place for the rollback window regardless.
 
 ### Upstream endpoints come from OIDC discovery, not from `Authority`
 
@@ -477,27 +517,29 @@ Two details of that fallback are easy to get wrong and are pinned by tests:
 - `MaxAutoPageFetches` — hard cap on page fetches per server-side filtered call (default 10; 100 items/page). Bounds fan-out against Vitally's 1000 req/min budget.
 
 `OAuthOptions` (singleton, bound from `OAuth:` section):
-- `Authority` — the provider's OIDC **issuer** identifier, e.g. `https://fiscal-it.uk.auth0.com/` (Auth0) or `https://login.microsoftonline.com/{tenant-id}/v2.0` (Entra). It is *not* a prefix the endpoint URLs are built from: `{Authority}/.well-known/openid-configuration` is fetched and the endpoints come from that document. The trailing slash is whatever the provider's own issuer carries — Auth0's has one, Entra's does not.
-- `Audience` — the Auth0 Resource Server / API identifier, e.g. `https://vitally.fiscaltec.com/` — **with the trailing slash**, because Auth0 identifiers are exact-match and production's carries one (verified against the live tenant, 2026-08-22). Validated against the JWT `aud` claim. **Under Entra it becomes the App ID URI `https://vitally.fiscaltec.com` — with NO slash**, because Entra refuses to register a slash-suffixed `identifierUris` value; see the divergence warning below.
-- `Resource` — canonical resource identifier published in `/.well-known/oauth-protected-resource` (falls back to `Audience` if empty). Set explicitly when MCP clients validate metadata `resource` against the server URL/origin (RFC 8707 + RFC 9728 compliance) — the published client rejects the whole document on a mismatch. **On Auth0 it happens to equal `Audience`; under Entra it must not** — see the divergence warning below.  Second role: `PublishedResourceIdentifier` (this value, falling back to `Audience`) is what an incoming RFC 8707 `resource` parameter is validated *against* on `/oauth/authorize` and `/oauth/token` — so it is now a control on what audience a caller may ask to be bound to, not only a value published. `PublicBaseUrl` is the odd one out: it is an origin, so no trailing slash (and `Validate()` trims one anyway).
+- `Authority` — the provider's OIDC **issuer** identifier: `https://login.microsoftonline.com/75bd6050-92a8-4bde-a406-50000b310c86/v2.0`. It is *not* a prefix the endpoint URLs are built from: `{Authority}/.well-known/openid-configuration` is fetched and the endpoints come from that document. The trailing slash is whatever the provider's own issuer carries — Entra's has none, Auth0's had one.
+- `Audience` — the Entra App ID URI, `https://vitally.fiscaltec.com` — **with NO trailing slash**, because Entra refuses to register a slash-suffixed `identifierUris` value. Validated against the JWT `aud` claim, though not alone: `OAuthOptions.ValidAudiences` also accepts `SharedClientId`, and that is what a **v2** access token actually carries (a v1 token carries this App ID URI). One registration is both the OAuth client and the API resource, so the two are the same object. See the divergence warning below for why this must not be reconciled with `Resource`.
+- `Resource` — canonical resource identifier published in `/.well-known/oauth-protected-resource` (falls back to `Audience` if empty). Set explicitly when MCP clients validate metadata `resource` against the server URL/origin (RFC 8707 + RFC 9728 compliance) — the published client rejects the whole document on a mismatch. **It must not be reconciled with `Audience`** — see the divergence warning below.  Second role: `PublishedResourceIdentifier` (this value, falling back to `Audience`) is what an incoming RFC 8707 `resource` parameter is validated *against* on `/oauth/authorize` and `/oauth/token` — so it is now a control on what audience a caller may ask to be bound to, not only a value published. `PublicBaseUrl` is the odd one out: it is an origin, so no trailing slash (and `Validate()` trims one anyway).
 
-> ⚠️ **`Audience` and `Resource` are equal today by coincidence, and must diverge at the Entra
-> cutover.** Auth0's Resource Server identifier carries a trailing slash and so does the value
-> clients normalise to, so both are `https://vitally.fiscaltec.com/` and they look like one setting.
-> Under Entra they are two:
+> ⚠️ **`Audience` and `Resource` differ by exactly one character and must stay that way.** They were
+> equal under Auth0 — that Resource Server identifier happened to carry a trailing slash, as does the
+> form clients normalise to — so they read as one setting, and `infra/terraform/` fed both from a
+> single `oauth_audience` variable. #108 split that variable, which is what makes the difference
+> structural rather than a convention someone has to remember.
 >
-> | | Auth0 (today) | Entra (#108) |
+> | | Auth0 (until 2026-09-03) | Entra (now) |
 > |---|---|---|
 > | `OAuth:Audience` — validated against JWT `aud` | `https://vitally.fiscaltec.com/` | `https://vitally.fiscaltec.com` — **no slash**, Entra refuses to register one on `identifierUris` |
 > | `OAuth:Resource` — published in RFC 9728, and validated against | `https://vitally.fiscaltec.com/` | `https://vitally.fiscaltec.com/` — **unchanged**, Claude Code normalises to it |
 >
 > Reconciling them "for consistency" breaks token validation in one direction and the metadata
 > document in the other. On staging they diverge by *host* as well, because one app registration
-> serves both origins (#107), so a staging token's `aud` is production's App ID URI.
-> `OAuthOptions.IsResourceIndicatorAllowed` tolerating exactly one trailing slash is what lets the
-> two forms name one resource — see `docs/runbooks/entra-app-registration.md`.
-- `SharedClientId` — pre-registered Auth0 native-app client_id that every MCP client converges on via the DCR shim. When set, the OAuth proxy endpoints become active.
-- `SharedClientSecret` — confidential-client secret for `SharedClientId`, injected server-side at `/oauth/token`.
+> serves both origins (#107), so a staging token's `aud` is production's App ID URI — expected, not
+> drift. `OAuthOptions.IsResourceIndicatorAllowed` tolerating exactly one trailing slash is what lets
+> the two forms name one resource — see `docs/runbooks/entra-app-registration.md`.
+- `UpstreamResourceScope` — `https://vitally.fiscaltec.com/mcp.access`. Setting it makes the proxy **terminate** the RFC 8707 `resource` parameter and name the API by this scope instead; leaving it empty relays `resource` (the Auth0 posture). One switch, because neither half works alone — see the `resource` section above. Validated at boot as a single whitespace-free token.
+- `SharedClientId` — appId of the pre-registered Entra app registration (`c3812e7d-a413-4169-b57e-803326611ba3`) that every MCP client converges on via the DCR shim. When set, the OAuth proxy endpoints become active. It is also a valid `aud` — see `Audience`.
+- `SharedClientSecret` — confidential-client secret for `SharedClientId`, injected server-side at `/oauth/token`. Sourced from the Key Vault secret `entra-mcp-client-secret`, which **expires 2027-03-01** — a hard outage date, since Key Vault refuses to read an expired secret. Rotation is in `docs/runbooks/entra-app-registration.md`.
 - `AllowedClientRedirectUris` — non-loopback `redirect_uri` allowlist for the OAuth proxy. Loopback URIs (`localhost`, `127.0.0.1`, `[::1]`) on any port are always allowed per RFC 8252 §7.3; this list covers hosted MCP clients like `https://claude.ai/api/mcp/auth_callback`. `OAuthOptions.IsRedirectUriAllowed(uri)` is the single check; `/oauth/authorize` and `/oauth/register` both use it. **This is the only thing standing between the proxy and an open redirector with authorisation-code theft — never bypass it.**
 - `PublicBaseUrl` — canonical public origin (e.g. `https://vitally.fiscaltec.com`). When set, `/.well-known/*` metadata and the OAuth proxy callback are built from this instead of the request `Host`, defending against Host-header injection into the metadata documents. Empty in local dev (falls back to request scheme+host so loopback works). Validated as absolute https.
 - `NoAuth` — local-only dev flag that bypasses JWT validation entirely.
@@ -506,14 +548,15 @@ Two details of that fallback are easy to get wrong and are pinned by tests:
 - `Enabled` (default `true`), `ReadPermission` (`vitally:read`), `WritePermission` (`vitally:write`), `DeletePermission` (`vitally:delete`), `CustomPermissionsClaim` (default `https://vitally.fiscaltec.com/permissions`).
 - `ReadOnly` (default `false`) — deployment-level read-only kill switch. When true, **every** mutating tool call (create/update/delete) is denied in `ToolAuthorizer` (checked before the `Enabled`/`NoAuth` gate, so it holds even with RBAC off), and the destructive tools are hidden from `tools/list` via an `AddListToolsFilter`. A blunt safety net for read-only deployments that doesn't depend on the per-user Entra-group RBAC. Denials are audited via `LogDenied`.
 - `LiveGroupCheck` (default `false`), `LiveGroupCacheSeconds` (default `60`), `LiveGroupStaleSeconds` (default `3600`; `0` disables stale serving), `ReaderGroupId`/`EditorGroupId`/`AdminGroupId` (Entra group object ids).
-- Permissions are read from the JWT `permissions` claim (Auth0 RBAC), the namespaced `CustomPermissionsClaim` (for the Entra-group→Action→custom-claim assignment model), or space-delimited `scope`. The Entra-group-driven model is the chosen assignment approach: a post-login Auth0 Action maps Entra group membership to the `vitally:*` permissions and writes them to the custom claim.
-- **Live group check (preferred for prompt propagation):** when `LiveGroupCheck=true`, `ToolAuthorizer` resolves permissions from the caller's *current* Entra group membership via `GraphGroupPermissionResolver` (Microsoft Graph — it lists each configured group's `transitiveMembers` filtered to the caller's object id, using the managed identity, cached `LiveGroupCacheSeconds` per user) instead of the token claim — so grants and **revocations** take effect within the cache window regardless of token/refresh age (the post-login Action does **not** re-run on refresh grants, so the claim alone is frozen at login). **`transitiveMembers` expands nested groups**, so a user who gets a tier via a department group nested inside an `sg-vitally-*` group is authorised, not only users assigned to the `sg-vitally-*` group directly. The object id is taken from the `oid` claim or the trailing GUID of `sub`. Requires the managed identity to hold Graph `GroupMember.Read.All`.
-- **A Graph failure degrades in two steps, not one** (#106). The effective order is **fresh Graph → stale Graph → token claim → deny**: `GraphGroupPermissionResolver` keeps each successful lookup with the time it was resolved and, when a Graph call fails, serves that caller's last known-good set for up to `LiveGroupStaleSeconds` (default 1 h) before giving up and returning null. Only then does `ToolAuthorizer` fall through to the token claim. Serving stale logs **one** warning carrying the subject id and how stale the result is in seconds — never the email, never two lines per call.
-  - **Why it exists:** once Auth0 is retired the claim tier is permanently empty, so a Graph outage would deny every user while the code still *read* as having a working degraded path. Bounded staleness is the trade — a revoked user could retain access for up to the window, but only while Graph is unavailable, which is strictly tighter than the 8-hour frozen claim the design tolerated before the live check existed.
+- **Entitlement comes from Entra group membership, resolved live from Graph — nothing in the token grants access.** `LiveGroupCheck` is `true` on every deployed target, and that flag alone chooses the mode: on, permissions come from Graph; off, from the token's `permissions` / `CustomPermissionsClaim` / `scope` claims. The claim path is a *different mode*, not a fallback beneath the live one, and there is no route from one to the other — including when the resolver is missing entirely, which denies rather than quietly selecting the claim mode. Those claim settings are inert on every deployed target; the Auth0 post-login Action that used to mint the custom claim was retired at the #108 cutover.
+- **Live group check (preferred for prompt propagation):** when `LiveGroupCheck=true`, `ToolAuthorizer` resolves permissions from the caller's *current* Entra group membership via `GraphGroupPermissionResolver` (Microsoft Graph — it lists each configured group's `transitiveMembers` filtered to the caller's object id, using the managed identity, cached `LiveGroupCacheSeconds` per user) instead of the token claim — so grants and **revocations** take effect within the cache window regardless of token/refresh age (a claim is frozen at login and does not refresh with the token). **`transitiveMembers` expands nested groups**, so a user who gets a tier via a department group nested inside an `sg-vitally-*` group is authorised, not only users assigned to the `sg-vitally-*` group directly. The object id is taken from the `oid` claim or the trailing GUID of `sub`. Requires the managed identity to hold Graph `GroupMember.Read.All`.
+- **A Graph failure degrades in one step, then denies** (#106, #108). The order is **fresh Graph → stale Graph → deny**: `GraphGroupPermissionResolver` keeps each successful lookup with the time it was resolved and, when a Graph call fails, serves that caller's last known-good set for up to `LiveGroupStaleSeconds` (default 1 h) before giving up and returning null — at which point `ToolAuthorizer` denies, explicitly and with a log line saying which of the two fail-closed routes was taken. Serving stale logs **one** warning carrying the subject id and how stale the result is in seconds — never the email, never two lines per call.
+  - **Why it exists:** the stale copy is the only thing between a Graph outage and a total denial, now that no claim can authorise. Bounded staleness is the trade — a revoked user could retain access for up to the window, but only while Graph is unavailable, which is strictly tighter than the 8-hour frozen claim the design tolerated before the live check existed. `LiveGroupStaleSeconds: 0` turns the protection off and denies immediately.
   - **The two windows are separate on purpose, and must stay separate.** `LiveGroupCacheSeconds` governs answering *without asking Graph*; `LiveGroupStaleSeconds` is consulted *only after a Graph call has failed*. Collapsing them — e.g. by simply lengthening the cache TTL to an hour — would stop revocations propagating, which is the whole reason the live check exists. `ReHitsGraph_OnceTheFreshTtlLapses_DespiteRetainingAStaleCopy` is the regression guard.
   - Age is measured against an injected `TimeProvider`, not by cache expiry: the warning needs the age itself, and `IMemoryCache` expiry cannot be wound forward in a test. The cache entry is keyed per user, which is what stops one caller's retained tier being served to another during an outage (`DoesNotServeOneUsersStaleResult_ToAnother`).
-  - **The claim tier is still live and still load-bearing.** #106 deliberately added the stale cache *beneath* it rather than replacing it: while Auth0 issues tokens the claim genuinely authorises, so removing it now would swap a working fallback for a denial. Removing it — and making the fail-closed explicit — belongs to the cutover (#108), where staging can prove the degraded path before it is the only path.
-- Server-side RBAC backstop. `ToolAuthorizer.EnsureAuthorizedAsync(method, ct)` is awaited from **`VitallyService.SendAsync`** — the single point every Vitally call funnels through — so all 93 tools are covered without per-tool annotation. The HTTP verb maps to the tier: GET → read, POST/PUT/PATCH → write, DELETE → delete (unknown verbs fall back to the strictest). Permissions are read from the JWT `permissions` claim (Auth0 RBAC), the namespaced `CustomPermissionsClaim`, or space-delimited `scope` (same three sources as above). Bypassed when `Enabled=false` or `OAuth:NoAuth=true`. **The `ReadOnly`/`Destructive` tool attributes are advisory client hints; this is the actual enforcement — when adding a new call path, route it through `VitallyService.SendAsync` so it stays covered, and never call the Vitally API around it.**
+  - **The degraded path is observed, not just unit-tested** (`StaleEntitlementCompositionTests`). #106 shipped it with unit coverage alone and it had never been seen working; staging cannot induce a Graph failure in isolation, because it shares the managed identity and CAE with production. #108 closed that gap with a composed-host test that drives the real wiring — DI, the typed Graph client, the singleton `IMemoryCache` that carries the retained copy *between requests*, the authorizer, the policy handler, the SDK filter — and reads the outcome off `tools/list` across an outage that starts, is survived, and then outlasts its window. A resolver handed a fresh cache per request would pass the unit tests and fail that one.
+  - **The claim tier used to sit beneath the stale cache and was removed at the cutover (#108).** While Auth0 minted the claim it genuinely authorised, which is why #106 added the stale cache *beneath* rather than in place of it. With the Action retired the claim is permanently absent, so a fall-through could only ever have denied — leaving code that read like a working fallback and behaved like a silent denial. Do not reinstate it "as a safety net": it is not one.
+- Server-side RBAC backstop. `ToolAuthorizer.EnsureAuthorizedAsync(method, ct)` is awaited from **`VitallyService.SendAsync`** — the single point every Vitally call funnels through — so all 93 tools are covered without per-tool annotation. The HTTP verb maps to the tier: GET → read, POST/PUT/PATCH → write, DELETE → delete (unknown verbs fall back to the strictest). Resolution is `HasEffectivePermissionAsync`, exactly as for discovery filtering (see above), so the two cannot disagree. Bypassed when `Enabled=false` or `OAuth:NoAuth=true`. **The `ReadOnly`/`Destructive` tool attributes are advisory client hints; this is the actual enforcement — when adding a new call path, route it through `VitallyService.SendAsync` so it stays covered, and never call the Vitally API around it.**
 - **Per-caller discovery filtering.** All 93 tools carry `[Authorize(Policy = "vitally:read|write|delete")]` (56 read / 25 write / 12 delete). `mcpBuilder.AddAuthorizationFilters()` makes the SDK evaluate that attribute on each tool, so `tools/list` shows only the tools the caller may actually invoke and an unauthorised call is rejected before the handler runs. **It and `AddAuthorizationBuilder()` are registered unconditionally — never guarded on `OAuth:NoAuth`.** Once any tool carries `[Authorize]`, the SDK *fails closed*: it throws ("Authorization filter was not invoked for tools/call operation, but authorization metadata was found on the tool") so a guarded registration yields a dev server that can neither list nor call any tool. Dev mode stays unfiltered instead via `VitallyPermissionHandler`, which succeeds when `ToolAuthorizer.IsAuthorizationBypassedAsync()` reports RBAC disabled or `NoAuth`. `VitallyPermissionHandler` resolves those policies through `ToolAuthorizer.HasEffectivePermissionAsync`, so discovery and the `VitallyService.SendAsync` backstop cannot drift apart. This is **discovery filtering** — the security boundary remains `SendAsync`. Distinct from the deployment-wide `Authorization:ReadOnly` switch, which hides destructive tools from everyone.
 - A denial refused at this SDK authorisation checkpoint is audited separately: see `LogToolCallDenied` under `AuditOptions` below — `SendAsync`'s own `LogDenied` never fires for a tier mismatch, because the SDK rejects the call before `SendAsync` runs.
 
@@ -530,7 +573,7 @@ Scoped. Resolution order on each call to `GetApiKeyAsync()`:
 2. Check `IMemoryCache` for `"vitally-api-key::{DefaultSecretRef}"`. Return if hit.
 3. Call `SecretClient.GetSecretAsync(DefaultSecretRef)` (uses the Container App's user-assigned managed identity), cache the value for `SecretCacheDuration`, return.
 
-This means: rotating the Vitally key is a `Set-AzKeyVaultSecret` away (cache expires on its own). Per-user keys can be re-introduced later by extending the provider to read the `https://vitally.fiscaltec.com/secret_ref` claim (set by the Auth0 Action) and selecting a different secret name per user — no other architecture changes needed.
+This means: rotating the Vitally key is a `Set-AzKeyVaultSecret` away (cache expires on its own). Per-user keys could be re-introduced by extending the provider to select a different secret name per caller, keyed off a claim or the caller's group membership — no other architecture changes needed. (An Auth0 Action used to mint a `secret_ref` claim for this; it went with the rest of the Auth0 configuration at the #108 cutover, and Vitally API keys are tenant-global anyway, so the idea needs a new motivation before it needs a mechanism.)
 
 ### HTTP Service (VitallyService.cs)
 
@@ -752,23 +795,25 @@ dotnet test VitallyMcp.sln -c Debug --filter-class "*MeetingsToolsTests"
 - `VitallyApiKeyProviderTests` — dev-fallback resolution (no SecretClient → returns `DevelopmentApiKey`; missing both → throws)
 - `VitallyServiceTests` — JSON field/trait filtering, pagination, resource-specific defaults, plus all six service methods (`GetResourcesAsync`, `GetResourceByIdAsync`, `CreateResourceAsync`, `UpdateResourceAsync`, `DeleteResourceAsync`, `GetRawAsync`, `PostRawAsync`, `DeleteRawAsync`) including HTTP-verb / URL / auth-header verification via Moq protected verification
 - `VitallyRateLimitHandlerTests` — 429 retry behaviour, header parsing, low-remaining warnings
+- `OAuthProxyResourceTerminationTests` — the proxy in the Entra posture (`OAuth:UpstreamResourceScope` set): `resource` dropped whatever its casing, still rejected when unpublished, the API scope merged into `scope` on both endpoints without duplicating or displacing the client's own, and advertised in both metadata documents. A separate fixture from the sibling proxy classes because the switch is composition-time and **both** postures must stay pinned — the relay is what a rollback returns to
+- `StaleEntitlementCompositionTests` — the serve-stale-on-Graph-failure path through a composed host, across an outage that starts, is survived and then outlasts its window; also pins that a token claim cannot authorise once the live check is on
 - `UpstreamOidcMetadataTests` / `UpstreamOidcStartupFailFastTests` — the OIDC-discovery resolver (all four endpoints, cache reuse, last-known-good on a failed refresh, rejection of an incomplete or malformed document) and the startup fail-fast wired into `Program.cs`
 - `Tools/*ToolsTests` — one test class per `Tools/*Tools.cs`, covering every public `[McpServerTool]` method (list/get/create/update/delete plus sub-resources)
 
 **When adding a new tool method:** add a matching test in the appropriate `*ToolsTests.cs` file. Use `TestHelpers.BuildVitallyService(httpClient)` — it builds a `VitallyService` with a stub `VitallyApiKeyProvider` that returns a fixed test API key (no Key Vault required).
 
-**Manual testing considerations** (require live Vitally credentials and a real Auth0-issued token in production):
+**Manual testing considerations** (require live Vitally credentials and a real Entra-issued token in production):
 - Test pagination by using low limit values (e.g., `limit=5`) and verify `from` parameter works with `next` cursor
 - Test client-side field filtering by specifying various field combinations
 - Test trait filtering by combining `fields="traits"` with `traits="trait1,trait2"`
 - For accounts, test the status filter with: `active`, `churned`, `activeOrChurned`
 - For meetings, test the `archived` filter
-- For local dev without Auth0, set `OAuth__NoAuth=true` and `Vitally__DevelopmentApiKey=<your key>`
+- For local dev without an identity provider, set `OAuth__NoAuth=true` and `Vitally__DevelopmentApiKey=<your key>`
 - Verify error handling with invalid IDs / missing config
 
 ## Deployment
 
-The deployment shape is **Azure Container Apps + Azure Key Vault + Auth0** (with Auth0 federating to Microsoft Entra for FISCAL employee sign-in), and the container image hosted in Azure Container Registry. `.github/workflows/deploy.yml` builds the image, imports it into the private ACR (via GitHub OIDC, no long-lived credentials) and rolls a Container App to the new revision.
+The deployment shape is **Azure Container Apps + Azure Key Vault + Microsoft Entra**, and the container image hosted in Azure Container Registry. `.github/workflows/deploy.yml` builds the image, imports it into the private ACR (via GitHub OIDC, no long-lived credentials) and rolls a Container App to the new revision.
 
 **It deploys to one of two targets, and the target is a GitHub *environment* name:** `production`
 (the default, and what the nightly release train ships to) or `staging` — see the staging section
@@ -794,8 +839,8 @@ than deploying somewhere unintended.
 | Identity | User-assigned managed identity | `AcrPull` on the registry + `Key Vault Secrets User` on the vault |
 | Image registry | Azure Container Registry (Premium SKU) | `vitally-mcp:sha-<short-sha>` tag per build; untagged purged after 7 days; ACR Task weekly purge keeps last 5 tags / 30 days |
 | Logs | Log Analytics (attached to the CAE) | + Application Insights for traces |
-| Auth | Auth0 tenant `fiscal-it.uk.auth0.com` | Two Resource Servers, one per origin: `https://vitally.fiscaltec.com/` and `https://vitally-staging.fiscaltec.com/` (trailing slash — identifiers are exact-match and immutable). **One** shared client (`Vitally MCP`) carrying both origins' `/oauth/callback`, so both targets use the same `SharedClientId` / `SharedClientSecret`. Post-login Action sets the `secret_ref` claim; tenant has **Resource Parameter Compatibility Profile** enabled to stop `resource=` forwarding to the Entra federation — and still needs it, since the proxy validates but does not terminate `resource` until the cutover |
-| Identity (Entra, provisioned but inert) | App registration `Vitally MCP` `c3812e7d-a413-4169-b57e-803326611ba3` | Provisioned by #107 on 2026-09-02 and **not yet used by anything** — the cutover (#108) is what points `OAuth:Authority` at it. Both OAuth client and API resource in one registration; App ID URI `https://vitally.fiscaltec.com` (no slash), exposes `mcp.access`, both origins' `/oauth/callback`, `appRoleAssignmentRequired` with the same seven department groups assigned **directly** (nesting does not grant sign-in). Secret `entra-mcp-client-secret` in the vault, expires **2027-03-01** — 180 days, the standard `scan/run.py` asserts. A rotation commitment Auth0 did not carry, and a hard outage date: Key Vault refuses to read an expired secret rather than merely warning. The expiry is set on the *Key Vault secret* as well as the Entra credential, because the scanner alerts on the former and knows nothing about Entra. `vitally-shared` was brought onto the same standard at the same time (2027-02-14, 180 days from its own creation). See `docs/runbooks/entra-app-registration.md` |
+| Auth | Entra app registration `Vitally MCP` `c3812e7d-a413-4169-b57e-803326611ba3` | Both the OAuth client and the API resource in one registration, which is why `SharedClientId` is also a valid `aud`. App ID URI `https://vitally.fiscaltec.com` (no slash), exposes `mcp.access`, carries both origins' `/oauth/callback`, so both targets share one `SharedClientId` / `SharedClientSecret`. `appRoleAssignmentRequired` with seven department groups assigned **directly** (nesting does not grant sign-in). Secret `entra-mcp-client-secret` in the vault, expires **2027-03-01** — 180 days, the standard `scan/run.py` asserts. A rotation commitment Auth0 did not carry, and a hard outage date: Key Vault refuses to read an expired secret rather than merely warning. The expiry is set on the *Key Vault secret* as well as the Entra credential, because the scanner alerts on the former and knows nothing about Entra. `vitally-shared` is on the same standard (2027-02-14). See `docs/runbooks/entra-app-registration.md` |
+| Auth (Auth0, retained for rollback only) | Tenant `fiscal-it.uk.auth0.com` | Nothing routes through it since the #108 cutover. Its client, the two Resource Servers and the `Vitally MCP claims` Action are deliberately **left in place** until production has soaked on Entra — deleting them early turns a one-command rollback into an outage. Removing them is a separate, later step. The tenant itself stays regardless: it hosts Simple Asset System, its API and a Terraform client |
 | CI/CD | GitHub Actions → OIDC federation → Azure | Reusable `deploy.yml` (build → GHCR → `az acr import` → roll, with smoke + rollback — the smoke covers `/health`, the exact-401 challenge **and** the OAuth metadata documents); nightly `release.yml` cuts a semver tag + GitHub Release, then deploys it — freeze by disabling the workflow, see the deploy-freeze note below; OIDC, no long-lived secrets in GitHub |
 | IaC | Terraform (`infra/terraform/`) | Infrastructure-as-code is in this repo at `infra/terraform/` (adopted via import blocks; see `infra/terraform/README.md`). The `deploy.yml` workflow consumes whatever that provisions. |
 | IaC — Entra | `infra/terraform/entra.tf` + the `azuread` provider | Added by #107. Same adopt-by-import convention, but it is the **first non-`azurerm` provider here**, so `terraform init` must be re-run before any plan. The client secret and the admin-consent grant are deliberately *not* modelled — state would hold the secret value, and the vault is private-endpoint only so Terraform cannot write it from outside the VNet regardless |
@@ -829,29 +874,26 @@ validating straight against production is the failure mode a staging-first desig
 registration be reused across a multi-run validation.
 
 **What it shares with production, deliberately:** the CAE, the managed identity, the ACR, the Key
-Vault *and its `vitally-shared` secret*, the `sg-vitally-*` tier group ids, and the single Auth0
-client. Sharing is the point — a staging environment that differs in more than the thing under test
-cannot tell you whether a failure is the change or the environment.
+Vault *and its `vitally-shared` secret*, the `sg-vitally-*` tier group ids, and the single Entra app
+registration. Sharing is the point — a staging environment that differs in more than the thing under
+test cannot tell you whether a failure is the change or the environment.
 
-**What diverges:** `OAuth__Audience` / `OAuth__Resource` (`https://vitally-staging.fiscaltec.com/`,
-its own Auth0 Resource Server), `OAuth__PublicBaseUrl`, `minReplicas: 0`, and — at #108 —
-`OAuth__Authority`, which staging flips to Entra first while production stays on Auth0.
+**What diverges:** `OAuth__Resource` and `OAuth__PublicBaseUrl` (both naming the staging origin) and
+`minReplicas: 0`. During an identity-provider migration `OAuth__Authority` diverges too, while
+staging runs the new provider ahead of production — that is what it is for.
 
-**Two divergences that will cost you time if you meet them cold:**
+**`OAuth__Audience` on staging names *production*, and that is correct.** One app registration serves
+both origins, so a staging token's `aud` is production's App ID URI while its `OAuth__Resource` must
+still be the staging origin (clients reject a metadata document whose `resource` is not the server
+they fetched it from). So the two diverge by **host as well as by slash** here. It looks like a
+copy-paste error and is not; see the divergence warning under *Configuration*.
 
-- **A staging token carries no `permissions` claim.** The post-login Action's guard is
-  `if (event.resource_server?.identifier !== 'https://vitally.fiscaltec.com/') return;`, so it mints
-  nothing for the staging audience. That is harmless today because `Authorization:LiveGroupCheck` is
-  `true` on both targets and entitlement comes from Graph `transitiveMembers` — but it does mean
-  staging has **no claim-based fallback tier**: a Graph failure denies on staging where production
-  would still degrade to the claim. Do **not** "fix" this by widening the Action's guard. The Action
-  and its claim disappear at cutover, so the work would be thrown away, and the divergence is in the
-  safe direction.
-- **There is one Vitally tenant and its API keys are global.** Staging reads the *production*
-  `vitally-shared` secret, so its write and delete tools mutate real customer data — there is no
-  sandbox to point it at. `Authorization:ReadOnly=true` is deliberately **not** set, because #108's
-  acceptance test needs the write tools visible to prove a reader is denied one. So staging is
-  read-only by convention, not by configuration.
+**One divergence that will cost you time if you meet it cold: there is one Vitally tenant and its API
+keys are global.** Staging reads the *production* `vitally-shared` secret, so its write and delete
+tools mutate real customer data — there is no sandbox to point it at. `Authorization:ReadOnly=true`
+is deliberately **not** set, because the tier-enforcement acceptance test needs the write tools
+visible to prove a reader is denied one. So staging is read-only by convention, not by
+configuration.
 
 **The custom domain is bound out of band**, as production's is. `fiscaltec.com` is on Cloudflare, so
 DNS is not in `infra/terraform/`: the zone needs an **un-proxied** (DNS-only) `CNAME` from
@@ -869,8 +911,8 @@ multi-session exercise #112 was raised to end:
 | Keep | Why |
 |---|---|
 | The Cloudflare `CNAME` + `asuid.vitally-staging` `TXT` | Costs nothing while the app is gone. The `CNAME` target is deterministic (`<app-name>.<CAE default domain>`), so it keeps pointing at the right place after a recreate under the same name |
-| The Auth0 Resource Server `https://vitally-staging.fiscaltec.com/` | **Identifiers are immutable.** Deleting and recreating it per run is precisely the orphaning cost the stable hostname exists to avoid |
-| The staging `/oauth/callback` on the shared Auth0 client | Same reason, and it is inert while no app answers there |
+| The staging `/oauth/callback` on the shared Entra app registration | **Identifiers and redirect URIs are the thing a recreate must not have to re-agree.** It is inert while no app answers there, and deleting it per teardown is precisely the orphaning cost the stable hostname exists to avoid |
+| The Auth0 Resource Server `https://vitally-staging.fiscaltec.com/` | Only while the Auth0 rollback path is retained; it goes with the rest of the Auth0 configuration when that is retired |
 | The Entra staging redirect URI (#107) | Same reason |
 | The `staging` GitHub environment + its `CONTAINER_APP` / `PUBLIC_ORIGIN` variables | The workflow reads them; recreating them by hand invites a typo into the origin, which the preflight check would catch but only after a wasted run |
 | The federated credential and role assignments | See the identity note below |
@@ -904,7 +946,7 @@ grant needs admin consent, which is the only real friction.
 
 Evaluated on 2026-08-28 and deliberately not done. A `global` / `prod` / `dev` split is the right end
 state and the `global` tier already exists implicitly — the Premium ACR with CMK, the CMK vault, the
-Auth0 tenant and DNS are all genuinely shared but carry `prod` names. The cheap version, if it is ever
+Entra tenant and DNS are all genuinely shared but carry `prod` names. The cheap version, if it is ever
 picked up, is **not** full duplication: the VNet is `10.80.0.0/23` with only `10.80.0.0-.127`
 allocated, so a second `/27` app subnet and its own CAE drop in with no re-addressing, one NAT gateway
 serves multiple subnets in the same VNet, and both CAEs resolve the same private endpoints through the
@@ -957,6 +999,73 @@ Verified when written by running it both ways round: it **passes** against a loc
 #100) — including `jwks_uri: null` in the RFC 9728 document, the exact defect that makes the published
 `@modelcontextprotocol/client` reject the whole document.
 
+### The Auth0 → Entra cutover (#108) and its rollback
+
+Config-only, and deliberately so: the code shipped ahead of the switch and behaves identically until
+`OAuth__UpstreamResourceScope` is set, so **rolling back is reverting environment variables** — no
+redeploy, no revision pin. Keep it that way. If a future change ends up gated on the authority value,
+say so loudly rather than letting the rollback quietly stop being a config revert.
+
+Five variables per target, and the secret behind the sixth:
+
+| Variable | Auth0 | Entra |
+|---|---|---|
+| `OAuth__Authority` | `https://fiscal-it.uk.auth0.com/` | `https://login.microsoftonline.com/75bd6050-92a8-4bde-a406-50000b310c86/v2.0` |
+| `OAuth__Audience` | `https://vitally.fiscaltec.com/` | `https://vitally.fiscaltec.com` (**no slash**; staging uses this same production value) |
+| `OAuth__Resource` | origin + `/` | **unchanged** — each target keeps its own origin |
+| `OAuth__UpstreamResourceScope` | *(unset)* | `https://vitally.fiscaltec.com/mcp.access` |
+| `OAuth__SharedClientId` | `VgB00WSYN2V0KkhtYx3WZXYH9XRBvK1D` | `c3812e7d-a413-4169-b57e-803326611ba3` |
+
+`OAuth__SharedClientSecret` stays a `secretRef` to the Container App secret
+`oauth-shared-client-secret`; what changes is that secret's **value**, which is copied from the Key
+Vault secret `entra-mcp-client-secret`. Reading it needs the two-switch Key Vault window described in
+`docs/runbooks/entra-app-registration.md` — and note the egress IP must be resolved with `curl -4`,
+because this workstation now egresses over IPv6 by default and Key Vault network ACLs are IPv4-only,
+which fails the rule add outright rather than degrading.
+
+**Order matters in one place only:** deploy the code before flipping the variables. With the scope
+unset the new code is the old behaviour, so the deploy is a no-op and the flip is the whole change.
+
+#### What a cutover can be verified against without a browser
+
+Everything below was run against staging before production; re-run it after any identity change.
+Together it covers every failure mode except "a real user cannot sign in", which needs a person.
+
+1. `bash .github/scripts/verify-oauth-metadata.sh <origin>` — 11 assertions. `jwks_uri` and
+   `userinfo_endpoint` coming back on `login.microsoftonline.com` / `graph.microsoft.com` is #104's
+   payoff visible: they are read from the provider's discovery document, and no choice of
+   `OAuth:Authority` could concatenate them.
+2. The app **starting at all** proves `StartupGuards.EnsureUpstreamOidcEndpointsAsync` fetched that
+   document and matched its `issuer` to `OAuth:Authority`. A wrong authority is a boot failure, not a
+   sign-in failure.
+3. `GET /oauth/authorize?…` — read the `Location` and assert on its query: upstream endpoint is the
+   provider's, `resource` is **absent**, `scope` carries the API scope appended to the client's own,
+   `redirect_uri` is our fixed callback.
+4. **Follow that `Location` to the provider.** Its sign-in page (HTTP 200, `urlLogin` in the body)
+   means every parameter was accepted; an `AADSTS` code means one was not. This is the check that
+   catches a wrong `client_id`, an unregistered `redirect_uri` or a malformed scope, and it needs no
+   credentials.
+5. `POST /mcp` unauthenticated → exactly **401** with `WWW-Authenticate: Bearer resource_metadata=…`;
+   with a junk token → 401 plus `error="invalid_token"`. `deploy.yml` smoke-tests the status and
+   rolls back if it changes.
+6. `/oauth/authorize` with a `resource` we do not publish → **400 `invalid_target`**; with the
+   published one → **302**. Terminating the parameter must not have become ignoring it.
+7. `POST /oauth/register` → the DCR shim returns the new `client_id`.
+
+**What is left for a person**, because it needs a real token: sign-in per tier, `tools/list` as a
+**department-nested** user (not a directly-assigned admin — every tier but `sg-vitally-admins` is
+granted by nesting, and the #102 spike produced three wrong conclusions by reasoning about nesting
+instead of testing it), a reader being denied a write tool, and decoding the token for `aud`, `iss`
+and `oid`.
+
+#### Rollback
+
+Revert the five variables on the affected target and restore the Container App secret to the Auth0
+client secret. The Auth0 client, both Resource Servers and the `Vitally MCP claims` Action are
+retained precisely so this stays one operation — **do not delete them until production has soaked**,
+and note that the Action's guard means an Auth0 rollback of *staging* mints no `permissions` claim
+there. That is harmless: entitlement comes from Graph on both targets either way.
+
 ### Freezing deploys
 
 **`gh workflow disable release.yml`** (re-enable with `gh workflow enable release.yml`). That is the
@@ -996,4 +1105,4 @@ tell: the release train passes `image_tag: <semver>`, whereas a manual dispatch 
 `sha-<short-sha>`, so the deployed image name says which path shipped it
 (`az containerapp show ... --query properties.template.containers[0].image`).
 
-Infrastructure-as-code is in this repo at `infra/terraform/` — the table above documents the runtime contract for what `deploy.yml` expects. Anyone replicating can swap Container Apps for App Service, ACR for GHCR, Auth0 for Keycloak, etc., without touching the application code.
+Infrastructure-as-code is in this repo at `infra/terraform/` — the table above documents the runtime contract for what `deploy.yml` expects. Anyone replicating can swap Container Apps for App Service, ACR for GHCR, Entra for Keycloak, etc., without touching the application code — `OAuth:UpstreamResourceScope` is the one setting whose value is provider-shaped, and it is a value rather than a branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1062,7 +1062,8 @@ Together it covers every failure mode except "a real user cannot sign in", which
 **department-nested** user (not a directly-assigned admin — every tier but `sg-vitally-admins` is
 granted by nesting, and the #102 spike produced three wrong conclusions by reasoning about nesting
 instead of testing it), a reader being denied a write tool, and decoding the token for `aud`, `iss`
-and `oid`.
+and `oid`. Written out as a checklist in `docs/runbooks/entra-cutover-staging-validation.md`, which
+also records what has already been machine-verified so it is not repeated.
 
 #### Rollback
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -990,6 +990,12 @@ Three things about it that are deliberate and shouldn't be "tidied":
 
 - **No normalisation anywhere.** Trailing slashes and case are compared literally, because that is
   what clients do — a check that tolerated a difference would pass configurations clients reject.
+- **A first manual run against staging can fail spuriously, and it is not a regression.** Staging is
+  `minReplicas: 0`, the script retries each *fetch* only twice, and a cold start can burn both — the
+  symptom is `200 but the body is not valid JSON` on the protected-resource documents, which look
+  perfectly valid the moment you curl them by hand. CI never sees it because the `/health` smoke runs
+  first and warms the replica. Warm it yourself (`curl <origin>/health`) before reading anything into
+  a manual failure.
 - **It is invoked through `bash`**, not by its executable bit. The repo is authored on Windows with
   `core.filemode=false`, so an edit can silently drop the mode; relying on it would surface as
   "Permission denied" during a deploy rather than in review.

--- a/VitallyMcp.Tests/IntegrationTestCollection.cs
+++ b/VitallyMcp.Tests/IntegrationTestCollection.cs
@@ -10,8 +10,9 @@ namespace VitallyMcp.Tests;
 ///
 /// <para>
 /// Member classes: <see cref="ReadOnlyToolsListTests"/>, <see cref="ToolsListCachingTests"/>,
-/// <see cref="AuthorizationFilterToolsListTests"/>, <see cref="ResourceMetadataDiscoveryTests"/> and
-/// <see cref="ServerInstructionsInitializeTests"/>. Keep this list complete — it is what a future
+/// <see cref="AuthorizationFilterToolsListTests"/>, <see cref="ResourceMetadataDiscoveryTests"/>,
+/// <see cref="ServerInstructionsInitializeTests"/> and
+/// <see cref="StaleEntitlementCompositionTests"/>. Keep this list complete — it is what a future
 /// author reads when deciding whether a new environment-variable-mutating class needs to join, and
 /// an incomplete list makes the collection look narrower in purpose than it is.
 /// <see cref="ServerInstructionsInitializeTests"/> is the sharpest illustration

--- a/VitallyMcp.Tests/OAuthOptionsTests.cs
+++ b/VitallyMcp.Tests/OAuthOptionsTests.cs
@@ -344,6 +344,100 @@ public class OAuthOptionsTests
         options.IsResourceIndicatorAllowed("https://anything.example.com/").Should().BeTrue();
     }
 
+    // ---- UpstreamResourceScope: the Auth0-relay / Entra-terminate switch (#105 part B, #108) ----
+
+    [Fact]
+    public void TerminatesResourceParameter_IsFalse_WhenNoUpstreamScopeIsConfigured()
+    {
+        // The Auth0 posture, and the default: `resource` is relayed, because the tenant's Resource
+        // Parameter Compatibility Profile consuming it is the only thing binding the audience there.
+        new OAuthOptions().TerminatesResourceParameter.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Validate_RejectsAnUpstreamResourceScopeContainingWhitespace()
+    {
+        // It names exactly one resource — the one whose `resource` parameter it stands in for — and
+        // whitespace would smuggle extra scopes into every authorize request this server makes.
+        var options = new OAuthOptions
+        {
+            Authority = "https://example.auth0.com/",
+            Audience = "https://api.example.com",
+            UpstreamResourceScope = "https://api.example.com/mcp.access openid"
+        };
+
+        options.Invoking(o => o.Validate()).Should().Throw<InvalidOperationException>()
+            .WithMessage("*UpstreamResourceScope*");
+    }
+
+    [Fact]
+    public void Validate_TrimsTheUpstreamResourceScope()
+    {
+        var options = new OAuthOptions
+        {
+            Authority = "https://example.auth0.com/",
+            Audience = "https://api.example.com",
+            UpstreamResourceScope = "  https://api.example.com/mcp.access  "
+        };
+        options.Validate();
+
+        options.UpstreamResourceScope.Should().Be("https://api.example.com/mcp.access");
+        options.TerminatesResourceParameter.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("", "https://api.example.com/mcp.access")]
+    [InlineData("openid profile", "openid profile https://api.example.com/mcp.access")]
+    [InlineData("  openid   profile  ", "openid profile https://api.example.com/mcp.access")]
+    [InlineData("openid https://api.example.com/mcp.access", "openid https://api.example.com/mcp.access")]
+    public void MergeUpstreamScope_AppendsOnceAndPreservesTheClientsOwnScopes(string requested, string expected)
+    {
+        // Dropping a client scope here would have consequences well past this method: losing
+        // offline_access costs the refresh token, and the failure would surface an hour later.
+        var options = new OAuthOptions { UpstreamResourceScope = "https://api.example.com/mcp.access" };
+
+        options.MergeUpstreamScope(requested).Should().Be(expected);
+    }
+
+    [Fact]
+    public void MergeUpstreamScope_DoesNotDuplicateOnACasingDifference()
+    {
+        // RFC 6749 §3.3 makes scope tokens case-sensitive, so this is deliberate leniency: a
+        // duplicate is a request the provider rejects, which is strictly worse than accepting the
+        // client's spelling of a scope it evidently already has.
+        var options = new OAuthOptions { UpstreamResourceScope = "https://api.example.com/mcp.access" };
+
+        options.MergeUpstreamScope("openid HTTPS://API.EXAMPLE.COM/MCP.ACCESS")
+            .Should().Be("openid HTTPS://API.EXAMPLE.COM/MCP.ACCESS");
+    }
+
+    // ---- ValidAudiences ----
+
+    [Fact]
+    public void ValidAudiences_CarriesBothTheAppIdUriAndTheClientId()
+    {
+        // An Entra v1 access token names the App ID URI; a v2 token names the resource
+        // application's appId GUID — and one registration is both our client and our API, so that
+        // GUID is SharedClientId. Accepting each settles which one arrives rather than betting.
+        var options = new OAuthOptions
+        {
+            Audience = "https://vitally.fiscaltec.com",
+            SharedClientId = "c3812e7d-a413-4169-b57e-803326611ba3"
+        };
+
+        options.ValidAudiences.Should().BeEquivalentTo(
+            new[] { "https://vitally.fiscaltec.com", "c3812e7d-a413-4169-b57e-803326611ba3" });
+    }
+
+    [Fact]
+    public void ValidAudiences_OmitsAnUnconfiguredSharedClientId()
+    {
+        // A null or empty entry in ValidAudiences is not inert — it would be compared against the
+        // token's `aud` like any other candidate.
+        new OAuthOptions { Audience = "https://api.example.com" }.ValidAudiences
+            .Should().ContainSingle().Which.Should().Be("https://api.example.com");
+    }
+
     private static OAuthOptions ValidOptions(string[] allowedRedirectUris)
     {
         var options = new OAuthOptions

--- a/VitallyMcp.Tests/OAuthOptionsTests.cs
+++ b/VitallyMcp.Tests/OAuthOptionsTests.cs
@@ -363,11 +363,12 @@ public class OAuthOptionsTests
         {
             Authority = "https://example.auth0.com/",
             Audience = "https://api.example.com",
+            SharedClientId = "test-client-id",
             UpstreamResourceScope = "https://api.example.com/mcp.access openid"
         };
 
         options.Invoking(o => o.Validate()).Should().Throw<InvalidOperationException>()
-            .WithMessage("*UpstreamResourceScope*");
+            .WithMessage("*whitespace*");
     }
 
     [Fact]
@@ -377,6 +378,7 @@ public class OAuthOptionsTests
         {
             Authority = "https://example.auth0.com/",
             Audience = "https://api.example.com",
+            SharedClientId = "test-client-id",
             UpstreamResourceScope = "  https://api.example.com/mcp.access  "
         };
         options.Validate();
@@ -409,6 +411,24 @@ public class OAuthOptionsTests
 
         options.MergeUpstreamScope("openid HTTPS://API.EXAMPLE.COM/MCP.ACCESS")
             .Should().Be("openid HTTPS://API.EXAMPLE.COM/MCP.ACCESS");
+    }
+
+    [Fact]
+    public void Validate_RejectsAnUpstreamResourceScopeWithNoProxyToApplyIt()
+    {
+        // Both halves of the switch live in /oauth/authorize and /oauth/token, so with no
+        // SharedClientId the setting does nothing — while `scopes_supported` still advertises the
+        // scope, making the configuration read as switched on. Fail at boot rather than let someone
+        // conclude from the metadata document that termination is happening.
+        var options = new OAuthOptions
+        {
+            Authority = "https://example.auth0.com/",
+            Audience = "https://api.example.com",
+            UpstreamResourceScope = "https://api.example.com/mcp.access"
+        };
+
+        options.Invoking(o => o.Validate()).Should().Throw<InvalidOperationException>()
+            .WithMessage("*SharedClientId*");
     }
 
     // ---- ValidAudiences ----

--- a/VitallyMcp.Tests/OAuthProxyResourceTerminationTests.cs
+++ b/VitallyMcp.Tests/OAuthProxyResourceTerminationTests.cs
@@ -38,11 +38,12 @@ public class OAuthProxyResourceTerminationTests : IClassFixture<OAuthProxyResour
     [InlineData("https://vitally.example.com/")]
     public async Task Authorize_DropsAMatchingResourceInsteadOfForwardingIt(string resource)
     {
-        // The failure this prevents is AADSTS9010010: Entra matches `resource` exactly against a
-        // registered identifier and rejects the trailing-slash form MCP clients send — which
-        // IsResourceIndicatorAllowed deliberately accepts, because that slash is the difference
-        // between what Entra will register and what Claude Code normalises to. Both spellings are
-        // exercised: the parameter has to disappear whichever one arrives.
+        // The failure this prevents is AADSTS9010010, and it is not slash-specific: Entra's v2
+        // authorize endpoint refuses any `resource` that does not match the requested scopes, and
+        // against the live tenant the slashed form, the exact App ID URI and an unregistered value
+        // all returned 400 alike. Both spellings are exercised here because
+        // IsResourceIndicatorAllowed accepts both — so both reach this point, and the parameter has
+        // to disappear whichever one arrives.
         using var client = NoRedirect(_factory);
 
         var response = await client.GetAsync(

--- a/VitallyMcp.Tests/OAuthProxyResourceTerminationTests.cs
+++ b/VitallyMcp.Tests/OAuthProxyResourceTerminationTests.cs
@@ -1,0 +1,236 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace VitallyMcp.Tests;
+
+/// <summary>
+/// The proxy with <c>OAuth:UpstreamResourceScope</c> set — the Entra posture (#105 part B / #108).
+/// The sibling proxy classes cover the Auth0 posture, where <c>resource</c> is validated and then
+/// relayed; here it is validated and then <b>terminated</b>, with the configured scope carrying the
+/// same meaning upstream.
+/// </summary>
+/// <remarks>
+/// A separate fixture rather than extra cases on the existing ones, because the switch is a
+/// composition-time option and the two postures must both stay pinned: the Auth0 relay is still live
+/// in production until the cutover deploys, and it is what a rollback returns to.
+/// </remarks>
+public class OAuthProxyResourceTerminationTests : IClassFixture<OAuthProxyResourceTerminationTests.Factory>
+{
+    /// <summary>The App ID URI + exposed scope, in the shape Entra requires on a custom API.</summary>
+    private const string ApiScope = "https://vitally.example.com/mcp.access";
+
+    private readonly Factory _factory;
+
+    public OAuthProxyResourceTerminationTests(Factory factory) => _factory = factory;
+
+    private static HttpClient NoRedirect(Factory factory) =>
+        factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+    [Theory]
+    [InlineData("https://vitally.example.com")]
+    [InlineData("https://vitally.example.com/")]
+    public async Task Authorize_DropsAMatchingResourceInsteadOfForwardingIt(string resource)
+    {
+        // The failure this prevents is AADSTS9010010: Entra matches `resource` exactly against a
+        // registered identifier and rejects the trailing-slash form MCP clients send — which
+        // IsResourceIndicatorAllowed deliberately accepts, because that slash is the difference
+        // between what Entra will register and what Claude Code normalises to. Both spellings are
+        // exercised: the parameter has to disappear whichever one arrives.
+        using var client = NoRedirect(_factory);
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=drop-resource"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback")
+            + "&resource=" + Uri.EscapeDataString(resource));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        QueryHelpers.ParseQuery(response.Headers.Location!.Query).Should().NotContainKey("resource");
+    }
+
+    [Fact]
+    public async Task Authorize_DropsAResourceWhateverItsCasing()
+    {
+        // IQueryCollection lookups are case-insensitive so an oddly-cased key is *validated*, but
+        // enumeration yields keys as parsed — an exact-match skip would forward `RESOURCE` intact
+        // and undo the whole change for that request.
+        using var client = NoRedirect(_factory);
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=drop-resource-cased"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback")
+            + "&RESOURCE=" + Uri.EscapeDataString("https://vitally.example.com/"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        QueryHelpers.ParseQuery(response.Headers.Location!.Query).Keys
+            .Should().NotContain(k => string.Equals(k, "resource", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Authorize_StillRejectsAResourceWeDoNotPublish()
+    {
+        // Terminating the parameter must not quietly become ignoring it. The check is about which
+        // audience a caller may ask to be bound to, so it survives the change unaltered.
+        using var client = NoRedirect(_factory);
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=still-validated"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback")
+            + "&resource=" + Uri.EscapeDataString("https://evil.example.com/"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("invalid_target");
+    }
+
+    [Fact]
+    public async Task Authorize_AppendsTheApiScopeToWhatTheClientAskedFor()
+    {
+        using var client = NoRedirect(_factory);
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=scope-appended"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback")
+            + "&scope=" + Uri.EscapeDataString("openid profile offline_access"));
+
+        var scope = QueryHelpers.ParseQuery(response.Headers.Location!.Query)["scope"];
+        scope.Count.Should().Be(1, "two scope parameters is a malformed request upstream");
+        scope[0]!.Split(' ').Should().BeEquivalentTo(
+            new[] { "openid", "profile", "offline_access", ApiScope },
+            "the client's own scopes must survive — dropping offline_access would cost the refresh token");
+    }
+
+    [Fact]
+    public async Task Authorize_SendsTheApiScopeEvenWhenTheClientAsksForNone()
+    {
+        // Without this the access token names no resource at all: the proxy sends no `audience`
+        // parameter anywhere, and `resource` is no longer forwarded either.
+        using var client = NoRedirect(_factory);
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=scope-invented"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback"));
+
+        QueryHelpers.ParseQuery(response.Headers.Location!.Query)["scope"].ToString().Should().Be(ApiScope);
+    }
+
+    [Fact]
+    public async Task Authorize_DoesNotRepeatTheApiScopeAClientAlreadyRequested()
+    {
+        // Clients build their request from `scopes_supported`, which now advertises this exact
+        // value — so the common case is that it is already there.
+        using var client = NoRedirect(_factory);
+
+        var response = await client.GetAsync(
+            "/oauth/authorize?response_type=code&client_id=test&state=scope-deduped"
+            + "&redirect_uri=" + Uri.EscapeDataString("http://localhost:54321/callback")
+            + "&scope=" + Uri.EscapeDataString("openid " + ApiScope));
+
+        QueryHelpers.ParseQuery(response.Headers.Location!.Query)["scope"].ToString()
+            .Should().Be("openid " + ApiScope);
+    }
+
+    [Fact]
+    public async Task Token_DropsResourceAndSendsTheApiScopeInstead()
+    {
+        using var client = _factory.CreateClient();
+
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = "test-code",
+            ["redirect_uri"] = "http://localhost:54321/callback",
+            ["resource"] = "https://vitally.example.com/"
+        });
+        var response = await client.PostAsync("/oauth/token", form);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = _factory.Upstream.RequestBodies.Last();
+        body.Should().NotContain("resource=");
+        body.Should().Contain("scope=" + Uri.EscapeDataString(ApiScope));
+    }
+
+    [Fact]
+    public async Task Token_NamesTheApiOnARefreshExchangeTheClientScopedToOidcOnly()
+    {
+        // The load-bearing case for merging on the token endpoint as well. Entra issues the new
+        // access token for whatever resource `scope` names, so a refresh carrying only the OIDC
+        // scopes would silently hand back a token for the wrong audience — which fails at /mcp,
+        // hours after the sign-in that looked fine.
+        using var client = _factory.CreateClient();
+
+        using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = "test-refresh",
+            ["scope"] = "openid profile offline_access"
+        });
+        var response = await client.PostAsync("/oauth/token", form);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = _factory.Upstream.RequestBodies.Last();
+        var scope = QueryHelpers.ParseQuery("?" + body)["scope"];
+        scope.Count.Should().Be(1);
+        scope[0]!.Split(' ').Should().Contain(ApiScope);
+    }
+
+    [Theory]
+    [InlineData("/.well-known/oauth-authorization-server")]
+    [InlineData("/.well-known/oauth-protected-resource")]
+    public async Task Metadata_AdvertisesTheApiScopeInTheFormTheProviderAccepts(string path)
+    {
+        // Both documents, because clients read `scopes_supported` from whichever they reached and
+        // build their `scope` request from it. Advertising a bare `mcp.access` while forwarding to
+        // Entra breaks the flow before sign-in: a scope on a custom API must carry the App ID URI.
+        using var client = _factory.CreateClient();
+
+        using var doc = JsonDocument.Parse(await client.GetStringAsync(path));
+
+        var scopes = doc.RootElement.GetProperty("scopes_supported")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        scopes.Should().Contain(ApiScope);
+        scopes.Should().NotContain("mcp.access", "the bare name is the Auth0 spelling and Entra rejects it");
+    }
+
+    public class Factory : WebApplicationFactory<Program>
+    {
+        /// <summary>Stands in for the upstream token endpoint; records what the proxy sent it.</summary>
+        public StubOidcDiscovery.CapturingHandler Upstream { get; } =
+            new("""{"access_token":"test-access-token","token_type":"Bearer","expires_in":3600}""");
+
+        protected override IHost CreateHost(IHostBuilder builder)
+        {
+            builder.UseEnvironment(Environments.Development);
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["OAuth:NoAuth"] = "true",
+                    ["OAuth:Authority"] = StubOidcDiscovery.Issuer,
+                    // Audience without the slash and Resource with it, as they diverge under Entra:
+                    // Audience follows the App ID URI (Entra refuses to register a trailing slash),
+                    // Resource stays the form clients normalise to. IsResourceIndicatorAllowed
+                    // tolerating exactly one slash is what lets both spellings name one resource.
+                    ["OAuth:Audience"] = "https://vitally.example.com",
+                    ["OAuth:Resource"] = "https://vitally.example.com/",
+                    ["OAuth:UpstreamResourceScope"] = ApiScope,
+                    ["OAuth:SharedClientId"] = "test-client-id",
+                    ["Vitally:Region"] = "EU",
+                    ["Vitally:DevelopmentApiKey"] = "sk_test_dummy"
+                });
+            });
+            builder.ConfigureServices(services =>
+            {
+                services.UseStubDiscovery();
+                services.AddHttpClient(Options.DefaultName)
+                    .ConfigurePrimaryHttpMessageHandler(() => Upstream);
+            });
+            return base.CreateHost(builder);
+        }
+    }
+}

--- a/VitallyMcp.Tests/ResourceMetadataDiscoveryTests.cs
+++ b/VitallyMcp.Tests/ResourceMetadataDiscoveryTests.cs
@@ -105,8 +105,9 @@ public class ResourceMetadataDiscoveryTests : IClassFixture<ResourceMetadataDisc
         root.TryGetProperty("scopes_supported", out var scopes).Should().BeTrue(
             "clients use this to request the right scopes up front");
         scopes.EnumerateArray().Select(e => e.GetString()).Should()
-            .BeEquivalentTo(ProtectedResourceMetadataBuilder.SupportedScopes,
-                "the advertised scopes must match the builder's list exactly, with no duplicates");
+            .BeEquivalentTo(ProtectedResourceMetadataBuilder.BaseScopes.Append("mcp.access"),
+                "the advertised scopes must match the builder's list exactly, with no duplicates; "
+                + "this fixture leaves OAuth:UpstreamResourceScope unset, so the API scope is the bare Auth0 form");
     }
 
     [Theory]

--- a/VitallyMcp.Tests/StaleEntitlementCompositionTests.cs
+++ b/VitallyMcp.Tests/StaleEntitlementCompositionTests.cs
@@ -1,0 +1,285 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace VitallyMcp.Tests;
+
+/// <summary>
+/// The serve-stale-on-Graph-failure path (#106), observed through a composed host rather than by
+/// unit-testing the resolver.
+/// </summary>
+/// <remarks>
+/// <para>
+/// #106 shipped that path with unit coverage but it had <b>never been observed working</b>. Staging
+/// cannot close the gap: it shares the managed identity and the Container Apps Environment with
+/// production, so a Graph failure cannot be induced there in isolation. The cutover (#108) is where
+/// the gap stops being theoretical — with the token-claim tier removed, the stale copy is the
+/// <i>only</i> thing standing between a Graph outage and a total denial — so it is closed here.
+/// </para>
+/// <para>
+/// What this adds over <see cref="GraphGroupPermissionResolverTests"/> is composition. Those tests
+/// construct the resolver directly; this drives the real wiring — DI registration, the typed Graph
+/// <see cref="HttpClient"/>, the singleton <c>IMemoryCache</c> that carries the retained copy between
+/// requests, <see cref="ToolAuthorizer"/>, <see cref="VitallyPermissionHandler"/> and the SDK
+/// authorisation filter — and reads the outcome off <c>tools/list</c>, which is what a user sees. A
+/// resolver that behaved perfectly while (say) being handed a fresh cache per request would pass
+/// there and fail here.
+/// </para>
+/// </remarks>
+[Collection(IntegrationTestCollection.Name)]
+public class StaleEntitlementCompositionTests
+{
+    private const string ReaderGroup = "71451cc9-f5df-44ee-8ed1-3acc41a911eb";
+    private const string EditorGroup = "19b9d659-284c-4f93-b1c3-a6354db1027c";
+    private const string AdminGroup = "70b48a20-d4b1-47dc-a132-21bc99272a86";
+    private const string UserOid = "675ebdda-7590-4d79-8ec3-a2d17ab029ba";
+
+    private const int FreshSeconds = 60;
+    private const int StaleSeconds = 3600;
+
+    [Fact]
+    public async Task GraphOutage_ServesTheLastKnownGoodTier_ThenDeniesOnceItIsTooStale()
+    {
+        // One scenario in one host on purpose: the stale path only engages *after* a success, so the
+        // three phases are not separable into independent tests — the retained copy is the state
+        // that links them.
+        using var harness = new Harness(memberOf: [EditorGroup]);
+
+        var whileHealthy = await harness.ToolNamesAsync();
+        whileHealthy.Should().Contain(n => n.StartsWith("Create_", StringComparison.Ordinal),
+            "the editor tier is resolved from Graph while it is reachable");
+
+        // Past the fresh window, so the next call must actually ask Graph — and Graph is now down.
+        harness.Graph.Status = HttpStatusCode.ServiceUnavailable;
+        harness.Clock.Advance(TimeSpan.FromSeconds(FreshSeconds + 1));
+
+        var duringOutage = await harness.ToolNamesAsync();
+        duringOutage.Should().BeEquivalentTo(whileHealthy,
+            "a Graph outage must degrade to this caller's last known-good tier, not revoke it");
+
+        // Past the stale window as well. Bounded staleness is the trade #106 made: access is
+        // retained during an outage, but not indefinitely.
+        harness.Clock.Advance(TimeSpan.FromSeconds(StaleSeconds + 1));
+
+        var afterTheWindow = await harness.ToolNamesAsync();
+        afterTheWindow.Should().BeEmpty(
+            "once the retained copy is older than LiveGroupStaleSeconds there is nothing left to serve");
+    }
+
+    [Fact]
+    public async Task GraphOutage_DeniesEvenACallerWhoseTokenClaimGrantsTheTier()
+    {
+        // The cutover half of the same story (#108). Before it, exhausting the stale window fell
+        // through to the Auth0 post-login Action's `permissions` claim; the Action is gone, so the
+        // claim is permanently absent and that tier was removed rather than left reading like a
+        // working fallback. This principal carries the claim anyway — a version that still consulted
+        // it would show the full tool list here.
+        using var harness = new Harness(memberOf: [AdminGroup], tokenPermissions:
+            ["vitally:read", "vitally:write", "vitally:delete"]);
+
+        (await harness.ToolNamesAsync()).Should().NotBeEmpty("Graph is reachable to begin with");
+
+        harness.Graph.Status = HttpStatusCode.ServiceUnavailable;
+        harness.Clock.Advance(TimeSpan.FromSeconds(FreshSeconds + StaleSeconds + 1));
+
+        (await harness.ToolNamesAsync()).Should().BeEmpty(
+            "with the live check on, the token claim is not a source of entitlement any more");
+    }
+
+    [Fact]
+    public async Task RecoveredGraph_ReplacesTheRetainedTierRatherThanCompoundingIt()
+    {
+        // Guards the stale path against over-reach in the other direction: a retained copy must not
+        // outlive the outage that justified it. A revocation applied during the outage has to take
+        // effect on the first successful lookup afterwards, not at the end of the stale window.
+        using var harness = new Harness(memberOf: [AdminGroup]);
+
+        (await harness.ToolNamesAsync()).Should().Contain(n => n.StartsWith("Delete_", StringComparison.Ordinal));
+
+        harness.Graph.Status = HttpStatusCode.ServiceUnavailable;
+        harness.Clock.Advance(TimeSpan.FromSeconds(FreshSeconds + 1));
+        (await harness.ToolNamesAsync()).Should().Contain(n => n.StartsWith("Delete_", StringComparison.Ordinal),
+            "still inside the stale window");
+
+        // Graph comes back, and the user has been demoted to reader in the meantime.
+        harness.Graph.Status = HttpStatusCode.OK;
+        harness.Graph.MemberGroupIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ReaderGroup };
+        harness.Clock.Advance(TimeSpan.FromSeconds(1));
+
+        var afterRecovery = await harness.ToolNamesAsync();
+        afterRecovery.Should().Contain(n => n.StartsWith("List_", StringComparison.Ordinal));
+        afterRecovery.Should().NotContain(n => n.StartsWith("Delete_", StringComparison.Ordinal),
+            "the fresh answer is authoritative the moment Graph can give one");
+    }
+
+    /// <summary>
+    /// One composed host plus the two things a test needs to steer it: the clock the freshness and
+    /// staleness windows are measured against, and the Graph endpoint's health. Disposing it tears
+    /// the host down and restores the environment variables the composition root reads directly.
+    /// </summary>
+    private sealed class Harness : IDisposable
+    {
+        private readonly WebApplicationFactory<Program> _baseFactory;
+        private readonly WebApplicationFactory<Program> _factory;
+
+        public FakeClock Clock { get; } = new(new DateTimeOffset(2026, 9, 2, 12, 0, 0, TimeSpan.Zero));
+        public GraphHandler Graph { get; }
+
+        public Harness(string[] memberOf, string[]? tokenPermissions = null)
+        {
+            Graph = new GraphHandler(new HashSet<string>(memberOf, StringComparer.OrdinalIgnoreCase));
+
+            // Process-wide, and read by Program.cs at composition time before test configuration is
+            // injected — hence the collection this class belongs to. Set every one the sibling
+            // classes touch, so scheduling order cannot decide the outcome.
+            Environment.SetEnvironmentVariable("OAuth__NoAuth", "false");
+            Environment.SetEnvironmentVariable("Authorization__ReadOnly", "false");
+            Environment.SetEnvironmentVariable("Vitally__DevelopmentApiKey", "sk_test_dummy");
+            Environment.SetEnvironmentVariable("Vitally__Region", "EU");
+            Environment.SetEnvironmentVariable("OAuth__Authority", "https://example.auth0.com/");
+            Environment.SetEnvironmentVariable("OAuth__Audience", "https://example.test/");
+            Environment.SetEnvironmentVariable("Authorization__LiveGroupCheck", "true");
+            Environment.SetEnvironmentVariable("Authorization__LiveGroupCacheSeconds", FreshSeconds.ToString());
+            Environment.SetEnvironmentVariable("Authorization__LiveGroupStaleSeconds", StaleSeconds.ToString());
+            Environment.SetEnvironmentVariable("Authorization__ReaderGroupId", ReaderGroup);
+            Environment.SetEnvironmentVariable("Authorization__EditorGroupId", EditorGroup);
+            Environment.SetEnvironmentVariable("Authorization__AdminGroupId", AdminGroup);
+
+            _baseFactory = new WebApplicationFactory<Program>();
+            _factory = _baseFactory.WithWebHostBuilder(b => b.ConfigureServices(services =>
+            {
+                // Authenticate as a principal carrying `oid`, which is what makes ToolAuthorizer
+                // take the live group path at all.
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<TestAuthHandlerOptions, TestAuthHandler>(TestAuthHandler.SchemeName, o =>
+                    {
+                        o.ObjectId = UserOid;
+                        o.Permissions = tokenPermissions ?? [];
+                    });
+                services.Configure<AuthorizationOptions>(o =>
+                    o.DefaultPolicy = new AuthorizationPolicyBuilder(TestAuthHandler.SchemeName)
+                        .RequireAuthenticatedUser().Build());
+
+                // Registered after Program.cs's own, so these win: last registration is what
+                // GetRequiredService resolves, and the named-client options are merged by name.
+                services.AddSingleton<TokenCredential>(new StubTokenCredential());
+                services.AddSingleton<TimeProvider>(Clock);
+                services.AddHttpClient<IGroupPermissionResolver, GraphGroupPermissionResolver>()
+                    .ConfigurePrimaryHttpMessageHandler(() => Graph);
+            }));
+        }
+
+        /// <summary>Tool names this caller is shown, which is the authorisation outcome made visible.</summary>
+        public async Task<IReadOnlyList<string>> ToolNamesAsync()
+        {
+            using var client = _factory.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+            {
+                Content = new StringContent(
+                    """{"jsonrpc":"2.0","id":1,"method":"tools/list"}""", Encoding.UTF8, "application/json")
+            };
+            request.Headers.TryAddWithoutValidation("Accept", "application/json, text/event-stream");
+
+            using var response = await client.SendAsync(request);
+            var raw = await response.Content.ReadAsStringAsync();
+            var json = raw.Contains("data:", StringComparison.Ordinal)
+                ? raw.Split('\n').First(l => l.TrimStart().StartsWith("data:", StringComparison.Ordinal))
+                    .Trim()["data:".Length..].Trim()
+                : raw;
+
+            using var doc = JsonDocument.Parse(json);
+            doc.RootElement.TryGetProperty("error", out var error).Should().BeFalse(
+                $"tools/list must succeed even when the caller is entitled to nothing, but the server returned {error}");
+
+            return doc.RootElement.GetProperty("result").GetProperty("tools")
+                .EnumerateArray().Select(t => t.GetProperty("name").GetString()!).ToList();
+        }
+
+        public void Dispose()
+        {
+            // Both, deliberately: WithWebHostBuilder returns a new factory rather than mutating the
+            // receiver, so disposing only the result leaks the one the constructor made.
+            _factory.Dispose();
+            _baseFactory.Dispose();
+
+            foreach (var name in new[]
+            {
+                "OAuth__NoAuth", "Authorization__ReadOnly", "Vitally__DevelopmentApiKey", "Vitally__Region",
+                "OAuth__Authority", "OAuth__Audience", "Authorization__LiveGroupCheck",
+                "Authorization__LiveGroupCacheSeconds", "Authorization__LiveGroupStaleSeconds",
+                "Authorization__ReaderGroupId", "Authorization__EditorGroupId", "Authorization__AdminGroupId"
+            })
+            {
+                Environment.SetEnvironmentVariable(name, null);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Controllable clock. The freshness and staleness decisions are age comparisons against
+    /// <see cref="TimeProvider"/>, and <see cref="Microsoft.Extensions.Caching.Memory.MemoryCache"/>
+    /// expiry runs on the real clock and cannot be wound forward — so the windows are only reachable
+    /// through this.
+    /// </summary>
+    private sealed class FakeClock(DateTimeOffset start) : TimeProvider
+    {
+        private DateTimeOffset _now = start;
+        public override DateTimeOffset GetUtcNow() => _now;
+        public void Advance(TimeSpan by) => _now += by;
+    }
+
+    private sealed class StubTokenCredential : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new("test-graph-token", DateTimeOffset.MaxValue);
+
+        public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+            => new(GetToken(requestContext, cancellationToken));
+    }
+
+    /// <summary>
+    /// Answers each per-group membership query. Both the membership and the health are mutable,
+    /// because the scenario needs Graph to go down and come back mid-test — a handler that failed
+    /// from the first call could never reach the stale path at all.
+    /// </summary>
+    private sealed class GraphHandler(ISet<string> memberGroupIds) : HttpMessageHandler
+    {
+        private readonly List<HttpResponseMessage> _responses = [];
+
+        public HttpStatusCode Status { get; set; } = HttpStatusCode.OK;
+        public ISet<string> MemberGroupIds { get; set; } = memberGroupIds;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var uri = request.RequestUri!.ToString();
+            var isMember = MemberGroupIds.Any(id => uri.Contains(id, StringComparison.OrdinalIgnoreCase));
+
+            var response = Status != HttpStatusCode.OK
+                ? new HttpResponseMessage(Status) { Content = new StringContent("""{"error":"graph is down"}""") }
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(isMember ? $$"""{"value":[{"id":"{{UserOid}}"}]}""" : """{"value":[]}""")
+                };
+            _responses.Add(response);
+            return Task.FromResult(response);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (var response in _responses)
+                {
+                    response.Dispose();
+                }
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/VitallyMcp.Tests/TestAuthHandler.cs
+++ b/VitallyMcp.Tests/TestAuthHandler.cs
@@ -12,6 +12,13 @@ namespace VitallyMcp.Tests;
 public class TestAuthHandlerOptions : AuthenticationSchemeOptions
 {
     public string[] Permissions { get; set; } = [];
+
+    /// <summary>
+    /// Entra object id to emit as an <c>oid</c> claim. Leave null for the claim-only principal most
+    /// tests want; set it when the test needs <see cref="ToolAuthorizer"/> to take the live group
+    /// path, which is skipped entirely when no object id can be determined.
+    /// </summary>
+    public string? ObjectId { get; set; }
 }
 
 /// <summary>
@@ -35,6 +42,10 @@ public class TestAuthHandler(
             new("sub", "test-subject")
         };
         claims.AddRange(Options.Permissions.Select(p => new Claim("permissions", p)));
+        if (!string.IsNullOrWhiteSpace(Options.ObjectId))
+        {
+            claims.Add(new Claim("oid", Options.ObjectId));
+        }
 
         var identity = new ClaimsIdentity(claims, SchemeName);
         var principal = new ClaimsPrincipal(identity);

--- a/VitallyMcp.Tests/ToolAuthorizerTests.cs
+++ b/VitallyMcp.Tests/ToolAuthorizerTests.cs
@@ -214,6 +214,18 @@ public class ToolAuthorizerTests
     }
 
     [Fact]
+    public async Task LiveCheck_Denies_WhenNoResolverIsRegistered_RatherThanFallingBackToTheClaim()
+    {
+        // The mode is chosen by the flag alone. Testing the resolver for null alongside it — which
+        // is how this was first written — hands a miswired container back to the token claim, a
+        // silent revert to the posture the cutover removed, by the one route nobody is watching.
+        var authorizer = Build(user: UserWithSub(SubWithOid, "vitally:delete"), options: LiveOptions(), resolver: null);
+
+        await authorizer.Invoking(a => a.EnsureAuthorizedAsync(HttpMethod.Delete))
+            .Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
     public async Task ClaimTier_StillResolves_WhenTheLiveCheckIsOff()
     {
         // Removing the fall-through must not remove the mode. With LiveGroupCheck off the token

--- a/VitallyMcp.Tests/ToolAuthorizerTests.cs
+++ b/VitallyMcp.Tests/ToolAuthorizerTests.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using VitallyMcp;
 
@@ -27,7 +28,8 @@ public class ToolAuthorizerTests
         bool noAuth = false,
         ClaimsPrincipal? user = null,
         ToolAuthorizationOptions? options = null,
-        IGroupPermissionResolver? resolver = null)
+        IGroupPermissionResolver? resolver = null,
+        ILogger<ToolAuthorizer>? logger = null)
     {
         var accessor = new HttpContextAccessor
         {
@@ -37,7 +39,8 @@ public class ToolAuthorizerTests
             Options.Create(options ?? new ToolAuthorizationOptions { Enabled = enabled }),
             Options.Create(new OAuthOptions { NoAuth = noAuth }),
             accessor,
-            resolver);
+            resolver,
+            logger);
     }
 
     private static ClaimsPrincipal UserWithPermissions(params string[] permissions) =>
@@ -223,6 +226,34 @@ public class ToolAuthorizerTests
 
         await authorizer.Invoking(a => a.EnsureAuthorizedAsync(HttpMethod.Delete))
             .Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Theory]
+    [InlineData(false)]  // resolver present, returns null  -> the "nothing usable" line
+    [InlineData(true)]   // resolver absent entirely        -> the "no resolver registered" line
+    public async Task LiveCheck_LogsItsDenialReasonOncePerRequest_NotOncePerEvaluation(bool noResolver)
+    {
+        // ToolAuthorizer is scoped, so one instance is one HTTP request — and a single tools/list
+        // evaluates authorisation once per tool (93 of them). Without the guard, one malformed token
+        // or one Graph outage buries the single line that explains the failure under 92 copies of
+        // itself, in exactly the logs someone is reading because authorisation is failing.
+        var logger = new CapturingLogger<ToolAuthorizer>();
+        var authorizer = Build(
+            user: UserWithSub(SubWithOid),
+            options: LiveOptions(),
+            resolver: noResolver ? null : new StubResolver(null),
+            logger: logger);
+
+        foreach (var method in new[] { HttpMethod.Get, HttpMethod.Post, HttpMethod.Delete, HttpMethod.Get })
+        {
+            await authorizer.Invoking(a => a.EnsureAuthorizedAsync(method))
+                .Should().ThrowAsync<UnauthorizedAccessException>();
+        }
+
+        logger.Entries.Should().ContainSingle().Which.Message
+            .Should().Contain("this request",
+                "the message describes the request's outcome, not one tool's tier — naming a permission "
+                + "would make a single line read as if only that tier were refused");
     }
 
     [Fact]

--- a/VitallyMcp.Tests/ToolAuthorizerTests.cs
+++ b/VitallyMcp.Tests/ToolAuthorizerTests.cs
@@ -183,23 +183,45 @@ public class ToolAuthorizerTests
     }
 
     [Fact]
-    public async Task LiveCheck_FallsBackToClaim_WhenResolverUnavailable()
+    public async Task LiveCheck_Denies_WhenResolverUnavailable_EvenThoughTheTokenClaimWouldGrantIt()
     {
-        // Resolver returns null (e.g. Graph down) -> fall back to the token claim, which grants delete.
+        // The claim tier that used to sit beneath the stale cache is gone (#108). The resolver
+        // returning null means it had neither a fresh Graph result nor a usable stale one, and
+        // there is nothing below that any more — so this must deny despite a token claim that
+        // plainly grants delete. Asserting *with* the claim present is the whole point: a version
+        // that still consulted it would pass a test written without one.
         var resolver = new StubResolver(null);
         var authorizer = Build(user: UserWithSub(SubWithOid, "vitally:delete"), options: LiveOptions(), resolver: resolver);
 
-        await authorizer.Invoking(a => a.EnsureAuthorizedAsync(HttpMethod.Delete)).Should().NotThrowAsync();
+        await authorizer.Invoking(a => a.EnsureAuthorizedAsync(HttpMethod.Delete))
+            .Should().ThrowAsync<UnauthorizedAccessException>().WithMessage("*vitally:delete*");
     }
 
     [Fact]
-    public async Task LiveCheck_FallbackDenies_WhenResolverUnavailableAndClaimLacksPermission()
+    public async Task LiveCheck_Denies_WhenNoObjectIdCanBeDetermined_EvenThoughTheTokenClaimWouldGrantIt()
     {
-        var resolver = new StubResolver(null);
-        var authorizer = Build(user: UserWithSub(SubWithOid, "vitally:read"), options: LiveOptions(), resolver: resolver);
+        // Same fail-closed rule for the other way out of the live path. An Entra v2 token always
+        // carries `oid`, so a subject with no GUID in it is a malformed token rather than an
+        // un-entitled user — and before #108 it fell through to the claim, which here would allow.
+        var resolver = new StubResolver(new HashSet<string> { "vitally:delete" });
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim("sub", "not-a-guid"), new Claim("permissions", "vitally:delete") }, "Test"));
+        var authorizer = Build(user: user, options: LiveOptions(), resolver: resolver);
 
         await authorizer.Invoking(a => a.EnsureAuthorizedAsync(HttpMethod.Delete))
             .Should().ThrowAsync<UnauthorizedAccessException>();
+        resolver.LastObjectId.Should().BeNull("the resolver must not be called with a subject that is not an object id");
+    }
+
+    [Fact]
+    public async Task ClaimTier_StillResolves_WhenTheLiveCheckIsOff()
+    {
+        // Removing the fall-through must not remove the mode. With LiveGroupCheck off the token
+        // claim is the entire resolution rather than a fallback beneath Graph, and a deployment
+        // configured that way has to keep working.
+        var authorizer = Build(user: UserWithSub(SubWithOid, "vitally:delete"), resolver: new StubResolver(null));
+
+        await authorizer.Invoking(a => a.EnsureAuthorizedAsync(HttpMethod.Delete)).Should().NotThrowAsync();
     }
 
     [Theory]

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -15,10 +15,18 @@ public class OAuthOptions
     public string Authority { get; set; } = string.Empty;
 
     /// <summary>
-    /// Value to validate the JWT <c>aud</c> claim against. Depends on the AS:
-    /// for Auth0 it's the API identifier; for v2 Entra tokens it's typically the application
-    /// (client) ID GUID.
+    /// Value to validate the JWT <c>aud</c> claim against — the Entra App ID URI, which carries
+    /// <b>no</b> trailing slash because Entra refuses to register one on <c>identifierUris</c>.
+    /// <see cref="ValidAudiences"/> also accepts <see cref="SharedClientId"/>, which is what a v2
+    /// token actually names.
     /// </summary>
+    /// <remarks>
+    /// <b>Not the same value as <see cref="Resource"/>, and must not be reconciled with it.</b> They
+    /// were equal under Auth0 by coincidence — that identifier happened to carry a trailing slash —
+    /// and differ by exactly that slash under Entra. Making them agree breaks token validation in one
+    /// direction and the RFC 9728 document in the other. On staging they differ by host as well,
+    /// because one app registration serves both origins.
+    /// </remarks>
     public string Audience { get; set; } = string.Empty;
 
     /// <summary>
@@ -44,6 +52,60 @@ public class OAuthOptions
         (string.IsNullOrWhiteSpace(Resource) ? Audience : Resource)?.Trim() ?? string.Empty;
 
     /// <summary>
+    /// Audience values the JWT <c>aud</c> claim may carry: <see cref="Audience"/> and, when set,
+    /// <see cref="SharedClientId"/>. Both, because which one a provider mints is a property of the
+    /// token version rather than of our configuration — an Entra <b>v1</b> access token names the
+    /// App ID URI, a <b>v2</b> token names the resource application's appId GUID, and this
+    /// registration is both the client and the resource so the two are the same object. Accepting
+    /// each removes the question rather than betting on it.
+    /// </summary>
+    /// <remarks>
+    /// The consequence to be aware of: an <i>ID</i> token for this app also carries the appId GUID as
+    /// <c>aud</c>, so one presented as a bearer token would pass audience validation. That is not an
+    /// escalation — it is issued to the same client for the same user, and entitlement is still
+    /// resolved from that user's live Entra group membership, so an ID token buys exactly the tier
+    /// its own access token would. Narrowing it would mean requiring <c>scp</c>, which is provider-
+    /// specific in a way this class deliberately is not.
+    /// </remarks>
+    public IReadOnlyList<string> ValidAudiences =>
+        new[] { Audience, SharedClientId }
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>
+    /// True when <see cref="UpstreamResourceScope"/> is configured, i.e. the proxy terminates the
+    /// RFC 8707 <c>resource</c> parameter at this façade rather than relaying it upstream.
+    /// </summary>
+    public bool TerminatesResourceParameter => !string.IsNullOrWhiteSpace(UpstreamResourceScope);
+
+    /// <summary>
+    /// Merges <see cref="UpstreamResourceScope"/> into the <c>scope</c> value a client sent, so the
+    /// upstream request names this server's API even when the client only asked for the OIDC scopes.
+    /// Returns the client's value unchanged if it already names it, and the bare scope when the
+    /// client sent none.
+    /// </summary>
+    /// <remarks>
+    /// The comparison is case-insensitive although RFC 6749 §3.3 makes scope tokens case-sensitive:
+    /// a duplicate here is a request that fails upstream, so tolerating a casing difference is
+    /// strictly better than emitting the same scope twice in two spellings.
+    /// </remarks>
+    public string MergeUpstreamScope(string? requestedScope)
+    {
+        var scope = UpstreamResourceScope;
+        var requested = (requestedScope ?? string.Empty).Trim();
+        if (requested.Length == 0)
+        {
+            return scope;
+        }
+
+        var tokens = requested.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return tokens.Contains(scope, StringComparer.OrdinalIgnoreCase)
+            ? string.Join(' ', tokens)
+            : string.Join(' ', tokens.Append(scope));
+    }
+
+    /// <summary>
     /// Canonical public origin of this server (scheme + host, no trailing path), e.g.
     /// <c>https://vitally.fiscaltec.com</c>. When set, the <c>/.well-known/*</c> metadata documents
     /// and the OAuth proxy's own callback URL are built from this value instead of the request's
@@ -54,23 +116,62 @@ public class OAuthOptions
     public string PublicBaseUrl { get; set; } = string.Empty;
 
     /// <summary>
-    /// OAuth client_id of a pre-registered Auth0 native application that all MCP clients share.
-    /// When set, the server intercepts RFC 7591 Dynamic Client Registration calls and returns this
-    /// client_id to every caller — eliminating per-session client proliferation in Auth0 and the
-    /// per-session manual API-grant clicks that DCR third-party clients otherwise require.
-    /// The pre-registered Auth0 app must be native/public, first-party, with redirect URI
-    /// <c>http://localhost</c> (loopback pattern matches any port), and have a client_grant on
-    /// the Vitally MCP API. Leave empty to fall through to Auth0's native DCR endpoint.
+    /// OAuth client_id of the pre-registered application that all MCP clients converge on. When set,
+    /// the server intercepts RFC 7591 Dynamic Client Registration calls and returns this client_id to
+    /// every caller — eliminating per-session client proliferation at the provider and the
+    /// per-session consent that DCR clients otherwise trigger. Leave empty to fall through to the
+    /// provider's own DCR endpoint, if it has one.
     /// </summary>
+    /// <remarks>
+    /// Under Entra this is the <c>Vitally MCP</c> app registration, which is <b>both</b> the OAuth
+    /// client and the API resource — hence its appearing in <see cref="ValidAudiences"/>. Its
+    /// redirect URIs are the fixed <c>/oauth/callback</c> of each origin, not the clients' own
+    /// loopback URIs: the proxy substitutes its own and reverses the substitution at the callback,
+    /// which is what lets ephemeral loopback ports coexist with one registration. See
+    /// <c>docs/runbooks/entra-app-registration.md</c>.
+    /// </remarks>
     public string SharedClientId { get; set; } = string.Empty;
 
     /// <summary>
-    /// Client secret of the SharedClientId application. Injected server-side by the OAuth proxy's
-    /// /oauth/token endpoint when forwarding token requests upstream — so the shared Auth0 app can
-    /// be a confidential client (verifiable first-party = skip consent screen) without exposing the
-    /// secret to MCP clients. Optional: leave empty for public-client mode (consent screen will show).
+    /// Client secret of the <see cref="SharedClientId"/> application. Injected server-side by the
+    /// OAuth proxy's /oauth/token endpoint when forwarding token requests upstream — so the shared
+    /// app can be a confidential client without exposing the secret to MCP clients. Optional: leave
+    /// empty for public-client mode. Sourced from the Key Vault secret <c>entra-mcp-client-secret</c>,
+    /// which <b>expires</b>; see <c>docs/runbooks/entra-app-registration.md</c> for the rotation.
     /// </summary>
     public string SharedClientSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Scope value that names this server's own API to the upstream provider — under Entra the App
+    /// ID URI plus the exposed scope, e.g. <c>https://vitally.fiscaltec.com/mcp.access</c>. Empty by
+    /// default.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Setting this switches the OAuth proxy from <b>relaying</b> the RFC 8707 <c>resource</c>
+    /// parameter to <b>terminating</b> it: <c>resource</c> is still validated against
+    /// <see cref="PublishedResourceIdentifier"/> and a mismatch is still refused, but a matching
+    /// value is then dropped at the façade instead of being forwarded, and this scope is merged into
+    /// the upstream <c>scope</c> parameter in its place.
+    /// </para>
+    /// <para>
+    /// The two halves are one setting on purpose, because neither is usable alone. Dropping
+    /// <c>resource</c> without naming the resource some other way leaves the issued token bound to no
+    /// audience at all — the proxy sends no <c>audience</c> parameter anywhere. Adding a
+    /// resource-naming scope while still relaying <c>resource</c> is exactly the
+    /// <c>AADSTS9010010</c> failure this exists to avoid: Entra matches <c>resource</c> exactly
+    /// against a registered identifier and rejects the trailing-slash form MCP clients send, which
+    /// <see cref="IsResourceIndicatorAllowed"/> deliberately accepts.
+    /// </para>
+    /// <para>
+    /// So this is the provider switch, expressed as configuration rather than inferred from
+    /// <see cref="Authority"/>: leave it empty on Auth0, where the tenant's Resource Parameter
+    /// Compatibility Profile consumes the relayed <c>resource</c> and is the only thing binding the
+    /// audience; set it on Entra. Keeping it configuration is what keeps a cutover rollback a
+    /// revert of environment variables rather than a redeploy.
+    /// </para>
+    /// </remarks>
+    public string UpstreamResourceScope { get; set; } = string.Empty;
 
     /// <summary>
     /// Allowlist of non-loopback redirect URIs that the OAuth proxy will accept on
@@ -96,6 +197,7 @@ public class OAuthOptions
         Resource = Resource?.Trim() ?? string.Empty;
         SharedClientId = SharedClientId?.Trim() ?? string.Empty;
         SharedClientSecret = SharedClientSecret?.Trim() ?? string.Empty;
+        UpstreamResourceScope = UpstreamResourceScope?.Trim() ?? string.Empty;
         PublicBaseUrl = (PublicBaseUrl?.Trim() ?? string.Empty).TrimEnd('/');
 
         if (!string.IsNullOrWhiteSpace(PublicBaseUrl)
@@ -157,6 +259,17 @@ public class OAuthOptions
         if (!string.IsNullOrWhiteSpace(SharedClientSecret) && string.IsNullOrWhiteSpace(SharedClientId))
         {
             throw new InvalidOperationException("OAuth:SharedClientSecret requires OAuth:SharedClientId to also be set.");
+        }
+
+        // A single scope token, checked at boot rather than at the first sign-in. Whitespace would
+        // smuggle extra scopes into every authorize request, and this value names exactly one
+        // resource — the one whose `resource` parameter it replaces. Entra's own form is an absolute
+        // URI plus the scope name, but the check stays shape-agnostic so a different provider's
+        // convention (a bare `api://.../scope`, or a plain name) is not rejected on principle.
+        if (TerminatesResourceParameter && UpstreamResourceScope.Any(char.IsWhiteSpace))
+        {
+            throw new InvalidOperationException(
+                $"OAuth:UpstreamResourceScope must be a single scope token with no whitespace (got '{UpstreamResourceScope}').");
         }
 
         // Normalise the allowlist: trim, strip trailing slashes (we match by prefix below so

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -159,9 +159,10 @@ public class OAuthOptions
     /// <c>resource</c> without naming the resource some other way leaves the issued token bound to no
     /// audience at all — the proxy sends no <c>audience</c> parameter anywhere. Adding a
     /// resource-naming scope while still relaying <c>resource</c> is exactly the
-    /// <c>AADSTS9010010</c> failure this exists to avoid: Entra matches <c>resource</c> exactly
-    /// against a registered identifier and rejects the trailing-slash form MCP clients send, which
-    /// <see cref="IsResourceIndicatorAllowed"/> deliberately accepts.
+    /// <c>AADSTS9010010</c> failure this exists to avoid: Entra's v2 authorize endpoint refuses any
+    /// <c>resource</c> that does not match the requested scopes, and every spelling of ours fails
+    /// that check — it is not a comparison against the registered identifier, so reshaping the value
+    /// is not an option.
     /// </para>
     /// <para>
     /// So this is the provider switch, expressed as configuration rather than inferred from

--- a/VitallyMcp/OAuthOptions.cs
+++ b/VitallyMcp/OAuthOptions.cs
@@ -273,6 +273,18 @@ public class OAuthOptions
                 $"OAuth:UpstreamResourceScope must be a single scope token with no whitespace (got '{UpstreamResourceScope}').");
         }
 
+        // Both halves of the switch live in the proxy — /oauth/authorize and /oauth/token are the
+        // only places `resource` is dropped and this scope injected. Without a SharedClientId there
+        // is no proxy, so the setting would do nothing while still being advertised in
+        // `scopes_supported`: a configuration that reads as switched on and is not. Refusing it is
+        // the same rule as SharedClientSecret below, for the same reason.
+        if (TerminatesResourceParameter && !proxyEnabled)
+        {
+            throw new InvalidOperationException(
+                "OAuth:UpstreamResourceScope requires OAuth:SharedClientId to also be set — it only takes "
+                + "effect in the OAuth proxy, which is inactive without one.");
+        }
+
         // Normalise the allowlist: trim, strip trailing slashes (we match by prefix below so
         // both stored and incoming values need the same shape), and fail fast on invalid URIs
         // rather than at first request.

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -96,7 +96,14 @@ if (!noAuth)
         .Configure<IOptions<OAuthOptions>>((jwt, oauth) =>
         {
             jwt.Authority = oauth.Value.Authority;
-            jwt.Audience = oauth.Value.Audience;
+            // ValidAudiences rather than the single-valued jwt.Audience: which audience a provider
+            // stamps on an access token is a property of the token version, not of our config. An
+            // Entra v1 token names the App ID URI (OAuth:Audience); a v2 token names the resource
+            // application's appId GUID — which, because one registration is both our OAuth client
+            // and our API resource, is OAuth:SharedClientId. Accepting both settles it rather than
+            // betting on it, and stays correct on Auth0, where SharedClientId is simply a second
+            // audience nothing mints for this API. See OAuthOptions.ValidAudiences.
+            jwt.TokenValidationParameters.ValidAudiences = oauth.Value.ValidAudiences;
 
             // MCP requires the 401 to point at the protected-resource metadata document. Without
             // this, clients can only guess the well-known location. Built from PublicBaseUrl so a
@@ -345,7 +352,10 @@ app.MapGet("/.well-known/oauth-authorization-server", async (HttpContext ctx, IO
         userinfo_endpoint = endpoints.UserInfoEndpoint,
         jwks_uri = endpoints.JwksUri,
         registration_endpoint = $"{ourBase}/oauth/register",
-        scopes_supported = new[] { "openid", "profile", "email", "offline_access", "mcp.access" },
+        // Shared with the RFC 9728 document rather than restated, so the two lists cannot drift.
+        // The API scope is named in the form the upstream provider will actually accept — see
+        // ProtectedResourceMetadataBuilder.ScopesFor.
+        scopes_supported = ProtectedResourceMetadataBuilder.ScopesFor(o),
         response_types_supported = new[] { "code" },
         grant_types_supported = new[] { "authorization_code", "refresh_token" },
         token_endpoint_auth_methods_supported = new[] { "none" },
@@ -391,19 +401,25 @@ app.MapGet("/oauth/authorize", async (HttpContext ctx, IOptions<OAuthOptions> oa
         return Results.BadRequest(new { error = "invalid_request", error_description = "redirect_uri is not allowed" });
     }
 
-    // RFC 8707. `resource` is what binds the audience of the token that comes back: this proxy
-    // sends no `audience` parameter anywhere, and the Auth0 tenant's Resource Parameter
-    // Compatibility Profile consumes `resource` locally to that end. It arrived here
-    // unvalidated — so a client could ask to be bound to an audience this server never
-    // published, and we would relay the request. Refuse the mismatch instead; the value is
-    // still forwarded verbatim below, because dropping it is what would break Auth0 today.
-    // Terminating it at this façade belongs to the Entra cutover (#105 part B / #108), which is
-    // where Entra's exact-match rule against a non-slashed identifierUri starts to matter.
+    // RFC 8707. `resource` is what binds the audience of the token that comes back — this proxy
+    // sends no `audience` parameter anywhere — so a client must not be able to ask to be bound to
+    // an audience this server never published. Refuse a mismatch regardless of what happens to the
+    // value afterwards, because the check is about what we are willing to request, not about which
+    // provider consumes it.
+    //
+    // What happens afterwards is OAuth:UpstreamResourceScope's job. Empty (Auth0): the value is
+    // relayed verbatim, because the tenant's Resource Parameter Compatibility Profile consuming it
+    // is the only thing binding the audience there. Set (Entra): it is dropped at this façade and
+    // the configured scope carries the same meaning instead — Entra matches `resource` exactly
+    // against a registered identifier and rejects the trailing-slash form clients send
+    // (AADSTS9010010), the very slash IsResourceIndicatorAllowed tolerates on purpose.
+    //
     // Indexer lookups on IQueryCollection are case-insensitive, so an oddly-cased `RESOURCE` is
-    // validated here too — and refused if it does not match. The forwarding loop below preserves
-    // the caller's key casing, so such a pair does travel upstream as-is; a conformant provider
-    // ignores it, because RFC 6749 defines parameter names as lowercase literals. #123 tracks
-    // stripping them rather than relying on that.
+    // validated here too — and refused if it does not match. When the parameter is terminated the
+    // forwarding loop drops it case-insensitively as well; when it is relayed, the loop preserves
+    // the caller's key casing and such a pair travels upstream as-is, which a conformant provider
+    // ignores because RFC 6749 defines parameter names as lowercase literals. #123 tracks stripping
+    // those rather than relying on it.
     if (query.ContainsKey("resource")
         && query["resource"].Any(value => !o.IsResourceIndicatorAllowed(value ?? string.Empty)))
     {
@@ -418,6 +434,11 @@ app.MapGet("/oauth/authorize", async (HttpContext ctx, IOptions<OAuthOptions> oa
 
     var ourCallback = $"{GetServerBaseUrl(ctx, o.PublicBaseUrl)}/oauth/callback";
     var endpoints = await upstream.GetAsync(ctx.RequestAborted);
+    // Repeated `scope` is not legal OAuth, but a client that sends it means the union — so join on
+    // a space rather than letting StringValues.ToString() comma-splice the values into one token.
+    var mergedScope = o.TerminatesResourceParameter
+        ? o.MergeUpstreamScope(string.Join(' ', query["scope"].Select(v => v ?? string.Empty)))
+        : null;
     // The provider is free to publish an authorization_endpoint that already carries a query
     // (nothing in OIDC Discovery forbids it), so pick the separator rather than assuming '?'.
     var separator = endpoints.AuthorizationEndpoint.Contains('?') ? '&' : '?';
@@ -429,10 +450,23 @@ app.MapGet("/oauth/authorize", async (HttpContext ctx, IOptions<OAuthOptions> oa
         // re-prompt every session even when a user_grant already exists. Without prompt=*
         // Auth0 honours the cached grant and silently issues an authorization code.
         if (kv.Key == "prompt") continue;
+        if (mergedScope is not null
+            && (string.Equals(kv.Key, "resource", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(kv.Key, "scope", StringComparison.OrdinalIgnoreCase)))
+        {
+            // Terminated here (`resource`) or re-emitted once below in merged form (`scope`).
+            // OrdinalIgnoreCase and not ==: a `RESOURCE` that survived would defeat the whole point
+            // of dropping it, and letting a `SCOPE` through would put two scope parameters upstream.
+            continue;
+        }
         foreach (var v in kv.Value)
         {
             sb.Append(Uri.EscapeDataString(kv.Key)).Append('=').Append(Uri.EscapeDataString(v ?? string.Empty)).Append('&');
         }
+    }
+    if (mergedScope is not null)
+    {
+        sb.Append("scope=").Append(Uri.EscapeDataString(mergedScope)).Append('&');
     }
     sb.Append("redirect_uri=").Append(Uri.EscapeDataString(ourCallback));
     return Results.Redirect(sb.ToString());
@@ -485,8 +519,8 @@ app.MapPost("/oauth/token", async (HttpContext ctx, IOptions<OAuthOptions> oauth
 
     var form = await ctx.Request.ReadFormAsync();
     // Same audience-binding control as /oauth/authorize, applied to the form body — a refresh
-    // exchange can carry `resource` just as a code exchange can, and this endpoint forwarded it
-    // unvalidated too. See the comment there for why it is validated but still relayed.
+    // exchange can carry `resource` just as a code exchange can. See the comment there for what
+    // OAuth:UpstreamResourceScope then does with a value that passes.
     if (form.ContainsKey("resource")
         && form["resource"].Any(value => !o.IsResourceIndicatorAllowed(value ?? string.Empty)))
     {
@@ -497,6 +531,15 @@ app.MapPost("/oauth/token", async (HttpContext ctx, IOptions<OAuthOptions> oauth
         });
     }
 
+    // Merged for both grants, not just refresh. On a refresh exchange it is load-bearing: Entra
+    // issues the new access token for whatever resource `scope` names, so a client that refreshes
+    // with only the OIDC scopes would silently be handed a token for the wrong audience. On a code
+    // exchange it is redundant but harmless — the scope was already consented at /oauth/authorize —
+    // and applying one rule to both is easier to keep true than a per-grant one.
+    var mergedScope = o.TerminatesResourceParameter
+        ? o.MergeUpstreamScope(string.Join(' ', form["scope"].Select(v => v ?? string.Empty)))
+        : null;
+
     var pairs = new List<KeyValuePair<string, string>>();
     var sawRedirect = false;
     foreach (var kv in form)
@@ -506,6 +549,14 @@ app.MapPost("/oauth/token", async (HttpContext ctx, IOptions<OAuthOptions> oauth
             pairs.Add(new KeyValuePair<string, string>("redirect_uri", ourCallback));
             sawRedirect = true;
         }
+        else if (mergedScope is not null
+            && (string.Equals(kv.Key, "resource", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(kv.Key, "scope", StringComparison.OrdinalIgnoreCase)))
+        {
+            // Terminated (`resource`) or replaced by the merged value below (`scope`) — see the
+            // matching skip in /oauth/authorize.
+            continue;
+        }
         else
         {
             foreach (var v in kv.Value)
@@ -513,6 +564,10 @@ app.MapPost("/oauth/token", async (HttpContext ctx, IOptions<OAuthOptions> oauth
                 pairs.Add(new KeyValuePair<string, string>(kv.Key, v ?? string.Empty));
             }
         }
+    }
+    if (mergedScope is not null)
+    {
+        pairs.Add(new KeyValuePair<string, string>("scope", mergedScope));
     }
     // Restrict the grants this proxy will service. We inject a confidential client_secret
     // below, so we must never forward a grant the shared app shouldn't service — otherwise a

--- a/VitallyMcp/Program.cs
+++ b/VitallyMcp/Program.cs
@@ -409,10 +409,13 @@ app.MapGet("/oauth/authorize", async (HttpContext ctx, IOptions<OAuthOptions> oa
     //
     // What happens afterwards is OAuth:UpstreamResourceScope's job. Empty (Auth0): the value is
     // relayed verbatim, because the tenant's Resource Parameter Compatibility Profile consuming it
-    // is the only thing binding the audience there. Set (Entra): it is dropped at this façade and
-    // the configured scope carries the same meaning instead — Entra matches `resource` exactly
-    // against a registered identifier and rejects the trailing-slash form clients send
-    // (AADSTS9010010), the very slash IsResourceIndicatorAllowed tolerates on purpose.
+    // is the only thing binding the audience there. Set (Entra): it is dropped here and the
+    // configured scope carries the same meaning instead, because Entra's v2 authorize endpoint
+    // refuses *any* `resource` alongside a custom-API `scope` — AADSTS9010010, "the resource
+    // parameter provided in the request doesn't match with the requested scopes". Verified against
+    // the live tenant on 2026-09-02: the slashed form, the exact App ID URI and an unregistered
+    // value all return 400 alike. It is a resource-vs-scope consistency check, not a comparison
+    // against identifierUris, so no amount of reshaping the value would have worked.
     //
     // Indexer lookups on IQueryCollection are case-insensitive, so an oddly-cased `RESOURCE` is
     // validated here too — and refused if it does not match. When the parameter is terminated the

--- a/VitallyMcp/ProtectedResourceMetadataBuilder.cs
+++ b/VitallyMcp/ProtectedResourceMetadataBuilder.cs
@@ -12,8 +12,21 @@ public static class ProtectedResourceMetadataBuilder
     /// <summary>Canonical metadata path. RFC 9728 also allows a resource-path suffix (…/mcp).</summary>
     public const string MetadataPath = "/.well-known/oauth-protected-resource";
 
-    /// <summary>Scopes advertised to clients so they can request them at the authorize step.</summary>
-    public static readonly string[] SupportedScopes = ["openid", "profile", "email", "offline_access", "mcp.access"];
+    /// <summary>
+    /// OIDC scopes advertised to clients so they can request them at the authorize step. The API
+    /// scope is appended by <see cref="ScopesFor"/>, because its spelling depends on the upstream
+    /// provider.
+    /// </summary>
+    public static readonly string[] BaseScopes = ["openid", "profile", "email", "offline_access"];
+
+    /// <summary>
+    /// The advertised scope list: the OIDC scopes plus this server's API scope, named the way the
+    /// upstream provider will accept it. Entra rejects a bare scope name on a custom API — it must
+    /// carry the App ID URI prefix — so advertising the short form to a client that builds its
+    /// request from this list would break the flow before sign-in.
+    /// </summary>
+    public static string[] ScopesFor(OAuthOptions oauth) =>
+        [.. BaseScopes, oauth.TerminatesResourceParameter ? oauth.UpstreamResourceScope : "mcp.access"];
 
     public static ProtectedResourceMetadata Build(OAuthOptions oauth, string serverBaseUrl)
     {
@@ -32,7 +45,7 @@ public static class ProtectedResourceMetadataBuilder
             // Assigning replaces the list outright for all three.
             AuthorizationServers = [authorizationServer ?? string.Empty],
             BearerMethodsSupported = ["header"],
-            ScopesSupported = [.. SupportedScopes],
+            ScopesSupported = [.. ScopesFor(oauth)],
             ResourceName = "Vitally MCP"
         };
     }

--- a/VitallyMcp/ToolAuthorizationOptions.cs
+++ b/VitallyMcp/ToolAuthorizationOptions.cs
@@ -6,9 +6,10 @@ namespace VitallyMcp;
 /// hard backstop behind the advisory <c>ReadOnly</c>/<c>Destructive</c> tool flags — those flags
 /// only guide MCP clients; this enforces access regardless of what the client does.
 ///
-/// Permission strings must match the permissions defined on the Auth0 API (Resource Server) with
-/// "Enable RBAC" + "Add Permissions in the Access Token" turned on. To collapse to two tiers,
-/// point <see cref="DeletePermission"/> at the same value as <see cref="WritePermission"/>.
+/// The permission strings are internal names, not something an identity provider issues: with
+/// <see cref="LiveGroupCheck"/> on they are produced by mapping Entra group membership to tiers in
+/// <see cref="GraphGroupPermissionResolver"/>. To collapse to two tiers, point
+/// <see cref="DeletePermission"/> at the same value as <see cref="WritePermission"/>.
 /// </summary>
 public class ToolAuthorizationOptions
 {
@@ -39,12 +40,16 @@ public class ToolAuthorizationOptions
     public string DeletePermission { get; set; } = "vitally:delete";
 
     /// <summary>
-    /// Optional namespaced claim that may carry the permission values, in addition to the standard
-    /// Auth0 RBAC <c>permissions</c> claim and the space-delimited <c>scope</c> claim. Use this when
-    /// an Auth0 post-login Action maps Entra group membership to permissions via a custom claim
-    /// rather than Auth0 role assignment. Auth0 requires custom claims to be namespaced (a URL on a
-    /// domain you control). Leave empty to check only <c>permissions</c> and <c>scope</c>.
+    /// Optional namespaced claim that may carry the permission values, alongside the <c>permissions</c>
+    /// claim and the space-delimited <c>scope</c> claim. Leave empty to check only those two.
     /// </summary>
+    /// <remarks>
+    /// <b>Consulted only when <see cref="LiveGroupCheck"/> is false.</b> It exists for the
+    /// namespaced-custom-claim convention (Auth0 required custom claims to be namespaced on a domain
+    /// you control), and the Auth0 post-login Action that minted it here was retired at the #108
+    /// cutover — so on every deployed target this value is inert, and no claim of any kind can grant
+    /// access. See <see cref="ToolAuthorizer"/>.
+    /// </remarks>
     public string CustomPermissionsClaim { get; set; } = "https://vitally.fiscaltec.com/permissions";
 
     /// <summary>
@@ -53,11 +58,12 @@ public class ToolAuthorizationOptions
     /// the frozen token claim — so group changes (grants and especially revocations) take effect
     /// within the cache window regardless of token age.
     ///
-    /// On a Graph failure the resolution degrades in two steps rather than one: the caller's last
-    /// known-good permission set is served for up to <see cref="LiveGroupStaleSeconds"/>, and only
-    /// when there is no such copy does it fall through to the token claim. Never fail-open — an
-    /// empty set and an empty claim both deny. Requires the server's managed identity to hold
-    /// Microsoft Graph <c>GroupMember.Read.All</c>.
+    /// On a Graph failure the caller's last known-good permission set is served for up to
+    /// <see cref="LiveGroupStaleSeconds"/>; when there is no such copy the call is <b>denied</b>.
+    /// There is no third tier — the token claim was removed at the #108 cutover, once the Auth0
+    /// Action that minted it was retired and it could only ever have denied anyway. Never
+    /// fail-open: an empty set denies just as a missing one does. Requires the server's managed
+    /// identity to hold Microsoft Graph <c>GroupMember.Read.All</c>.
     /// </summary>
     public bool LiveGroupCheck { get; set; }
 
@@ -69,12 +75,12 @@ public class ToolAuthorizationOptions
     /// being fresh, so a Microsoft Graph outage degrades to the caller's last known-good tier instead
     /// of denying them. Default 3600; <b>0 disables stale serving</b> entirely.
     ///
-    /// This exists because Graph becomes the sole source of entitlement once Auth0 is retired
-    /// (#102/#106), at which point the token-claim fall-through is always empty and a Graph outage
-    /// would deny every user. Bounded staleness is the trade being made: a revoked user could retain
-    /// access for up to this window, but only while Graph is unavailable — a better failure mode than
-    /// a total outage, and strictly tighter than the 8-hour frozen token claim the architecture
-    /// tolerated before the live check existed.
+    /// Graph is now the sole source of entitlement (#102/#106/#108), so without this a Graph outage
+    /// would deny every user outright. Bounded staleness is the trade being made: a revoked user
+    /// could retain access for up to this window, but only while Graph is unavailable — a better
+    /// failure mode than a total outage, and strictly tighter than the 8-hour frozen token claim the
+    /// architecture tolerated before the live check existed. Setting it to 0 restores the
+    /// deny-immediately behaviour, at the cost of that protection.
     ///
     /// Distinct from <see cref="LiveGroupCacheSeconds"/> on purpose: that one governs how long a
     /// result is served <i>without asking Graph</i>, and lengthening it would slow revocation

--- a/VitallyMcp/ToolAuthorizer.cs
+++ b/VitallyMcp/ToolAuthorizer.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace VitallyMcp;
@@ -11,20 +12,23 @@ namespace VitallyMcp;
 /// (including search) is a GET and every mutation is a POST/PUT/DELETE, the HTTP verb is a
 /// faithful proxy for the tool's read/write/delete tier.
 ///
-/// Permission resolution order:
-///   1. If <see cref="ToolAuthorizationOptions.LiveGroupCheck"/> is on, the caller's <b>live</b>
-///      Entra group membership (via <see cref="IGroupPermissionResolver"/>) — so group changes
-///      take effect within the cache window regardless of token age. The resolver answers from its
-///      own fresh cache, and on a Graph failure from that caller's last known-good set for up to
-///      <see cref="ToolAuthorizationOptions.LiveGroupStaleSeconds"/>.
-///   2. Otherwise — the live check is off, no object id could be determined, or the resolver has
-///      nothing usable at all — the token's permission claim / scope.
+/// Permission resolution has two modes, chosen by
+/// <see cref="ToolAuthorizationOptions.LiveGroupCheck"/> and never mixed:
+///   1. <b>Live group check on</b> (every deployed target): permissions come from the caller's
+///      current Entra group membership via <see cref="IGroupPermissionResolver"/>, which answers
+///      from its own fresh cache and, when a Graph call fails, from that caller's last known-good
+///      set for up to <see cref="ToolAuthorizationOptions.LiveGroupStaleSeconds"/>. So the tiers are
+///      <b>fresh Graph → stale Graph → deny</b>. Nothing in the token can grant access.
+///   2. <b>Live group check off</b>: the token's permission claim / scope, for deployments with no
+///      Graph reachability that accept a token-frozen entitlement.
 ///
-/// So the effective tiers are: fresh Graph → stale Graph → token claim → deny. The claim tier is the
-/// Auth0 post-login Action's <c>permissions</c> claim, which still authorises correctly today; it
-/// becomes permanently empty at the Entra cutover, and removing it there is #108's job. Until then
-/// the tier below the stale cache is a working fallback, not a formality — which is why the stale
-/// cache was added beneath it rather than in place of it.
+/// <para>The token claim used to sit beneath the stale cache as a third tier in mode 1. It was the
+/// Auth0 post-login Action's <c>permissions</c> claim, and while Auth0 issued the tokens it genuinely
+/// authorised — which is why #106 added the stale cache beneath it rather than in place of it. The
+/// Entra cutover (#108) retired the Action, so that claim is now permanently absent and a
+/// fall-through to it could only ever deny. Keeping it would have left code that reads like a working
+/// fallback and behaves like a silent denial; the explicit deny below says what actually happens, and
+/// logs why.</para>
 /// </summary>
 public class ToolAuthorizer
 {
@@ -32,17 +36,20 @@ public class ToolAuthorizer
     private readonly bool _noAuth;
     private readonly IHttpContextAccessor? _httpContextAccessor;
     private readonly IGroupPermissionResolver? _groupResolver;
+    private readonly ILogger<ToolAuthorizer>? _logger;
 
     public ToolAuthorizer(
         IOptions<ToolAuthorizationOptions> options,
         IOptions<OAuthOptions> oauth,
         IHttpContextAccessor? httpContextAccessor = null,
-        IGroupPermissionResolver? groupResolver = null)
+        IGroupPermissionResolver? groupResolver = null,
+        ILogger<ToolAuthorizer>? logger = null)
     {
         _options = options.Value;
         _noAuth = oauth.Value.NoAuth;
         _httpContextAccessor = httpContextAccessor;
         _groupResolver = groupResolver;
+        _logger = logger;
     }
 
     /// <summary>
@@ -78,8 +85,9 @@ public class ToolAuthorizer
     }
 
     /// <summary>
-    /// Resolves whether <paramref name="user"/> effectively holds <paramref name="required"/>, using
-    /// the live Entra group lookup when enabled and falling back to the token claim. Public so the
+    /// Resolves whether <paramref name="user"/> effectively holds <paramref name="required"/> — from
+    /// the live Entra group lookup when it is enabled, and from the token claim only when it is not.
+    /// There is no path from the former to the latter: see the class remarks. Public so the
     /// ASP.NET Core authorization policy handler can share exactly this resolution — the discovery
     /// filter and the <see cref="VitallyService"/> enforcement backstop must never disagree.
     /// </summary>
@@ -87,19 +95,40 @@ public class ToolAuthorizer
     {
         if (_options.LiveGroupCheck && _groupResolver is not null)
         {
+            // Fail closed: with the live check on, Graph is the *only* source of entitlement, so
+            // every way out of this block that is not an answer from Graph is a denial. Both are
+            // logged rather than quietly returning false — after the cutover they are the only two
+            // ways a correctly signed-in user can be refused everything, and neither is visible in
+            // the audit record, which reports the denial and not its cause.
             var objectId = ExtractObjectId(user);
-            if (objectId is not null)
+            if (objectId is null)
             {
-                var live = await _groupResolver.TryResolvePermissionsAsync(objectId, cancellationToken);
-                if (live is not null)
-                {
-                    // Authoritative when the live lookup succeeds (empty set => deny).
-                    return live.Contains(required);
-                }
-                // live == null => the resolver had neither a fresh nor a usable stale result,
-                // so fall through to the token claim. Not merely "Graph was slow": the stale window
-                // has already been considered and declined by this point.
+                // An Entra v2 token always carries `oid`. Reaching here means the token is not
+                // shaped as expected (or inbound claim mapping has changed), not that the user lacks
+                // a tier — so it is worth its own line.
+                _logger?.LogWarning(
+                    "Denying '{RequiredPermission}': no Entra object id could be determined from the caller's token, "
+                    + "and Authorization:LiveGroupCheck makes the live group lookup the only source of entitlement.",
+                    required);
+                return false;
             }
+
+            var live = await _groupResolver.TryResolvePermissionsAsync(objectId, cancellationToken);
+            if (live is null)
+            {
+                // The resolver had neither a fresh result nor a usable stale one — it has already
+                // considered and declined the stale window by this point, and logged the underlying
+                // Graph failure itself. Subject id only, never the caller's email (see AuditOptions).
+                _logger?.LogWarning(
+                    "Denying '{RequiredPermission}' for {UserObjectId}: the live group lookup returned nothing usable "
+                    + "and there is no other source of entitlement.",
+                    required,
+                    objectId);
+                return false;
+            }
+
+            // Authoritative when the live lookup succeeds (empty set => deny).
+            return live.Contains(required);
         }
 
         return HasPermission(user, required, _options.CustomPermissionsClaim);
@@ -161,10 +190,15 @@ public class ToolAuthorizer
     public Task<bool> IsAuthorizationBypassedAsync() => Task.FromResult(!_options.Enabled || _noAuth);
 
     /// <summary>
-    /// True if the principal carries <paramref name="required"/> as an Auth0 RBAC <c>permissions</c>
-    /// claim entry, as an entry in the optional <paramref name="customClaimType"/> claim, or as a
-    /// space-delimited value in the <c>scope</c> claim.
+    /// True if the principal carries <paramref name="required"/> as a <c>permissions</c> claim entry,
+    /// as an entry in the optional <paramref name="customClaimType"/> claim, or as a space-delimited
+    /// value in the <c>scope</c> claim.
     /// </summary>
+    /// <remarks>
+    /// Reached only when <see cref="ToolAuthorizationOptions.LiveGroupCheck"/> is off, where it is
+    /// that mode's entire resolution rather than a fallback beneath the live check. See the class
+    /// remarks for why there is no longer a fall-through from the live path to here.
+    /// </remarks>
     public static bool HasPermission(ClaimsPrincipal user, string required, string? customClaimType = null)
     {
         if (user.FindAll("permissions").Any(c => string.Equals(c.Value, required, StringComparison.Ordinal)))

--- a/VitallyMcp/ToolAuthorizer.cs
+++ b/VitallyMcp/ToolAuthorizer.cs
@@ -22,6 +22,10 @@ namespace VitallyMcp;
 ///   2. <b>Live group check off</b>: the token's permission claim / scope, for deployments with no
 ///      Graph reachability that accept a token-frozen entitlement.
 ///
+/// <para>Which mode applies is decided by that one flag alone. A missing resolver does not quietly
+/// select mode 2 — it denies, because a miswired container silently reverting to token claims is
+/// exactly the posture this arrangement exists to rule out.</para>
+///
 /// <para>The token claim used to sit beneath the stale cache as a third tier in mode 1. It was the
 /// Auth0 post-login Action's <c>permissions</c> claim, and while Auth0 issued the tokens it genuinely
 /// authorised — which is why #106 added the stale cache beneath it rather than in place of it. The
@@ -93,13 +97,27 @@ public class ToolAuthorizer
     /// </summary>
     public async Task<bool> HasEffectivePermissionAsync(ClaimsPrincipal user, string required, CancellationToken cancellationToken = default)
     {
-        if (_options.LiveGroupCheck && _groupResolver is not null)
+        if (_options.LiveGroupCheck)
         {
             // Fail closed: with the live check on, Graph is the *only* source of entitlement, so
-            // every way out of this block that is not an answer from Graph is a denial. Both are
-            // logged rather than quietly returning false — after the cutover they are the only two
-            // ways a correctly signed-in user can be refused everything, and neither is visible in
+            // every way out of this block that is not an answer from Graph is a denial. Each is
+            // logged rather than quietly returning false — after the cutover they are the only ways
+            // a correctly signed-in user can be refused everything, and none of them is visible in
             // the audit record, which reports the denial and not its cause.
+            //
+            // The resolver being absent is deliberately part of that rule and not a reason to leave
+            // the block. Testing it in the condition above would have handed a miswired container
+            // back to the token claim — a silent downgrade to the posture this cutover removed,
+            // reached by the one route where nobody is watching.
+            if (_groupResolver is null)
+            {
+                _logger?.LogError(
+                    "Denying '{RequiredPermission}': Authorization:LiveGroupCheck is enabled but no "
+                    + "IGroupPermissionResolver is registered, so entitlement cannot be resolved at all.",
+                    required);
+                return false;
+            }
+
             var objectId = ExtractObjectId(user);
             if (objectId is null)
             {

--- a/VitallyMcp/ToolAuthorizer.cs
+++ b/VitallyMcp/ToolAuthorizer.cs
@@ -42,6 +42,17 @@ public class ToolAuthorizer
     private readonly IGroupPermissionResolver? _groupResolver;
     private readonly ILogger<ToolAuthorizer>? _logger;
 
+    // One line per request per cause, not one per evaluation. This service is scoped, so an instance
+    // is exactly one HTTP request — and a single tools/list evaluates authorisation once per tool
+    // (93 of them), so an unguarded warning turns one malformed token or one Graph outage into 93
+    // identical lines per request. That is not merely noisy: it buries the one line that says what
+    // went wrong under its own repetitions, in the logs someone is reading precisely because
+    // authorisation is failing. A benign race between concurrent evaluations can at worst emit a
+    // second line, which is why a plain bool is enough and Interlocked would be theatre.
+    private bool _loggedNoResolver;
+    private bool _loggedNoObjectId;
+    private bool _loggedUnresolvable;
+
     public ToolAuthorizer(
         IOptions<ToolAuthorizationOptions> options,
         IOptions<OAuthOptions> oauth,
@@ -101,9 +112,11 @@ public class ToolAuthorizer
         {
             // Fail closed: with the live check on, Graph is the *only* source of entitlement, so
             // every way out of this block that is not an answer from Graph is a denial. Each is
-            // logged rather than quietly returning false — after the cutover they are the only ways
-            // a correctly signed-in user can be refused everything, and none of them is visible in
-            // the audit record, which reports the denial and not its cause.
+            // logged once per request rather than quietly returning false — after the cutover they
+            // are the only ways a correctly signed-in user can be refused everything, and none of
+            // them is visible in the audit record, which reports the denial and not its cause. The
+            // messages name no permission, because the outcome is not tier-specific: whichever tool
+            // was evaluated first, the answer for every other one is the same.
             //
             // The resolver being absent is deliberately part of that rule and not a reason to leave
             // the block. Testing it in the condition above would have handed a miswired container
@@ -111,10 +124,13 @@ public class ToolAuthorizer
             // reached by the one route where nobody is watching.
             if (_groupResolver is null)
             {
-                _logger?.LogError(
-                    "Denying '{RequiredPermission}': Authorization:LiveGroupCheck is enabled but no "
-                    + "IGroupPermissionResolver is registered, so entitlement cannot be resolved at all.",
-                    required);
+                if (!_loggedNoResolver)
+                {
+                    _loggedNoResolver = true;
+                    _logger?.LogError(
+                        "Denying all tool access for this request: Authorization:LiveGroupCheck is enabled "
+                        + "but no IGroupPermissionResolver is registered, so entitlement cannot be resolved at all.");
+                }
                 return false;
             }
 
@@ -124,10 +140,14 @@ public class ToolAuthorizer
                 // An Entra v2 token always carries `oid`. Reaching here means the token is not
                 // shaped as expected (or inbound claim mapping has changed), not that the user lacks
                 // a tier — so it is worth its own line.
-                _logger?.LogWarning(
-                    "Denying '{RequiredPermission}': no Entra object id could be determined from the caller's token, "
-                    + "and Authorization:LiveGroupCheck makes the live group lookup the only source of entitlement.",
-                    required);
+                if (!_loggedNoObjectId)
+                {
+                    _loggedNoObjectId = true;
+                    _logger?.LogWarning(
+                        "Denying all tool access for this request: no Entra object id could be determined from "
+                        + "the caller's token, and Authorization:LiveGroupCheck makes the live group lookup the "
+                        + "only source of entitlement.");
+                }
                 return false;
             }
 
@@ -137,11 +157,14 @@ public class ToolAuthorizer
                 // The resolver had neither a fresh result nor a usable stale one — it has already
                 // considered and declined the stale window by this point, and logged the underlying
                 // Graph failure itself. Subject id only, never the caller's email (see AuditOptions).
-                _logger?.LogWarning(
-                    "Denying '{RequiredPermission}' for {UserObjectId}: the live group lookup returned nothing usable "
-                    + "and there is no other source of entitlement.",
-                    required,
-                    objectId);
+                if (!_loggedUnresolvable)
+                {
+                    _loggedUnresolvable = true;
+                    _logger?.LogWarning(
+                        "Denying all tool access for this request for {UserObjectId}: the live group lookup "
+                        + "returned nothing usable and there is no other source of entitlement.",
+                        objectId);
+                }
                 return false;
             }
 

--- a/VitallyMcp/appsettings.Example.json
+++ b/VitallyMcp/appsettings.Example.json
@@ -8,11 +8,15 @@
     "DevelopmentApiKey": ""
   },
   "OAuth": {
-    "Authority": "https://fiscal-it.uk.auth0.com/",
-    "Audience": "https://vitally.fiscaltec.com/",
+    "Authority": "https://login.microsoftonline.com/75bd6050-92a8-4bde-a406-50000b310c86/v2.0",
+    "//Audience": "The Entra App ID URI, with NO trailing slash — Entra refuses to register one on identifierUris. Deliberately NOT equal to Resource; see docs/runbooks/entra-app-registration.md.",
+    "Audience": "https://vitally.fiscaltec.com",
+    "//Resource": "Published in RFC 9728 and validated against. Keeps the trailing slash, because that is what Claude Code normalises to.",
     "Resource": "https://vitally.fiscaltec.com/",
+    "//UpstreamResourceScope": "Set => the RFC 8707 resource parameter is validated and then terminated here, with this scope naming the API upstream instead. Leave empty on Auth0, where the relayed resource is the only thing binding the audience.",
+    "UpstreamResourceScope": "https://vitally.fiscaltec.com/mcp.access",
     "PublicBaseUrl": "https://vitally.fiscaltec.com",
-    "SharedClientId": "VgB00WSYN2V0KkhtYx3WZXYH9XRBvK1D",
+    "SharedClientId": "c3812e7d-a413-4169-b57e-803326611ba3",
     "AllowedClientRedirectUris": [
       "https://claude.ai/api/mcp/auth_callback"
     ],
@@ -23,9 +27,11 @@
     "ReadPermission": "vitally:read",
     "WritePermission": "vitally:write",
     "DeletePermission": "vitally:delete",
+    "//CustomPermissionsClaim": "Only consulted when LiveGroupCheck is false. With it true — every deployed target — entitlement comes from Graph alone, and no claim can grant access. The Auth0 Action that used to mint this claim was retired at the #108 cutover.",
     "CustomPermissionsClaim": "https://vitally.fiscaltec.com/permissions",
     "LiveGroupCheck": true,
     "LiveGroupCacheSeconds": 60,
+    "LiveGroupStaleSeconds": 3600,
     "ReaderGroupId": "00000000-0000-0000-0000-000000000000",
     "EditorGroupId": "00000000-0000-0000-0000-000000000000",
     "AdminGroupId": "00000000-0000-0000-0000-000000000000"

--- a/docs/runbooks/entra-app-registration.md
+++ b/docs/runbooks/entra-app-registration.md
@@ -1,10 +1,12 @@
 # Entra app registration — Vitally MCP (#107)
 
-The app registration that replaces the Auth0 client + Resource Server pair at the #108 cutover. It is
-**both** the shared OAuth client and the API resource, because that is what the proxy's
-`SharedClientId` / `SharedClientSecret` model expects.
+The app registration that **replaced** the Auth0 client + Resource Server pair at the #108 cutover on
+2026-09-03. It is **both** the shared OAuth client and the API resource, because that is what the
+proxy's `SharedClientId` / `SharedClientSecret` model expects — which is also why its appId is a
+valid `aud` as well as the `client_id`.
 
 Provisioned 2026-09-02 via `az` / Microsoft Graph; captured as-built in `infra/terraform/entra.tf`.
+Live since 2026-09-03.
 
 | | |
 |---|---|
@@ -73,9 +75,9 @@ az rest --method post \
   --headers "Content-Type=application/json" --body @body.json
 ```
 
-Add it to `entra_gate1_group_object_ids` in `infra/terraform/entra.tf` in the same change, and do the
-equivalent on `FISCAL IT Auth0` until the cutover completes — until then, Auth0 is still the live
-sign-in path and this app gates nothing.
+Add it to `entra_gate1_group_object_ids` in `infra/terraform/entra.tf` in the same change. Until the
+Auth0 rollback path is retired, do the equivalent on `FISCAL IT Auth0` too — not because Auth0 gates
+anything today (it does not), but so a rollback does not silently lock the new department out.
 
 Verify at any time:
 
@@ -155,6 +157,11 @@ own creation on 2026-08-18, not from the day it was changed), and this secret wa
 >   --name entra-mcp-client-secret --expires "2027-03-01T13:18:59Z"
 > ```
 
+> **Resolve the egress IP with `curl -4`.** This workstation egresses over IPv6 by default now, and
+> Key Vault network ACLs accept IPv4 only — an unqualified `curl https://ifconfig.me` returns an IPv6
+> address and `az keyvault network-rule add` fails outright with *"Invalid IPv4 address"*. That one is
+> at least loud; the quiet failure is the stale-address case below.
+>
 > **The vault's data plane is private-endpoint only** (`publicNetworkAccess: Disabled`,
 > `networkAcls.defaultAction: Deny`, no IP or VNet rules). A `secret set` from a workstation fails
 > with `ForbiddenByConnection` — a *network* denial, independent of RBAC, so Global Administrator
@@ -246,26 +253,66 @@ configuration — worth raising after #108 rather than during it.
   a separate object in `identity.tf`.
 - **No implicit grant.** Authorization code + PKCE only.
 
-## At the cutover (#108)
+## The cutover (#108) — done 2026-09-03
 
-This app is inert until then — nothing about the live Auth0 path changes by its existence. The
-cutover is config-only:
+Config-only, as designed. The variable table and the rollback live in **CLAUDE.md**, under *The
+Auth0 → Entra cutover (#108) and its rollback*; the per-target values are in
+`infra/terraform/variables.tf`. What belongs here is what the cutover **learned about this
+registration**, since that is what the next person changing it needs.
 
-| Setting | Auth0 (today) | Entra |
-|---|---|---|
-| `OAuth__Authority` | `https://fiscal-it.uk.auth0.com/` | `https://login.microsoftonline.com/75bd6050-92a8-4bde-a406-50000b310c86/v2.0` |
-| `OAuth__Audience` | `https://vitally.fiscaltec.com/` | `https://vitally.fiscaltec.com` (**no slash**) |
-| `OAuth__Resource` | `https://vitally.fiscaltec.com/` | unchanged — **still with the slash** |
-| `OAuth__SharedClientId` | Auth0 client | `c3812e7d-a413-4169-b57e-803326611ba3` |
-| `OAuth__SharedClientSecret` | `auth0-shared-client-secret` | `entra-mcp-client-secret` |
+### `resource` had to be dropped, not reshaped — and the reason recorded earlier was wrong
 
-Staging flips first. Note that staging's token `aud` will be *production's* App ID URI, since one
-registration serves both origins — that is expected, and is why `Audience` and `Resource` diverge by
-host as well as by slash there.
+#105 shipped validation only, relaying the parameter because on Auth0 the relay was the only thing
+binding the token audience. The note here predicted the relay would fail under Entra "because Entra
+matches `resource` exactly against a registered identifier and will not accept the trailing-slash
+form". Driving `/oauth2/v2.0/authorize` against the live tenant on 2026-09-02 showed something
+different, and more absolute:
 
-**#108 also has to stop forwarding the RFC 8707 `resource` parameter.** #105 shipped validation only:
-the proxy checks `resource` and still relays it, because on Auth0 that relay is the only thing binding
-the token audience. Under Entra the relay *fails* — Entra matches `resource` exactly against a
-registered identifier and will not accept the trailing-slash form clients send (`AADSTS9010010`). So
-"the proxy consumes `resource` locally" becomes true only when #108 lands, and the Auth0 tenant's
-*Resource Parameter Compatibility Profile* must stay enabled until it does.
+```
+error=invalid_target&error_description=AADSTS9010010: The resource parameter provided in the
+request doesn't match with the requested scopes.
+```
+
+| Request | Result |
+|---|---|
+| no `resource`, scope `openid profile` | 200, sign-in page |
+| `resource=https://vitally.fiscaltec.com/` | **400** |
+| `resource=https://vitally.fiscaltec.com` (the exact App ID URI) | **400** |
+| `resource=` anything unregistered | **400** |
+| `scope=openid mcp.access` (bare, unqualified) | 200, sign-in page |
+
+So the v2 endpoint cross-checks `resource` against `scope` — it is not comparing against
+`identifierUris` at all, and **the trailing slash is beside the point**. Dropping the parameter is
+required rather than tidier; normalising the slash would not have helped.
+
+The last row is the one worth remembering, because it fails the other way round: a bare `mcp.access`
+is *accepted* at `/authorize` and resolved against Microsoft Graph, so the flow completes and hands
+back a token for the wrong resource. A scope on a custom API must carry the App ID URI prefix, which
+is why both metadata documents advertise `https://vitally.fiscaltec.com/mcp.access` in
+`scopes_supported`.
+
+### The proxy names this API by scope now
+
+`OAuth:UpstreamResourceScope = https://vitally.fiscaltec.com/mcp.access`. That single value is what
+switches the proxy from relaying `resource` to terminating it — `resource` is still validated, and a
+value we never published is still refused with `invalid_target`. It is merged into `scope` on
+`/oauth/token` as well as `/oauth/authorize`, which matters on a **refresh**: Entra issues the new
+access token for whatever resource `scope` names.
+
+### `aud` is the appId, not the App ID URI
+
+`requestedAccessTokenVersion = 2`, and a v2 access token names the resource application's **appId
+GUID**. `OAuthOptions.ValidAudiences` therefore accepts both that and the App ID URI (which is what a
+v1 token would carry), so `OAuth:Audience` remaining the URI is correct and not the whole story.
+
+One consequence to be aware of rather than alarmed by: an **ID** token for this app carries the same
+`aud`, because one registration is both client and resource — so one presented as a bearer token
+passes audience validation. It is not an escalation (same client, same user, and entitlement is still
+the live Graph lookup), and narrowing it would mean requiring `scp`, a provider-specific rule in a
+deliberately provider-neutral class. Tracked separately rather than bundled into the cutover.
+
+### The Auth0 side is retained, not removed
+
+Its client, both Resource Servers and the `Vitally MCP claims` Action stay in place until production
+has soaked on Entra — deleting them early turns a one-command rollback into an outage. The tenant's
+*Resource Parameter Compatibility Profile* is now irrelevant to this server and can be left alone.

--- a/docs/runbooks/entra-cutover-staging-validation.md
+++ b/docs/runbooks/entra-cutover-staging-validation.md
@@ -3,8 +3,12 @@
 `https://vitally-staging.fiscaltec.com` runs Entra-direct. This is the part of the acceptance suite
 that needs a real sign-in, and therefore a person.
 
-**Nothing here touches production.** Staging is a separate Container App; production is still on
-Auth0 until its five environment variables are flipped as a separate step.
+Written for the #108 cutover, but it is the standing checklist for **any** identity-provider change:
+staging is the pre-production target for exactly this, so re-run it whenever the authority, the app
+registration or the entitlement wiring moves.
+
+**Nothing here touches production.** Staging is a separate Container App with its own configuration,
+and none of the steps below reach production whatever state it is in.
 
 ⚠️ **Staging reads the production `vitally-shared` Vitally key.** There is one Vitally tenant and its
 API keys are global, so its write and delete tools mutate **real customer data**. `Authorization:ReadOnly`
@@ -13,7 +17,7 @@ exercise one at all — reading the tool list is enough for every check below.
 
 ## Already verified, so you can skip it
 
-Run against `sha-d7bbdf1` and re-runnable at any time:
+Verified on the branch head before merge, and re-runnable at any time:
 
 | | |
 |---|---|
@@ -86,14 +90,15 @@ mistaken for something this change caused.
 
 ## If something fails
 
-Staging rolls back by reverting its five `OAuth__*` variables and restoring the Container App secret
-to the Auth0 client secret — see *The Auth0 → Entra cutover (#108) and its rollback* in `CLAUDE.md`.
-Production is untouched throughout and needs nothing.
+Staging rolls back by reverting its `OAuth__*` variables and its Container App secret to the previous
+provider's — see *The Auth0 → Entra cutover (#108) and its rollback* in `CLAUDE.md`. Production is
+untouched throughout and needs nothing.
 
 ## After it passes
 
-Production takes the same five variables plus the Container App secret, copied from the Key Vault
-secret `entra-mcp-client-secret` through the two-switch network window in
-`docs/runbooks/entra-app-registration.md`. The code is already there and inert until
-`OAuth__UpstreamResourceScope` is set, so the flip is the whole change and reverting it is the whole
-rollback.
+If production has not yet had the same five variables applied, that is the next step: the values are
+in `CLAUDE.md`, and the Container App secret is copied from the Key Vault secret
+`entra-mcp-client-secret` through the two-switch network window in
+`docs/runbooks/entra-app-registration.md`. The code ships ahead of the configuration and is inert
+until `OAuth__UpstreamResourceScope` is set, so the flip is the whole change and reverting it is the
+whole rollback.

--- a/docs/runbooks/entra-cutover-staging-validation.md
+++ b/docs/runbooks/entra-cutover-staging-validation.md
@@ -1,0 +1,99 @@
+# Staging validation — the Entra cutover (#108)
+
+`https://vitally-staging.fiscaltec.com` runs Entra-direct. This is the part of the acceptance suite
+that needs a real sign-in, and therefore a person.
+
+**Nothing here touches production.** Staging is a separate Container App; production is still on
+Auth0 until its five environment variables are flipped as a separate step.
+
+⚠️ **Staging reads the production `vitally-shared` Vitally key.** There is one Vitally tenant and its
+API keys are global, so its write and delete tools mutate **real customer data**. `Authorization:ReadOnly`
+is deliberately not set, because step 4 needs the write tools visible. Pick a harmless target if you
+exercise one at all — reading the tool list is enough for every check below.
+
+## Already verified, so you can skip it
+
+Run against `sha-d7bbdf1` and re-runnable at any time:
+
+| | |
+|---|---|
+| `bash .github/scripts/verify-oauth-metadata.sh https://vitally-staging.fiscaltec.com` | 11/11, with `jwks_uri` and `userinfo_endpoint` on `login.microsoftonline.com` / `graph.microsoft.com` |
+| The app boots at all | proves the OIDC discovery document was fetched and its `issuer` matched `OAuth:Authority` |
+| `/oauth/authorize` → upstream | Entra's v2 endpoint; `resource` **absent**; `scope` = the client's scopes + `https://vitally.fiscaltec.com/mcp.access`; our fixed callback |
+| Following that to Entra | HTTP 200 sign-in page, no `AADSTS` — every parameter accepted |
+| `POST /mcp` unauthenticated / bad token | exactly 401, with `resource_metadata` and `error="invalid_token"` respectively |
+| `resource` we do not publish / do publish | 400 `invalid_target` / 302 |
+| `POST /oauth/register` | returns `c3812e7d-a413-4169-b57e-803326611ba3` |
+
+## What needs you
+
+### 1. Complete a real sign-in
+
+```bash
+claude mcp add --transport http vitally-staging https://vitally-staging.fiscaltec.com/mcp
+```
+
+or `npx @modelcontextprotocol/inspector` pointed at the same URL — the harness #90 established.
+
+**Expect:** a Microsoft sign-in (not Auth0), no consent screen, and the flow completing. A consent
+prompt would mean the admin-consent grant or `api.preAuthorizedApplications` has drifted.
+
+### 2. Decode the access token
+
+Paste it into <https://jwt.ms>. Check:
+
+| Claim | Expect |
+|---|---|
+| `iss` | `https://login.microsoftonline.com/75bd6050-92a8-4bde-a406-50000b310c86/v2.0` |
+| `aud` | `c3812e7d-a413-4169-b57e-803326611ba3` — the **appId GUID**, because `requestedAccessTokenVersion = 2`. `https://vitally.fiscaltec.com` is also accepted (a v1 token) but is not what should arrive |
+| `oid` | present, a GUID — this is the *only* thing entitlement is resolved from |
+| `scp` | `mcp.access` — the short name, not the URI-qualified form |
+
+An `aud` of anything else, or a missing `oid`, is a stop.
+
+### 3. `tools/list` as a **department-nested** user — the one that matters most
+
+Every tier except `sg-vitally-admins` is granted by *nesting*: a department group inside an
+`sg-vitally-*` group. The #102 spike produced three separate wrong conclusions by reasoning about
+nesting instead of testing it, so **a directly-assigned admin account passing proves very little.**
+
+Sign in as someone whose tier comes only via a department group and confirm they see a non-empty tool
+list of the right shape:
+
+| Tier | Sees |
+|---|---|
+| reader | `List_*` / `Get_*` only — no `Create_`, `Update_`, `Delete_` |
+| editor | the above plus `Create_` / `Update_`, no `Delete_` |
+| admin | all 93 |
+
+An **empty** list means Graph resolved the caller into none of the three groups — the fail-closed
+working, but the wrong answer. Check `transitiveMembers` for that user before assuming code.
+
+### 4. A reader is denied a write tool, and it is audited
+
+With a reader account, the write tools should not appear in `tools/list` at all (discovery
+filtering). To see the enforcement rather than the filtering, the denial is recorded by
+`AuditLogger.LogToolCallDenied` — in Application Insights, look for the tool name, the caller's
+subject id and the required permission. **No email, no tool arguments.** If either appears, that is a
+defect worth raising on its own.
+
+### 5. Sanity-check the logs
+
+Nothing at `Warning` from `VitallyMcp.ToolAuthorizer` or `VitallyMcp.GraphGroupPermissionResolver`
+during a normal sign-in. A warning naming a subject id and a staleness in seconds means Graph is
+failing and the stale copy is being served — correct behaviour, but worth knowing about before it is
+mistaken for something this change caused.
+
+## If something fails
+
+Staging rolls back by reverting its five `OAuth__*` variables and restoring the Container App secret
+to the Auth0 client secret — see *The Auth0 → Entra cutover (#108) and its rollback* in `CLAUDE.md`.
+Production is untouched throughout and needs nothing.
+
+## After it passes
+
+Production takes the same five variables plus the Container App secret, copied from the Key Vault
+secret `entra-mcp-client-secret` through the two-switch network window in
+`docs/runbooks/entra-app-registration.md`. The code is already there and inert until
+`OAuth__UpstreamResourceScope` is set, so the flip is the whole change and reverting it is the whole
+rollback.

--- a/infra/terraform/containerapps-staging.tf
+++ b/infra/terraform/containerapps-staging.tf
@@ -42,8 +42,8 @@ resource "azurerm_container_app" "staging" {
     identity = azurerm_user_assigned_identity.app.id
   }
 
-  # The same Auth0 client as production, so this is the same secret value. The client's Allowed
-  # Callback URLs carry both origins' /oauth/callback; the proxy's callback is fixed per origin.
+  # The same Entra app registration as production, so this is the same secret value. Its redirect
+  # URIs carry both origins' /oauth/callback; the proxy's callback is fixed per origin.
   secret {
     name  = "oauth-shared-client-secret"
     value = var.oauth_shared_client_secret
@@ -102,19 +102,26 @@ resource "azurerm_container_app" "staging" {
         name  = "AZURE_CLIENT_ID"
         value = var.managed_identity_client_id
       }
-      # The one value that intentionally diverges from production during the migration: staging is
-      # pointed at Entra first (#108), production stays on Auth0 until staging has passed.
+      # Staging is pointed at a new identity provider first and production follows once it has
+      # passed; both are on Entra now that #108 has cut over.
       env {
         name  = "OAuth__Authority"
         value = var.staging_oauth_authority
       }
+      # Note this is *production's* App ID URI: one Entra registration serves both origins, so a
+      # staging token's `aud` names production. Resource below must still name the staging origin,
+      # so here the two diverge by host as well as by slash. See variables.tf.
       env {
         name  = "OAuth__Audience"
         value = var.staging_oauth_audience
       }
       env {
         name  = "OAuth__Resource"
-        value = var.staging_oauth_audience
+        value = var.staging_oauth_resource
+      }
+      env {
+        name  = "OAuth__UpstreamResourceScope"
+        value = var.oauth_upstream_resource_scope
       }
       env {
         name  = "OAuth__NoAuth"

--- a/infra/terraform/containerapps.tf
+++ b/infra/terraform/containerapps.tf
@@ -97,9 +97,17 @@ resource "azurerm_container_app" "app" {
         name  = "OAuth__Audience"
         value = var.oauth_audience
       }
+      # Deliberately a different variable from OAuth__Audience — see the note on oauth_resource in
+      # variables.tf. They were one value on Auth0 by coincidence and must not be reunified.
       env {
         name  = "OAuth__Resource"
-        value = var.oauth_audience
+        value = var.oauth_resource
+      }
+      # Terminates the RFC 8707 `resource` parameter at the proxy and names the API by scope
+      # instead. Required under Entra; empty is the Auth0 relay behaviour a rollback returns to.
+      env {
+        name  = "OAuth__UpstreamResourceScope"
+        value = var.oauth_upstream_resource_scope
       }
       env {
         name  = "OAuth__NoAuth"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -33,18 +33,39 @@ variable "managed_identity_client_id" {
 }
 
 variable "oauth_authority" {
-  type    = string
-  default = "https://fiscal-it.uk.auth0.com/"
+  type        = string
+  description = "Upstream OIDC issuer. Entra since the #108 cutover; the endpoints are read from its discovery document, not built from this."
+  default     = "https://login.microsoftonline.com/75bd6050-92a8-4bde-a406-50000b310c86/v2.0"
 }
 
+# oauth_audience and oauth_resource are NOT the same value and must not be reconciled. Audience is
+# validated against the token `aud` and follows the Entra App ID URI, which cannot carry a trailing
+# slash (Entra refuses to register one on identifierUris). Resource is published in the RFC 9728
+# document and keeps the slash, because that is the form Claude Code normalises to and then compares.
+# OAuthOptions.IsResourceIndicatorAllowed tolerates exactly one slash of difference, which is what
+# lets the two forms name one resource.
 variable "oauth_audience" {
-  type    = string
-  default = "https://vitally.fiscaltec.com/"
+  type        = string
+  description = "Entra App ID URI, validated against the JWT aud claim. NO trailing slash."
+  default     = "https://vitally.fiscaltec.com"
+}
+
+variable "oauth_resource" {
+  type        = string
+  description = "Canonical resource identifier published in RFC 9728 and validated against as an RFC 8707 indicator. WITH the trailing slash."
+  default     = "https://vitally.fiscaltec.com/"
+}
+
+variable "oauth_upstream_resource_scope" {
+  type        = string
+  description = "Scope naming this server's API upstream. Setting it terminates the RFC 8707 `resource` parameter at the proxy instead of relaying it — required under Entra, which rejects the trailing-slash form clients send (AADSTS9010010). Empty on Auth0."
+  default     = "https://vitally.fiscaltec.com/mcp.access"
 }
 
 variable "oauth_shared_client_id" {
-  type    = string
-  default = "VgB00WSYN2V0KkhtYx3WZXYH9XRBvK1D"
+  type        = string
+  description = "Entra app registration appId — both the OAuth client and the API resource (#107)."
+  default     = "c3812e7d-a413-4169-b57e-803326611ba3"
 }
 
 variable "public_base_url" {
@@ -90,13 +111,23 @@ variable "staging_image_tag" {
 
 variable "staging_oauth_authority" {
   type        = string
-  description = "Upstream OIDC issuer for staging. Auth0 today (a like-for-like baseline against production); becomes the Entra issuer first at #108, while production stays on Auth0."
-  default     = "https://fiscal-it.uk.auth0.com/"
+  description = "Upstream OIDC issuer for staging. Moved to Entra first at #108, ahead of production."
+  default     = "https://login.microsoftonline.com/75bd6050-92a8-4bde-a406-50000b310c86/v2.0"
 }
 
+# Staging's Audience and Resource diverge by HOST as well as by slash, and that is expected. One
+# Entra app registration serves both origins (#107), so a staging token's `aud` is production's App
+# ID URI — whereas `resource` must equal the staging origin, because MCP clients reject a metadata
+# document whose `resource` does not match the server they fetched it from.
 variable "staging_oauth_audience" {
   type        = string
-  description = "Auth0 Resource Server identifier for staging, WITH the trailing slash. Must equal the staging origin: it is published as the RFC 9728 `resource`, and MCP clients reject the whole metadata document when that does not match the server they fetched it from."
+  description = "Entra App ID URI validated against a staging token's aud. Production's URI, because one registration serves both origins. NO trailing slash."
+  default     = "https://vitally.fiscaltec.com"
+}
+
+variable "staging_oauth_resource" {
+  type        = string
+  description = "Canonical resource identifier published by staging, WITH the trailing slash. Must equal the staging origin."
   default     = "https://vitally-staging.fiscaltec.com/"
 }
 
@@ -109,7 +140,7 @@ variable "staging_public_base_url" {
 # ---- Secrets (DO NOT hardcode/commit — supply via TF_VAR_* or an untracked tfvars) ----
 variable "oauth_shared_client_secret" {
   type        = string
-  description = "Auth0 shared app client secret (Container App secret 'oauth-shared-client-secret')."
+  description = "Entra app client secret, sourced from the Key Vault secret `entra-mcp-client-secret` (Container App secret 'oauth-shared-client-secret'). Expires 2027-03-01 — see docs/runbooks/entra-app-registration.md."
   sensitive   = true
 }
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -58,7 +58,7 @@ variable "oauth_resource" {
 
 variable "oauth_upstream_resource_scope" {
   type        = string
-  description = "Scope naming this server's API upstream. Setting it terminates the RFC 8707 `resource` parameter at the proxy instead of relaying it — required under Entra, which rejects the trailing-slash form clients send (AADSTS9010010). Empty on Auth0."
+  description = "Scope naming this server's API upstream. Setting it terminates the RFC 8707 `resource` parameter at the proxy instead of relaying it — required under Entra, whose v2 authorize endpoint refuses any `resource` that does not match the requested scopes (AADSTS9010010), whatever its spelling. Empty on Auth0."
   default     = "https://vitally.fiscaltec.com/mcp.access"
 }
 


### PR DESCRIPTION
Final step of #102: the server now authenticates against Microsoft Entra directly, with Auth0 out
of the path.

The whole cutover is environment variables plus the code below, and **rollback stays a config
revert** — no code change is gated on the authority value.

## 1. Stop forwarding the RFC 8707 `resource` parameter (#105 part B)

`OAuth:UpstreamResourceScope` is the switch, and it is deliberately configuration rather than a
sniff of `OAuth:Authority`:

| | `UpstreamResourceScope` empty | `UpstreamResourceScope` set |
|---|---|---|
| Provider | Auth0 | Entra |
| `resource` | validated, then **relayed** | validated, then **dropped** |
| Names the API upstream by | the relayed `resource` | this scope, merged into `scope` |

On Auth0 the relay is the only thing binding the token audience — nothing sends an `audience`
parameter anywhere, and the tenant's *Resource Parameter Compatibility Profile* consumes `resource`
to that end. Under Entra the relay **fails**: Entra matches `resource` exactly against a registered
identifier and rejects the trailing-slash form clients send (`AADSTS9010010`) — the very slash
`IsResourceIndicatorAllowed` tolerates on purpose, because Entra will not register one and Claude
Code normalises to it.

Validation is unchanged in both postures. Which audience a caller may ask to be bound to is a
separate question from what happens to the parameter afterwards.

The merge applies to `/oauth/token` as well as `/oauth/authorize`, which is load-bearing on a
**refresh** exchange: Entra issues the new access token for whatever resource `scope` names, so a
client refreshing with only the OIDC scopes would silently be handed a token for the wrong
audience — a failure that surfaces an hour after a sign-in that looked fine.

Both metadata documents now advertise the API scope in the form the provider accepts, sharing one
list so they cannot drift. Entra rejects a bare `mcp.access` on a custom API, and clients build
their `scope` request from `scopes_supported`.

## 2. Accept both audiences

`TokenValidationParameters.ValidAudiences` carries the App ID URI **and** the appId GUID. An Entra
v1 access token names the former, a v2 token the latter, and one registration is both our OAuth
client and our API resource — so accepting each settles the question rather than betting on it.

## 3. Remove the token-claim entitlement tier

With `LiveGroupCheck` on the tiers are now **fresh Graph → stale Graph → deny**. #106 deliberately
left the claim *beneath* the stale cache because Auth0 still minted it and it genuinely authorised;
the Action is retired, so it could only ever have denied. Both ways out of the live path now deny
explicitly and log why, instead of falling through to something permanently empty.

`HasPermission` stays — it is the entire resolution when `LiveGroupCheck` is off, not a fallback
beneath the live check.

## 4. Close the #106 observation gap

Its stale path had unit coverage but had **never been observed working**: staging cannot induce a
Graph failure in isolation, because it shares the managed identity and CAE with production. This is
where that path stops being a fallback and becomes the only degraded path, so it is closed here.

`StaleEntitlementCompositionTests` drives the real composition — DI registration, the typed Graph
`HttpClient`, the singleton `IMemoryCache` that carries the retained copy *between requests*,
`ToolAuthorizer`, `VitallyPermissionHandler` and the SDK authorisation filter — and reads the
outcome off `tools/list`, across an outage that starts, is survived, and then outlasts its window.
A resolver that behaved perfectly while being handed a fresh cache per request would pass the unit
tests and fail here.

Mutation-checked: setting `LiveGroupStaleSeconds` to 0 fails two of the three, so they genuinely
depend on the window rather than passing incidentally.

## Configuration

| Setting | Auth0 | Entra |
|---|---|---|
| `OAuth__Authority` | `https://fiscal-it.uk.auth0.com/` | `https://login.microsoftonline.com/75bd…/v2.0` |
| `OAuth__Audience` | `https://vitally.fiscaltec.com/` | `https://vitally.fiscaltec.com` — **no slash** |
| `OAuth__Resource` | `https://vitally.fiscaltec.com/` | **unchanged** |
| `OAuth__UpstreamResourceScope` | *(unset)* | `https://vitally.fiscaltec.com/mcp.access` |
| `OAuth__SharedClientId` | Auth0 client | `c3812e7d-a413-4169-b57e-803326611ba3` |
| `OAuth__SharedClientSecret` | `auth0-shared-client-secret` | `entra-mcp-client-secret` |

`Audience` and `Resource` **must not** be reconciled — they were equal on Auth0 by coincidence and
differ by exactly one slash here. `infra/terraform/` splits the single `oauth_audience` variable
that fed both, which is what made that coincidence structural.

## Tests

523 pass, up from 498.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018s9X2PLQizLk8i545tumsM
